### PR TITLE
fix zombie processes from Action::Spawn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 VENDOR ?= 0
 ifneq ($(VENDOR),0)
-	ARGS += --locked
+	ARGS += --offline --locked
 endif
 
 TARGET_BIN="$(DESTDIR)$(bindir)/$(BINARY)"

--- a/debian/rules
+++ b/debian/rules
@@ -15,9 +15,6 @@ ifeq ($(VENDOR),1)
 	ischroot || make vendor
 endif
 
-override_dh_auto_build:
-	CARGO_HOME="$$(pwd)/target/cargo" make
-
 override_dh_installinit:
 	dh_installinit -r
 

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,2 @@
+tar-ignore=target
+tar-ignore=vendor


### PR DESCRIPTION
Each invocation of `Action::Spawn` was spawning a process without waiting on the child; resulting in an accumulation of zombie sh processes. This will spawn them in a background thread which waits on the child so that it can be reaped.