### PR TITLE
shell: fix window size when unmaximize from tiling mode

### DIFF
--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -300,6 +300,9 @@ impl Workspace {
             self.floating_layer.refresh();
             self.tiling_layer.recalculate(output);
             self.tiling_layer.refresh();
+            if let Some((_, _, rect)) = self.tiling_layer.windows().find(|(_, w, _)| w == window) {
+              window.set_geometry(rect);
+            };
             window.send_configure();
             self.fullscreen.retain(|_, w| w != window);
         }


### PR DESCRIPTION
Steps to reproduce bug:
1. Enter tiling mode
2. Open 2+ windows
2. Maximize window (Super + m)
3. UnMaximize window (Super + m)
4. (Bug) the unmaximized window will render at the full size of the display, but be cropped to the size of the tiled area.

After this the window will render to the size of the tiling.