### PR TITLE
Setup Github CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: "Build"
+on:
+  pull_request:
+    branches:
+    - master_jammy
+  push:
+    branches:
+    - master_jammy
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        nix_path: nixpkgs=channel:nixpkgs-unstable
+    - run: nix build
+    - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ vendor
 vendor.tar
 .vscode
 *.log
-result
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -90,6 +90,21 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1666547822,
+        "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "1a3b735e13e90a8d2fd5629f2f8363bd7ffbbec7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1672428209,
@@ -111,6 +126,7 @@
         "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils_2",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs"
       }
     },


### PR DESCRIPTION
The `build` workflow currently just compile the `cosmic-comp` binary according to `flake.nix`.
Currently it is set to trigger when there are new commits on `master_jammy` or any pull requests targeting it.

A potential thing to do is to setup a Cachix cache (cachix.org), which will cut down CI time and allow Nix users to avoid building the project locally if they choose to use the cache.

I've setup a similar cache on my other project (https://github.com/cosette-solver/cosette-prover), but the setup requires creating an account on cachix.org and setting an API key in the repository secrets.
Usage of the Cachix service is free up to a certain quota, and if any maintainer is willing to do this, I can update the workflow file accordingly to make use of the cache.