### PR TITLE
config: Set click_method for input devices

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -431,6 +431,16 @@ impl Config {
                         );
                     }
                 }
+                if let Some(method) = config.click_method {
+                    if let Err(err) = device.config_click_set_method(method) {
+                        slog_scope::warn!(
+                            "Failed to apply click method {:?} for device {:?}: {:?}",
+                            method,
+                            device.name(),
+                            err
+                        );
+                    }
+                }
                 if let Some(dwt) = config.disable_while_typing {
                     if let Err(err) = device.config_dwt_set_enabled(dwt) {
                         slog_scope::warn!(


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/29

While the setting was correctly read-out from the device, changes were not applied as the necessary code for this particular setting was just missing..

@jacobgkau Can you confirm this fixes your problem?