### PR TITLE
Exclude "workspace-overview" from workspace screencopy

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -239,10 +239,12 @@ pub fn init_backend(
                                 );
                             }
                         } else {
-                            if let Err(err) =
-                                data.state
-                                    .device_added(dev, path.into(), &data.display.handle(), true)
-                            {
+                            if let Err(err) = data.state.device_added(
+                                dev,
+                                path.into(),
+                                &data.display.handle(),
+                                true,
+                            ) {
                                 slog_scope::error!(
                                     "Failed to add drm device {}: {}",
                                     path.display(),
@@ -322,10 +324,16 @@ pub fn init_backend(
             .device_added(dev, path.into(), dh, false)
             .with_context(|| format!("Failed to add drm device: {}", path.display()))?;
     }
-    
+
     // HACK: amdgpu doesn't like us initializing vulkan too early..
     //      so lets do that delayed until mesa fixes that.
-    let devices = state.backend.kms().devices.iter().map(|(drm_node, device)| (*drm_node, device.render_node)).collect::<Vec<_>>();
+    let devices = state
+        .backend
+        .kms()
+        .devices
+        .iter()
+        .map(|(drm_node, device)| (*drm_node, device.render_node))
+        .collect::<Vec<_>>();
     for (drm_node, render_node) in devices {
         state.init_vulkan(drm_node, render_node);
     }
@@ -333,7 +341,13 @@ pub fn init_backend(
 }
 
 impl State {
-    fn device_added(&mut self, dev: dev_t, path: PathBuf, dh: &DisplayHandle, try_vulkan: bool) -> Result<()> {
+    fn device_added(
+        &mut self,
+        dev: dev_t,
+        path: PathBuf,
+        dh: &DisplayHandle,
+        try_vulkan: bool,
+    ) -> Result<()> {
         if !self.backend.kms().session.is_active() {
             return Ok(());
         }

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -158,6 +158,7 @@ where
         cursor_mode,
         screencopy,
         fps,
+        false,
     );
 
     result
@@ -175,6 +176,7 @@ pub fn render_workspace<'frame, R, Target, OffTarget, Source>(
     mut cursor_mode: CursorMode,
     screencopy: Option<(Source, &[(ScreencopySession, BufferParams)])>,
     mut fps: Option<&mut Fps>,
+    exclude_workspace_overview: bool,
 ) -> Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), RenderError<R>>
 where
     R: Renderer
@@ -254,6 +256,7 @@ where
                 output,
                 &state.shell.override_redirect_windows,
                 state.xwayland_state.values_mut(),
+                exclude_workspace_overview,
             )
             .map_err(|_| OutputNoMode)?
             .into_iter()


### PR DESCRIPTION
Not especially elegant, but simple enough. And works, mostly.

This doesn't capture correctly for the current workspace. I guess it's rendered only once, and the render for display on the screen has the layer shell surface? (There's a comment about this for cursors, which are also captured when they shouldn't be.)