### PR TITLE
Update Nix flake and CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
+    - uses: cachix/install-nix-action@v21
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
     - run: nix build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,5 @@ jobs:
     - uses: cachix/install-nix-action@v21
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - run: nix build
+    - run: GIT_LFS_SKIP_SMUDGE=1 nix build
     - run: nix flake check

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1672095661,
-        "narHash": "sha256-7NTsdCn3qsvU7A+1/7tY8pxbq0DYy1pFYNpzN6he9lI=",
+        "lastModified": 1684981077,
+        "narHash": "sha256-68X9cFm0RTZm8u0rXPbeBzOVUH5OoUGAfeHHVoxGd9o=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "98894bb39b03bfb379c5e10523cd61160e1ac782",
+        "rev": "35110cccf28823320f4fd697fcafcb5038683982",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1672468395,
-        "narHash": "sha256-eIrQGHZub98IiLqtFXa00ooHBCjtKY+rfKJs5lhyF/c=",
+        "lastModified": 1685600533,
+        "narHash": "sha256-7oly5/7xJMtFH44I/Bsrnc2VG4M6HyUVhph3WoZrG64=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d6f9bdfb4a25395b15f6c6feba3d0bba5e62b3ce",
+        "rev": "360c6a0bc9b78b896fdd60c8803ba98298a37f7c",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -61,12 +61,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -76,12 +79,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -92,11 +98,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1666547822,
-        "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
+        "lastModified": 1681154353,
+        "narHash": "sha256-MCJ5FHOlbfQRFwN0brqPbCunLEVw05D/3sRVoNVt2tI=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "1a3b735e13e90a8d2fd5629f2f8363bd7ffbbec7",
+        "rev": "f529f42792ade8e32c4be274af6b6d60857fbee7",
         "type": "github"
       },
       "original": {
@@ -107,11 +113,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672428209,
-        "narHash": "sha256-eejhqkDz2cb2vc5VeaWphJz8UXNuoNoM8/Op8eWv2tQ=",
+        "lastModified": 1685591878,
+        "narHash": "sha256-Ib3apaLqIFkZb94q6Q214DXrz0FnJq5C7usywTv63og=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847",
+        "rev": "8d4d822bc0efa9de6eddc79cb0d82897a9baa750",
         "type": "github"
       },
       "original": {
@@ -133,11 +139,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1672438471,
-        "narHash": "sha256-bB/7XFnRgGhOhYY6HIov7eF/qnR5NPtKtSfDa2aWqh8=",
+        "lastModified": 1685541053,
+        "narHash": "sha256-ck8hhiuxvy8jLIv2cPsQK8bfc/aYZjrIelmLAv16T4o=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "0d76b94c90a20c20d3e57ea1ab03d9afa00dee72",
+        "rev": "bafa6c4ee5d3acdbb62ec289364564270357c6a2",
         "type": "github"
       },
       "original": {
@@ -159,16 +165,46 @@
         ]
       },
       "locked": {
-        "lastModified": 1670034122,
-        "narHash": "sha256-EqmuOKucPWtMvCZtHraHr3Q3bgVszq1x2PoZtQkUuEk=",
+        "lastModified": 1683080331,
+        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a0d5773275ecd4f141d792d3a0376277c0fc0b65",
+        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,11 @@
               ./resources
             ];
           };
-          nativeBuildInputs = with pkgs; [ pkg-config autoPatchelfHook ];
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            autoPatchelfHook
+            cmake
+          ];
           buildInputs = with pkgs; [
             wayland
             systemd # For libudev
@@ -39,8 +43,12 @@
             libxkbcommon
             libinput
             mesa # For libgbm
+            fontconfig
+            stdenv.cc.cc.lib
           ];
-          runtimeDependencies = with pkgs; [ libglvnd ]; # For libEGL
+          runtimeDependencies = with pkgs; [
+            libglvnd # For libEGL
+          ];
         };
 
         cargoArtifacts = craneLib.buildDepsOnly pkgDef;


### PR DESCRIPTION
Fix the build issues and update dependencies.
Currently I can successfully build the binary on my laptop, but when running it, I encountered the following error.
<details>

```
2023-06-02T04:28:33.407325Z  WARN cosmic_comp::config::types: Key-Binding 'Period' only matched case insensitive for "period"
2023-06-02T04:28:33.407404Z  WARN cosmic_comp::config::types: Key-Binding 'Comma' only matched case insensitive for "comma"
2023-06-02T04:28:33.407422Z  WARN cosmic_comp::config::types: Key-Binding 'Period' only matched case insensitive for "period"
2023-06-02T04:28:33.407434Z  WARN cosmic_comp::config::types: Key-Binding 'Comma' only matched case insensitive for "comma"
2023-06-02T04:28:33.471306Z  WARN cosmic_comp::backend::x11: Failed to instanciate vulkan, falling back to gbm allocator. err=Load(LoadError)
2023-06-02T04:28:33.471367Z  WARN smithay::backend::drm::device::fd: Unable to become drm master, assuming unprivileged mode
DRI driver not from this Mesa build ('23.0.3' vs '23.0.1')
failed to bind extensions
DRI driver not from this Mesa build ('23.0.3' vs '23.0.1')
failed to bind extensions
DRI driver not from this Mesa build ('23.0.3' vs '23.0.1')
failed to bind extensions
DRI driver not from this Mesa build ('23.0.3' vs '23.0.1')
failed to bind extensions
2023-06-02T04:28:33.472568Z ERROR cosmic_comp::backend::x11: Failed to create GBM device. err=Os { code: 2, kind: NotFound, message: "No such file or directory" }
2023-06-02T04:28:33.475239Z ERROR panic: thread 'main' panicked at 'Failed to create allocator for x11': src/backend/x11.rs:361
   0: <backtrace::capture::Backtrace as core::default::Default>::default
   1: log_panics::Config::install_panic_hook::{{closure}}
   2: std::panicking::rust_panic_with_hook
   3: std::panicking::begin_panic_handler::{{closure}}
   4: std::sys_common::backtrace::__rust_end_short_backtrace
   5: rust_begin_unwind
   6: core::panicking::panic_fmt
   7: core::panicking::panic_display
   8: core::panicking::panic_str
   9: core::option::expect_failed
  10: cosmic_comp::backend::x11::init_backend
  11: cosmic_comp::main
  12: std::sys_common::backtrace::__rust_begin_short_backtrace
  13: main
  14: __libc_start_call_main
  15: __libc_start_main@@GLIBC_2.34
  16: _start
```

</details>

Not sure if it is caused a problem in the build process or the runtime environment.