### PR TITLE
Add libfontconfig-dev to build depends, sort them alphabetically

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,16 +6,17 @@ Build-Depends:
     cargo,
     cmake,
     debhelper-compat (=10),
-    rustc (>=1.57),
-    libudev-dev,
     libegl1-mesa-dev,
+    libfontconfig-dev,
     libgbm-dev,
     libinput-dev,
+    libseat-dev,
+    libsystemd-dev,
+    libudev-dev,
     libwayland-dev,
     libxcb1-dev,
     libxkbcommon-dev,
-    libsystemd-dev,
-    libseat-dev
+    rustc (>=1.57),
 Standards-Version: 4.1.1
 Homepage: https://github.com/pop-os/cosmic-comp
 


### PR DESCRIPTION
This should actually fix CI.