### PR TITLE
Fix advertised buffer size for shm toplevel capture

### DIFF
--- a/src/wayland/handlers/screencopy.rs
+++ b/src/wayland/handlers/screencopy.rs
@@ -161,10 +161,7 @@ impl ScreencopyHandler for State {
 
     fn capture_toplevel(&mut self, toplevel: Window, session: Session) -> Vec<BufferInfo> {
         let surface = toplevel.toplevel().wl_surface();
-        let size = toplevel
-            .bbox_with_popups()
-            .size
-            .to_buffer(1, Transform::Normal);
+        let size = toplevel.geometry().size.to_buffer(1, Transform::Normal);
 
         let mut _kms_renderer = None;
         let renderer = match self.backend {


### PR DESCRIPTION
This uses the same size that is later tested when capturing. So it doesn't error about a size mismatch.

Fixes https://github.com/pop-os/cosmic-comp/issues/52.