### PR TITLE
Log to journald, and log panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,15 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
@@ -324,7 +333,8 @@ dependencies = [
  "id_tree",
  "indexmap",
  "lazy_static",
- "libsystemd",
+ "libsystemd 0.5.0",
+ "log-panics",
  "png",
  "regex",
  "renderdoc",
@@ -334,6 +344,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
+ "slog-journald",
  "slog-scope",
  "slog-stdlog",
  "slog-term",
@@ -407,6 +418,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,11 +479,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -841,11 +871,21 @@ dependencies = [
 
 [[package]]
 name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1017,18 +1057,35 @@ dependencies = [
 
 [[package]]
 name = "libsystemd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4f0b5b062ba67aa075e331de778082c09e66b5ef32970ea5a1e9c37c9555d1"
+dependencies = [
+ "hmac 0.11.0",
+ "libc",
+ "log",
+ "nix 0.23.1",
+ "once_cell",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "libsystemd"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8144587c71c16756b1055d3dcb0c75cb605a10ecd6523cc33702d5f90902bf6d"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "libc",
  "log",
  "nix 0.23.1",
  "nom",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.6",
  "thiserror",
  "uuid",
 ]
@@ -1060,6 +1117,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "log-panics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
+dependencies = [
+ "backtrace",
+ "log",
 ]
 
 [[package]]
@@ -1341,6 +1408,12 @@ name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -1734,13 +1807,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1774,6 +1860,16 @@ dependencies = [
  "slog",
  "take_mut",
  "thread_local",
+]
+
+[[package]]
+name = "slog-journald"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e14eb8c2f5d0c8fc9fbac40e6391095e4dc5cb334f7dce99c75cb1919eb39c"
+dependencies = [
+ "libsystemd 0.4.1",
+ "slog",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bitflags = "1.3.2"
 slog = { version = "2.7", features = [] } # "release_max_level_debug", "max_level_trace"] }
 slog-term = "2.8"
 slog-async = "2.7"
+slog-journald = "2.2.0"
 slog-scope = "4.4"
 slog-stdlog = "4.1"
 serde = { version = "1", features = ["derive"] }
@@ -21,6 +22,7 @@ renderdoc = { version = "0.10.1", optional = true }
 edid-rs = { version = "0.1" }
 png = "0.17.5"
 lazy_static = "1.4.0"
+log-panics = { version = "2", features = ["with-backtrace"] }
 thiserror = "1.0.26"
 regex = "1"
 xcursor = "0.3.3"

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -9,20 +9,18 @@ pub struct LogState {
 
 pub fn init_logger() -> Result<LogState> {
     let decorator = slog_term::TermDecorator::new().stderr().build();
+    let term_drain = slog_term::CompactFormat::new(decorator)
+        .build()
+        .ignore_res();
+    let journald_drain = slog_journald::JournaldDrain.ignore_res();
+    let drain = slog::Duplicate::new(term_drain, journald_drain);
     // usually we would not want to use a Mutex here, but this is usefull for a prototype,
     // to make sure we do not miss any in-flight messages, when we crash.
-    let logger = slog::Logger::root(
-        std::sync::Mutex::new(
-            slog_term::CompactFormat::new(decorator)
-                .build()
-                .ignore_res(),
-        )
-        .fuse(),
-        slog::o!(),
-    );
+    let logger = slog::Logger::root(std::sync::Mutex::new(drain).fuse(), slog::o!());
 
     let _guard = slog_scope::set_global_logger(logger);
     slog_stdlog::init().unwrap();
+    log_panics::init();
 
     slog_scope::info!("Version: {}", std::env!("CARGO_PKG_VERSION"));
     if cfg!(feature = "debug") {


### PR DESCRIPTION
This integrates a bit better than having `cosmic-session` copy logs from stderr to journald, and works when not started through `cosmic-session`.

Having panics logged should be helpful if panics ever occur.