### PR TITLE
fix: return if output is none

### DIFF
--- a/src/shell/grabs.rs
+++ b/src/shell/grabs.rs
@@ -47,12 +47,14 @@ impl Shell {
             }
 
             let pos = pointer.current_location();
-            let output = workspace
+            let output = match workspace
                 .space
                 .outputs_for_window(&window)
                 .into_iter()
-                .find(|o| o.geometry().contains(pos.to_i32_round()))
-                .unwrap();
+                .find(|o| o.geometry().contains(pos.to_i32_round())) {
+                    Some(o) => o,
+                    None => return,
+                };
             let mut initial_window_location = workspace.space.window_location(&window).unwrap();
 
             let output = match &window.toplevel() {


### PR DESCRIPTION
Sometimes recently when I moved a window to a different workspace it would cause cosmic-comp to crash, and I noticed that it was because of the unwrap here. I've just made it return instead of unwrapping, which seems to have solved the issue, but maybe there is a better fix.