### PR TITLE
Fixes for debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Build-Depends:
     rustc (>=1.57),
     libudev-dev,
     libegl1-mesa-dev,
-    libgl1-mesa-dri,
     libgbm-dev,
     libinput-dev,
     libwayland-dev,
@@ -18,21 +17,15 @@ Build-Depends:
     libseat-dev
 Standards-Version: 4.1.1
 Homepage: https://github.com/pop-os/cosmic-comp
+
 Package: cosmic-comp
 Architecture: amd64 arm64
 Depends:
     ${misc:Depends},
     ${shlibs:Depends},
     libegl1,
-    libgl1-mesa-dri,
-    libudev,
-    libinput,
-    libgbm,
-    libwayland,
-    libxcb1,
-    libxkbcommon,
-    libsystemd,
-    libseat
+    libwayland-server0,
 Recommends:
-    cosmic-session
+    cosmic-session,
+    libgl1-mesa-dri
 Description: Wayland compositor of pop-os cosmic shell


### PR DESCRIPTION
The `control` file is invalid without the newline before `Package:`, and fails to build.

Generally, libraries shouldn't be listed under `Dependencies`. The -dev versions should be listed under `Build-Dependencies`, and `shlibs` automatically adds runtime dependencies based on the linked libraries with the version of the library that was linked.

`libsystemd` also doesn't exist, the package is `libsystemd0`. But is that actually needed? Looks like it's pulled in by `libseat1` and not used directly. `libxcb1` shouldn't be needed, x11rb provides a Rust implementation, and doesn't support integration with libxcb without the `allow-unsafe-code` feature, which doesn't seem to be used here.

For things that are opened with `dlopen`, this doesn't apply, though it would probably be best to avoid that for any hard dependency.