### PR TITLE
Add keybindings for volume, display brightness

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -46,6 +46,11 @@
         (modifiers: [Logo], key: "t"): Spawn("gnome-terminal"),
         (modifiers: [Logo], key: "a"): Spawn("busctl --user call com.system76.CosmicAppletHost /com/system76/CosmicAppletHost com.system76.CosmicAppletHost Toggle s 'com.system76.CosmicAppLibrary'"),
         (modifiers: [Logo], key: "slash"): Spawn("busctl --user call com.system76.CosmicAppletHost /com/system76/CosmicAppletHost com.system76.CosmicAppletHost Toggle s 'com.system76.CosmicLauncher'"),
+        (modifiers: [], key: "XF86AudioRaiseVolume"): Spawn("amixer sset Master 5%+"),
+        (modifiers: [], key: "XF86AudioLowerVolume"): Spawn("amixer sset Master 5%-"),
+        (modifiers: [], key: "XF86AudioMute"): Spawn("amixer sset Master toggle"),
+        (modifiers: [], key: "XF86MonBrightnessUp"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness"),
+        (modifiers: [], key: "XF86MonBrightnessDown"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness"),
     },
     workspace_mode: OutputBound,
 )

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Package: cosmic-comp
 Architecture: amd64 arm64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Recommends:
+    alsa-utils,
     cosmic-app-library,
     cosmic-launcher,
     xdg-shell-wrapper


### PR DESCRIPTION
For display brightness, this requires `cosmic-settings-daemon` to be running.