### PR TITLE
Update smithay and implement shortcuts inhibit protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,10 +322,10 @@ dependencies = [
  "smithay-egui",
  "thiserror",
  "wayland-backend",
- "wayland-scanner 0.30.0-beta.8",
+ "wayland-scanner 0.30.0-beta.9",
  "xcursor",
  "xdg",
- "xkbcommon",
+ "xkbcommon 0.4.1",
 ]
 
 [[package]]
@@ -335,8 +335,8 @@ source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#3ff11df30ef
 dependencies = [
  "bitflags",
  "wayland-backend",
- "wayland-protocols 0.30.0-beta.8",
- "wayland-scanner 0.30.0-beta.8",
+ "wayland-protocols 0.30.0-beta.9",
+ "wayland-scanner 0.30.0-beta.9",
  "wayland-server",
 ]
 
@@ -1221,6 +1221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9279fbdacaad3baf559d8cabe0acc3d06e30ea14931af31af79578ac0946decc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,7 +1501,7 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay//smithay?rev=6e6f1f4d#6e6f1f4d2969d10d1dc6f922f28bdd6977b3ac32"
+source = "git+https://github.com/Smithay//smithay?rev=355513d3#355513d3f675dbf5c61196cd98f5134bba53582c"
 dependencies = [
  "appendlist",
  "bitflags",
@@ -1521,14 +1530,14 @@ dependencies = [
  "udev",
  "wayland-backend",
  "wayland-egl",
- "wayland-protocols 0.30.0-beta.8",
+ "wayland-protocols 0.30.0-beta.9",
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-server",
- "wayland-sys 0.30.0-beta.8",
+ "wayland-sys 0.30.0-beta.9",
  "winit",
  "x11rb",
- "xkbcommon",
+ "xkbcommon 0.5.0",
 ]
 
 [[package]]
@@ -1561,7 +1570,7 @@ dependencies = [
  "memoffset",
  "slog",
  "smithay",
- "xkbcommon",
+ "xkbcommon 0.4.1",
 ]
 
 [[package]]
@@ -1792,16 +1801,16 @@ checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wayland-backend"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee8e77c63b0cdc68bfc7b407b862b0fe2718949ce060b32d4f94ef1ea9607a4"
+checksum = "7d83397002f3bec4c8d8f0c4dd1cc4ce564e7aaf00615b6473185318011a827a"
 dependencies = [
  "cc",
  "downcast-rs",
  "nix 0.24.2",
  "scoped-tls",
  "smallvec",
- "wayland-sys 0.30.0-beta.8",
+ "wayland-sys 0.30.0-beta.9",
 ]
 
 [[package]]
@@ -1845,13 +1854,13 @@ dependencies = [
 
 [[package]]
 name = "wayland-egl"
-version = "0.30.0-beta.8"
+version = "0.30.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c476ffaaea6f046c976d2ffd48c0bda72fba50a701d82f28651be9fab8e99a"
+checksum = "393d480911d3021abf6828dc09926c975a417133874dcbdbf7a6e3b4c047b4a4"
 dependencies = [
  "thiserror",
  "wayland-backend",
- "wayland-sys 0.30.0-beta.8",
+ "wayland-sys 0.30.0-beta.9",
 ]
 
 [[package]]
@@ -1868,39 +1877,39 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.30.0-beta.8"
+version = "0.30.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47c45a60d531d5a513601f47f51a4743901836778ddae208ae9124606be1719"
+checksum = "13c411b907898bbb0b589b4d9768cba34f899ca9003dd008497933b0e71b272c"
 dependencies = [
  "bitflags",
  "wayland-backend",
- "wayland-scanner 0.30.0-beta.8",
+ "wayland-scanner 0.30.0-beta.9",
  "wayland-server",
 ]
 
 [[package]]
 name = "wayland-protocols-misc"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b660ecc6e9709a438d9e227eedbea31d6c551672ff75eec90eeef0447c8ecc7c"
+checksum = "555dfad2cecb2ef227a25ba96f64f044e5161d127faf1d95515ca96d60cacfc9"
 dependencies = [
  "bitflags",
  "wayland-backend",
- "wayland-protocols 0.30.0-beta.8",
- "wayland-scanner 0.30.0-beta.8",
+ "wayland-protocols 0.30.0-beta.9",
+ "wayland-scanner 0.30.0-beta.9",
  "wayland-server",
 ]
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b477d16e0c1d7512f11799403c8dbb1964e756667208569ec0ea2bd1abbccb"
+checksum = "256b26eecbd27bd190bbed648034d7244f89e4186d9d2b436fb03b678ac29996"
 dependencies = [
  "bitflags",
  "wayland-backend",
- "wayland-protocols 0.30.0-beta.8",
- "wayland-scanner 0.30.0-beta.8",
+ "wayland-protocols 0.30.0-beta.9",
+ "wayland-scanner 0.30.0-beta.9",
  "wayland-server",
 ]
 
@@ -1917,28 +1926,28 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.30.0-beta.8"
+version = "0.30.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87933ccc3df4f6335cf240aca0647aa34319fdd693dda503f645ca4df4e10386"
+checksum = "4f5f5b0892a8a2dcd51d65ec843cd9350d407eae476ebbf10ff35650f510f761"
 dependencies = [
  "proc-macro2",
+ "quick-xml",
  "quote",
  "syn",
- "xml-rs",
 ]
 
 [[package]]
 name = "wayland-server"
-version = "0.30.0-beta.8"
+version = "0.30.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41683fd43b57d7ab2a2d5cc60acecea2cd8feca8514857088fba1721a568819"
+checksum = "09f4aebf7374a9bcadb01631dc5f80e8b0b6c4d6adfe60227b54905d7adfaa01"
 dependencies = [
  "bitflags",
  "downcast-rs",
  "nix 0.24.2",
  "thiserror",
  "wayland-backend",
- "wayland-scanner 0.30.0-beta.8",
+ "wayland-scanner 0.30.0-beta.9",
 ]
 
 [[package]]
@@ -1954,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.30.0-beta.8"
+version = "0.30.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca223ed017df1b356ff181d4d6e7f2b135418c4888df5bb02df7a563f02ab0"
+checksum = "efcfeb926ec16a184f83b98c3f9d9d76699035ebb229740377724e10993926ef"
 dependencies = [
  "dlib",
  "libc",
@@ -2139,6 +2148,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "032ed00cc755c31221bbd6aaf9fa4196a01bf33bca185f9316e14f26d28c28cf"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xkbcommon"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbee136714379ab22da0280207fdb7f47e0bb940adea97731b65598b8c7a92e"
+dependencies = [
+ "libc",
+ "memmap2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ xdg = "^2.1"
 ron = "0.7"
 atomic_float = "0.1"
 libsystemd = "0.5"
-wayland-backend = "=0.1.0-beta.8"
-wayland-scanner = "=0.30.0-beta.8"
+wayland-backend = "=0.1.0-beta.9"
+wayland-scanner = "=0.30.0-beta.9"
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"] }
 
 [dependencies.smithay]
@@ -62,4 +62,4 @@ debug = true
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/Smithay//smithay", rev = "6e6f1f4d" }
+smithay = { git = "https://github.com/Smithay//smithay", rev = "355513d3" }

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -27,6 +27,7 @@ use smithay::{
         session::{auto::AutoSession, Session, Signal},
         udev::{all_gpus, primary_gpu, UdevBackend, UdevEvent},
     },
+    output::{Mode as OutputMode, Output, PhysicalProperties, Subpixel},
     reexports::{
         calloop::{
             timer::{TimeoutAction, Timer},
@@ -35,19 +36,13 @@ use smithay::{
         drm::control::{connector, crtc, Device as ControlDevice, ModeTypeFlags},
         input::Libinput,
         nix::{fcntl::OFlag, sys::stat::dev_t},
-        wayland_server::{
-            protocol::{wl_output, wl_surface::WlSurface},
-            DisplayHandle, Resource,
-        },
+        wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle, Resource},
     },
     utils::{
         signaling::{Linkable, SignalToken, Signaler},
-        Size,
+        Size, Transform,
     },
-    wayland::{
-        dmabuf::DmabufGlobal,
-        output::{Mode as OutputMode, Output, PhysicalProperties},
-    },
+    wayland::dmabuf::DmabufGlobal,
 };
 
 use std::{
@@ -650,7 +645,7 @@ impl Device {
             PhysicalProperties {
                 size: (phys_w as i32, phys_h as i32).into(),
                 // TODO: We need to read that from the connector properties
-                subpixel: wl_output::Subpixel::Unknown,
+                subpixel: Subpixel::Unknown,
                 make: edid_info.manufacturer,
                 model: edid_info.model,
             },
@@ -668,7 +663,7 @@ impl Device {
         output.change_current_state(
             Some(output_mode),
             // TODO: Readout property for monitor rotation
-            Some(wl_output::Transform::Normal),
+            Some(Transform::Normal),
             None,
             Some(position.into()),
         );

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -29,8 +29,9 @@ use smithay::{
         utils::damage_from_surface_tree,
         Window,
     },
+    output::Output,
     utils::{Physical, Point, Rectangle, Scale, Transform},
-    wayland::{output::Output, shell::wlr_layer::Layer as WlrLayer},
+    wayland::shell::wlr_layer::Layer as WlrLayer,
 };
 
 pub mod cursor;

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -14,14 +14,12 @@ use smithay::{
         winit::{self, WinitEvent, WinitGraphicsBackend, WinitVirtualDevice},
     },
     desktop::layer_map_for_output,
+    output::{Mode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::{
         calloop::{ping, EventLoop},
-        wayland_server::{
-            protocol::wl_output::{Subpixel, Transform},
-            DisplayHandle,
-        },
+        wayland_server::DisplayHandle,
     },
-    wayland::output::{Mode, Output, PhysicalProperties, Scale},
+    utils::Transform,
 };
 use std::cell::RefCell;
 

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -17,15 +17,13 @@ use smithay::{
         x11::{Window, WindowBuilder, X11Backend, X11Event, X11Handle, X11Input, X11Surface},
     },
     desktop::layer_map_for_output,
+    output::{Mode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::{
         calloop::{ping, EventLoop, LoopHandle},
         gbm::{Device as GbmDevice, FdWrapper},
-        wayland_server::{
-            protocol::wl_output::{Subpixel, Transform},
-            DisplayHandle,
-        },
+        wayland_server::DisplayHandle,
     },
-    wayland::output::{Mode, Output, PhysicalProperties, Scale},
+    utils::Transform,
 };
 use std::{
     cell::RefCell,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub use smithay::{
     backend::input::KeyState,
     input::keyboard::{keysyms as KeySyms, Keysym, ModifiersState},
+    output::{Mode, Output},
     reexports::{
         calloop::LoopHandle,
         input::{
@@ -16,7 +17,6 @@ pub use smithay::{
         },
     },
     utils::{Logical, Physical, Point, Size, Transform},
-    wayland::output::{Mode, Output},
 };
 use std::{cell::RefCell, collections::HashMap, fs::OpenOptions, path::PathBuf};
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 pub use smithay::{
     backend::input::KeyState,
     input::keyboard::{keysyms as KeySyms, Keysym, XkbConfig as WlXkbConfig},
+    output::{Mode, Output},
     reexports::input::{AccelProfile, ClickMethod, ScrollMethod, TapButtonMap},
     utils::{Logical, Physical, Point, Size, Transform},
-    wayland::output::{Mode, Output},
 };
 use xkbcommon::xkb;
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -17,9 +17,10 @@ use smithay::{
         pointer::{AxisFrame, ButtonEvent, CursorImageStatus, MotionEvent},
         Seat, SeatState,
     },
+    output::Output,
     reexports::wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle},
     utils::{Buffer, Logical, Point, Rectangle, Size, SERIAL_COUNTER},
-    wayland::{output::Output, shell::wlr_layer::Layer as WlrLayer},
+    wayland::shell::wlr_layer::Layer as WlrLayer,
 };
 
 use std::{cell::RefCell, collections::HashMap};

--- a/src/shell/grabs.rs
+++ b/src/shell/grabs.rs
@@ -18,12 +18,12 @@ use smithay::{
         },
         Seat,
     },
+    output::Output,
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel::State as XdgState,
         wayland_server::protocol::wl_surface::WlSurface,
     },
     utils::{IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial},
-    wayland::output::Output,
 };
 use std::cell::RefCell;
 

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -6,13 +6,12 @@ use smithay::{
         pointer::{Focus, GrabStartData as PointerGrabStartData},
         Seat,
     },
+    output::Output,
     reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::{
         ResizeEdge, State as XdgState,
     },
     utils::{IsAlive, Logical, Point, Rectangle, Serial},
-    wayland::{
-        compositor::with_states, output::Output, shell::xdg::XdgToplevelSurfaceRoleAttributes,
-    },
+    wayland::{compositor::with_states, shell::xdg::XdgToplevelSurfaceRoleAttributes},
 };
 use std::{collections::HashSet, sync::Mutex};
 

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -5,9 +5,8 @@ use regex::RegexSet;
 use smithay::{
     desktop::{Space, Window},
     input::Seat,
-    wayland::{
-        compositor::with_states, output::Output, shell::xdg::XdgToplevelSurfaceRoleAttributes,
-    },
+    output::Output,
+    wayland::{compositor::with_states, shell::xdg::XdgToplevelSurfaceRoleAttributes},
 };
 use std::sync::Mutex;
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3,11 +3,11 @@ use std::{cell::Cell, mem::MaybeUninit};
 use smithay::{
     desktop::{layer_map_for_output, LayerSurface, PopupManager, Window, WindowSurfaceType},
     input::{pointer::MotionEvent, Seat},
+    output::Output,
     reexports::wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle},
     utils::{Logical, Point, Rectangle, SERIAL_COUNTER},
     wayland::{
         compositor::with_states,
-        output::Output,
         shell::{
             wlr_layer::{
                 KeyboardInteractivity, Layer, LayerSurfaceCachedState, WlrLayerShellState,

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -7,12 +7,12 @@ use crate::{
 use smithay::{
     desktop::{Kind, Space, Window, WindowSurfaceType},
     input::{pointer::GrabStartData as PointerGrabStartData, Seat},
+    output::Output,
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel::{self, ResizeEdge},
         wayland_server::{protocol::wl_surface::WlSurface, DisplayHandle},
     },
     utils::{IsAlive, Serial},
-    wayland::output::Output,
 };
 use std::collections::HashMap;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,7 @@ use crate::{
 use smithay::{
     backend::drm::DrmNode,
     input::{Seat, SeatState},
+    output::{Mode as OutputMode, Output, Scale},
     reexports::{
         calloop::{LoopHandle, LoopSignal},
         wayland_server::{
@@ -23,12 +24,8 @@ use smithay::{
     },
     utils::{Buffer, Size},
     wayland::{
-        compositor::CompositorState,
-        data_device::DataDeviceState,
-        dmabuf::DmabufState,
-        output::{Mode as OutputMode, Output, OutputManagerState, Scale},
-        primary_selection::PrimarySelectionState,
-        shm::ShmState,
+        compositor::CompositorState, data_device::DataDeviceState, dmabuf::DmabufState,
+        output::OutputManagerState, primary_selection::PrimarySelectionState, shm::ShmState,
         viewporter::ViewporterState,
     },
 };

--- a/src/state.rs
+++ b/src/state.rs
@@ -25,8 +25,8 @@ use smithay::{
     utils::{Buffer, Size},
     wayland::{
         compositor::CompositorState, data_device::DataDeviceState, dmabuf::DmabufState,
-        output::OutputManagerState, primary_selection::PrimarySelectionState, shm::ShmState,
-        viewporter::ViewporterState,
+        keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState, output::OutputManagerState,
+        primary_selection::PrimarySelectionState, shm::ShmState, viewporter::ViewporterState,
     },
 };
 
@@ -86,6 +86,7 @@ pub struct Common {
     pub data_device_state: DataDeviceState,
     pub dmabuf_state: DmabufState,
     pub export_dmabuf_state: ExportDmabufState,
+    pub keyboard_shortcuts_inhibit_state: KeyboardShortcutsInhibitState,
     pub output_state: OutputManagerState,
     pub output_configuration_state: OutputConfigurationState<State>,
     pub primary_selection_state: PrimarySelectionState,
@@ -301,6 +302,7 @@ impl State {
             //|client| client.get_data::<ClientState>().unwrap().privileged,
             |_| true,
         );
+        let keyboard_shortcuts_inhibit_state = KeyboardShortcutsInhibitState::new::<Self>(dh);
         let output_state = OutputManagerState::new_with_xdg_output::<Self>(dh);
         let output_configuration_state = OutputConfigurationState::new(dh, |_| true);
         let primary_selection_state = PrimarySelectionState::new::<Self, _>(dh, None);
@@ -355,6 +357,7 @@ impl State {
                 export_dmabuf_state,
                 shm_state,
                 seat_state,
+                keyboard_shortcuts_inhibit_state,
                 output_state,
                 output_configuration_state,
                 primary_selection_state,

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -1,8 +1,8 @@
 use crate::input::{ActiveOutput, SeatId};
 use smithay::{
     input::Seat,
+    output::Output,
     utils::{Logical, Rectangle, Transform},
-    wayland::output::Output,
 };
 use std::cell::RefCell;
 

--- a/src/wayland/handlers/export_dmabuf.rs
+++ b/src/wayland/handlers/export_dmabuf.rs
@@ -16,12 +16,12 @@ use smithay::{
     },
     desktop::{draw_window, draw_window_popups, space::RenderElement, Kind, Window},
     input::pointer::CursorImageStatus,
+    output::Output,
     reexports::wayland_server::{protocol::wl_output::WlOutput, DisplayHandle, Resource},
     utils::{IsAlive, Size, Transform},
     wayland::{
         compositor::{get_children, with_states, SurfaceAttributes},
         dmabuf::get_dmabuf,
-        output::Output,
     },
 };
 

--- a/src/wayland/handlers/keyboard_shortcuts_inhibit.rs
+++ b/src/wayland/handlers/keyboard_shortcuts_inhibit.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::state::State;
+use smithay::{
+    delegate_keyboard_shortcuts_inhibit,
+    wayland::keyboard_shortcuts_inhibit::{
+        KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
+    },
+};
+
+impl KeyboardShortcutsInhibitHandler for State {
+    fn keyboard_shortcuts_inhibit_state(&mut self) -> &mut KeyboardShortcutsInhibitState {
+        &mut self.common.keyboard_shortcuts_inhibit_state
+    }
+
+    fn new_inhibitor(&mut self, inhibitor: KeyboardShortcutsInhibitor) {
+        // TODO: Restrict what apps can inhibit shortcuts
+        inhibitor.activate();
+    }
+}
+
+delegate_keyboard_shortcuts_inhibit!(State);

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -4,15 +4,13 @@ use crate::utils::prelude::*;
 use smithay::{
     delegate_layer_shell,
     desktop::{LayerSurface, PopupKind},
+    output::Output,
     reexports::wayland_server::protocol::wl_output::WlOutput,
-    wayland::{
-        output::Output,
-        shell::{
-            wlr_layer::{
-                Layer, LayerSurface as WlrLayerSurface, WlrLayerShellHandler, WlrLayerShellState,
-            },
-            xdg::PopupSurface,
+    wayland::shell::{
+        wlr_layer::{
+            Layer, LayerSurface as WlrLayerSurface, WlrLayerShellHandler, WlrLayerShellState,
         },
+        xdg::PopupSurface,
     },
 };
 

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -5,6 +5,7 @@ pub mod compositor;
 pub mod data_device;
 pub mod dmabuf;
 pub mod export_dmabuf;
+pub mod keyboard_shortcuts_inhibit;
 pub mod layer_shell;
 pub mod output;
 pub mod output_configuration;

--- a/src/wayland/handlers/output_configuration.rs
+++ b/src/wayland/handlers/output_configuration.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use smithay::wayland::output::Output;
+use smithay::output::Output;
 
 use crate::{
     config::OutputConfig,

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -6,6 +6,7 @@ use smithay::{
         layer_map_for_output, LayerSurface, PopupKind, PopupManager, Space, Window,
         WindowSurfaceType,
     },
+    output::Output,
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_positioner::{
             Anchor, ConstraintAdjustment, Gravity,
@@ -15,7 +16,6 @@ use smithay::{
     utils::{Logical, Point, Rectangle},
     wayland::{
         compositor::{get_role, with_states},
-        output::Output,
         shell::xdg::{
             PopupSurface, PositionerState, SurfaceCachedState, XdgPopupSurfaceRoleAttributes,
             XDG_POPUP_ROLE,

--- a/src/wayland/protocols/output_configuration.rs
+++ b/src/wayland/protocols/output_configuration.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use smithay::{
+    output::{Mode, Output, OutputData},
     reexports::{
         wayland_protocols_wlr::output_management::v1::server::{
             zwlr_output_configuration_head_v1::{self, ZwlrOutputConfigurationHeadV1},
@@ -16,7 +17,6 @@ use smithay::{
         },
     },
     utils::{Logical, Physical, Point, Size, Transform},
-    wayland::output::{Mode, Output, OutputData},
 };
 use std::{
     convert::{TryFrom, TryInto},
@@ -734,7 +734,7 @@ where
     if inner.enabled {
         let point = output.current_location();
         instance.head.position(point.x, point.y);
-        instance.head.transform(output.current_transform());
+        instance.head.transform(output.current_transform().into());
         instance
             .head
             .scale(output.current_scale().fractional_scale());
@@ -759,10 +759,10 @@ macro_rules! delegate_output_configuration {
             smithay::reexports::wayland_protocols_wlr::output_management::v1::server::zwlr_output_manager_v1::ZwlrOutputManagerV1: $crate::wayland::protocols::output_configuration::OutputMngrInstanceData
         ] => $crate::wayland::protocols::output_configuration::OutputConfigurationState<Self>);
         smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols_wlr::output_management::v1::server::zwlr_output_head_v1::ZwlrOutputHeadV1: smithay::wayland::output::Output
+            smithay::reexports::wayland_protocols_wlr::output_management::v1::server::zwlr_output_head_v1::ZwlrOutputHeadV1: smithay::output::Output
         ] => $crate::wayland::protocols::output_configuration::OutputConfigurationState<Self>);
         smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols_wlr::output_management::v1::server::zwlr_output_mode_v1::ZwlrOutputModeV1: smithay::wayland::output::Mode
+            smithay::reexports::wayland_protocols_wlr::output_management::v1::server::zwlr_output_mode_v1::ZwlrOutputModeV1: smithay::output::Mode
         ] => $crate::wayland::protocols::output_configuration::OutputConfigurationState<Self>);
         smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             smithay::reexports::wayland_protocols_wlr::output_management::v1::server::zwlr_output_configuration_v1::ZwlrOutputConfigurationV1: $crate::wayland::protocols::output_configuration::PendingConfiguration

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, sync::Mutex};
 
 use smithay::{
     desktop::Window,
+    output::Output,
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel,
         wayland_server::{
@@ -13,9 +14,7 @@ use smithay::{
         },
     },
     utils::{IsAlive, Logical, Rectangle},
-    wayland::{
-        compositor::with_states, output::Output, shell::xdg::XdgToplevelSurfaceRoleAttributes,
-    },
+    wayland::{compositor::with_states, shell::xdg::XdgToplevelSurfaceRoleAttributes},
 };
 
 use super::workspace::{WorkspaceHandle, WorkspaceHandler, WorkspaceState};

--- a/src/wayland/protocols/toplevel_management.rs
+++ b/src/wayland/protocols/toplevel_management.rs
@@ -3,13 +3,13 @@
 use smithay::{
     desktop::Window,
     input::{Seat, SeatHandler},
+    output::Output,
     reexports::wayland_server::{
         backend::{ClientId, GlobalId, ObjectId},
         protocol::wl_surface::WlSurface,
         Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
     },
     utils::{Logical, Rectangle},
-    wayland::output::Output,
 };
 
 pub use cosmic_protocols::toplevel_management::v1::server::zcosmic_toplevel_manager_v1::ZcosmicToplelevelManagementCapabilitiesV1 as ManagementCapabilities;

--- a/src/wayland/protocols/workspace.rs
+++ b/src/wayland/protocols/workspace.rs
@@ -3,11 +3,11 @@
 use std::{collections::HashSet, sync::Mutex};
 
 use smithay::{
+    output::Output,
     reexports::wayland_server::{
         backend::{ClientData, ClientId, GlobalId, ObjectId},
         Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
     },
-    wayland::output::Output,
 };
 
 use cosmic_protocols::workspace::v1::server::{


### PR DESCRIPTION
We may want to restrict what applications can use this protocol in some way? I guess the ecosystem is still figuring out how to restrict which Wayland protocols sandboxed (Flatpak) apps can use. For now, always allow.