### PR TITLE
shell: Fix position of floating windows before/after drag

### DIFF
--- a/src/shell/layout/floating/grabs/moving.rs
+++ b/src/shell/layout/floating/grabs/moving.rs
@@ -66,7 +66,7 @@ impl MoveGrabState {
         elements.extend(AsRenderElements::<R>::render_elements::<I>(
             &self.window,
             renderer,
-            render_location.to_physical_precise_round(scale),
+            (render_location - self.window.geometry().loc).to_physical_precise_round(scale),
             scale,
         ));
         elements
@@ -179,7 +179,7 @@ impl MoveSurfaceGrab {
 
         let grab_state = MoveGrabState {
             window: window.clone(),
-            window_offset: dbg!(initial_window_location) + output.geometry().loc
+            window_offset: dbg!(initial_window_location)
                 - dbg!(initial_cursor_location.to_i32_round()),
         };
 


### PR DESCRIPTION
This fixes two issues that seem to have been introduced by 98dc342:

* During drag, CSD windows being offset from their original location and the frames rendered around them.
* Windows on additional monitors being positioned incorrectly when dragged.

This seems to work well in floating mode with `OutputBound` workspaces. With `Global` workspaces it seems position of dragged windows on additional monitors isn't right before or after this...