### PR TITLE
wip: layer surface popup positioning improvements

### DIFF
--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -138,7 +138,9 @@ fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surfac
     // the output_rect represented relative to the parents coordinate system
     let mut relative = Rectangle::from_loc_and_size((0, 0), output.geometry().size);
     relative.loc -= layer_geo.loc;
-    let geometry = surface.with_pending_state(|state| state.positioner.get_geometry());
+    let mut geometry = surface.with_pending_state(|state| state.positioner.get_geometry());
+    geometry.loc += layer_geo.loc;
+
     let offset = check_constrained(geometry, relative);
 
     if offset.x != 0 || offset.y != 0 {


### PR DESCRIPTION
Layer surface popups should probably only be unconstrained if the popup is not contained in the output geometry. 

Replacing the offset check with `output_contains_popup` seems to prevent the bottom panel's popups from being flipped / re-positioned off-screen. Popups which still are not contained in the output geometry are still unconstrained, as can be seen in the right panel popups, some of which may be flipped off-screen while unconstraining them. I'll work on some more improvements so that doesn't happen.