### PR TITLE
Add default `systemd` feature flag to enable systemd integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ xkbcommon = "0.4"
 indexmap = "1.8.0"
 xdg = "^2.1"
 ron = "0.7"
-libsystemd = "0.5"
+libsystemd = { version = "0.5", optional = true }
 wayland-backend = "0.1.0"
 wayland-scanner = "0.30.0"
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"] }
@@ -53,8 +53,9 @@ features = ["svg"]
 optional = true
 
 [features]
-default = []
+default = ["systemd"]
 debug = ["egui", "smithay-egui", "renderdoc", "anyhow/backtrace"]
+systemd = ["libsystemd"]
 
 [profile.dev]
 lto = "thin"

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod logger;
 pub mod session;
 pub mod shell;
 pub mod state;
+#[cfg(feature = "systemd")]
 pub mod systemd;
 pub mod utils;
 pub mod wayland;
@@ -46,6 +47,7 @@ fn main() -> Result<()> {
     // init backend
     backend::init_backend_auto(&display.handle(), &mut event_loop, &mut state)?;
     // potentially tell systemd we are setup now
+    #[cfg(feature = "systemd")]
     if let state::BackendData::Kms(_) = &state.backend {
         systemd::ready(&state);
     }


### PR DESCRIPTION
The `libsystemd` crate fails to build on FreeBSD and is presumably undesirable on any non-systemd distros. At least at present it's easy to make it optional.