### PR TITLE
Fixes for rendering windows in `Global` workspace mode

### DIFF
--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -290,7 +290,8 @@ where
         .unwrap()
         .borrow()
         .is_some();
-    let active_output = &last_active_seat.active_output() == output;
+    let active_output = last_active_seat.active_output();
+    let is_active_space = workspace.outputs().any(|o| o == &active_output);
 
     elements.extend(
         workspace
@@ -299,7 +300,7 @@ where
                 output,
                 &state.shell.override_redirect_windows,
                 state.xwayland_state.as_mut(),
-                (!move_active && active_output).then_some(&last_active_seat),
+                (!move_active && is_active_space).then_some(&last_active_seat),
                 state.config.static_conf.active_hint,
                 exclude_workspace_overview,
             )

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -361,12 +361,14 @@ impl FloatingLayout {
         puffin::profile_function!();
 
         let output_scale = output.current_scale().fractional_scale();
+        let output_loc = self.space.output_geometry(output).unwrap().loc;
+
         self.space
             .elements_for_output(output)
             .rev()
             .flat_map(|elem| {
                 let render_location =
-                    self.space.element_location(elem).unwrap() - elem.geometry().loc;
+                    self.space.element_location(elem).unwrap() - output_loc - elem.geometry().loc;
                 let mut elements = elem.render_elements(
                     renderer,
                     render_location.to_physical_precise_round(output_scale),
@@ -377,7 +379,7 @@ impl FloatingLayout {
                         let element = IndicatorShader::element(
                             renderer,
                             Rectangle::from_loc_and_size(
-                                self.space.element_location(elem).unwrap(),
+                                self.space.element_location(elem).unwrap() - output_loc,
                                 elem.geometry().size,
                             ),
                             indicator_thickness,

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -406,6 +406,10 @@ impl Workspace {
             .chain(self.tiling_layer.mapped().map(|(_, w, _)| w))
     }
 
+    pub fn outputs(&self) -> impl Iterator<Item = &Output> {
+        self.floating_layer.space.outputs()
+    }
+
     pub fn windows(&self) -> impl Iterator<Item = CosmicSurface> + '_ {
         self.floating_layer
             .windows()


### PR DESCRIPTION
* Render window and active indicator at correct position relative to where the output is within the space.
* Show active indicator around whole window, not only part of window on focused output.