### PR TITLE
shell: Allow querying current vs pending state

### DIFF
--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -247,14 +247,14 @@ impl CosmicMapped {
         }
     }
 
-    pub fn is_resizing(&self) -> Option<bool> {
+    pub fn is_resizing(&self, pending: bool) -> Option<bool> {
         let window = match &self.element {
             CosmicMappedInternal::Stack(s) => s.active(),
             CosmicMappedInternal::Window(w) => w.surface(),
             _ => unreachable!(),
         };
 
-        window.is_resizing()
+        window.is_resizing(pending)
     }
 
     pub fn set_tiled(&self, tiled: bool) {
@@ -268,14 +268,14 @@ impl CosmicMapped {
         }
     }
 
-    pub fn is_tiled(&self) -> Option<bool> {
+    pub fn is_tiled(&self, pending: bool) -> Option<bool> {
         let window = match &self.element {
             CosmicMappedInternal::Stack(s) => s.active(),
             CosmicMappedInternal::Window(w) => w.surface(),
             _ => unreachable!(),
         };
 
-        window.is_tiled()
+        window.is_tiled(pending)
     }
 
     pub fn set_fullscreen(&self, fullscreen: bool) {
@@ -290,14 +290,14 @@ impl CosmicMapped {
         }
     }
 
-    pub fn is_fullscreen(&self) -> bool {
+    pub fn is_fullscreen(&self, pending: bool) -> bool {
         let window = match &self.element {
             CosmicMappedInternal::Stack(s) => s.active(),
             CosmicMappedInternal::Window(w) => w.surface(),
             _ => unreachable!(),
         };
 
-        window.is_fullscreen()
+        window.is_fullscreen(pending)
     }
 
     pub fn set_maximized(&self, maximized: bool) {
@@ -312,14 +312,14 @@ impl CosmicMapped {
         }
     }
 
-    pub fn is_maximized(&self) -> bool {
+    pub fn is_maximized(&self, pending: bool) -> bool {
         let window = match &self.element {
             CosmicMappedInternal::Stack(s) => s.active(),
             CosmicMappedInternal::Window(w) => w.surface(),
             _ => unreachable!(),
         };
 
-        window.is_maximized()
+        window.is_maximized(pending)
     }
 
     pub fn set_activated(&self, activated: bool) {
@@ -334,14 +334,14 @@ impl CosmicMapped {
         }
     }
 
-    pub fn is_activated(&self) -> bool {
+    pub fn is_activated(&self, pending: bool) -> bool {
         let window = match &self.element {
             CosmicMappedInternal::Stack(s) => s.active(),
             CosmicMappedInternal::Window(w) => w.surface(),
             _ => unreachable!(),
         };
 
-        window.is_activated()
+        window.is_activated(pending)
     }
 
     pub fn set_geometry(&self, geo: Rectangle<i32, Logical>) {

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -107,7 +107,7 @@ impl CosmicWindowInternal {
     }
 
     pub fn has_ssd(&self) -> bool {
-        !self.window.is_decorated()
+        !self.window.is_decorated(false)
     }
 }
 
@@ -259,7 +259,7 @@ impl Program for CosmicWindowInternal {
     }
 
     fn background_color(&self) -> Color {
-        if self.window.is_activated() {
+        if self.window.is_activated(false) {
             Color {
                 r: 0.1176,
                 g: 0.1176,
@@ -281,7 +281,7 @@ impl Program for CosmicWindowInternal {
         pixels: &mut tiny_skia::PixmapMut<'_>,
         damage: &[Rectangle<i32, BufferCoords>],
     ) {
-        if !self.window.is_activated() {
+        if !self.window.is_activated(false) {
             let mask = self.mask.lock().unwrap();
             let mut paint = tiny_skia::Paint::default();
             paint.set_color_rgba8(0, 0, 0, 102);

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -226,7 +226,7 @@ impl ResizeSurfaceGrab {
 
             // Finish resizing.
             if let Some(ResizeState::WaitingForCommit(_)) = *resize_state {
-                if !window.is_resizing().unwrap_or(false) {
+                if !window.is_resizing(false).unwrap_or(false) {
                     *resize_state = None;
                 }
             }

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -158,7 +158,7 @@ impl FloatingLayout {
 
     pub fn unmap(&mut self, window: &CosmicMapped) -> bool {
         #[allow(irrefutable_let_patterns)]
-        let is_maximized = window.is_maximized();
+        let is_maximized = window.is_maximized(true);
 
         if !is_maximized {
             if let Some(location) = self.space.element_location(window) {

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -1415,7 +1415,7 @@ impl TilingLayout {
                             }
                         },
                         Data::Mapped { mapped, .. } => {
-                            if !(mapped.is_fullscreen() || mapped.is_maximized()) {
+                            if !(mapped.is_fullscreen(true) || mapped.is_maximized(true)) {
                                 mapped.set_tiled(true);
                                 let internal_geometry = Rectangle::from_loc_and_size(
                                     geo.loc + output.geometry().loc,
@@ -1460,7 +1460,7 @@ impl TilingLayout {
                             .unwrap()
                             .filter(|node| node.data().is_mapped(None))
                             .filter(|node| match node.data() {
-                                Data::Mapped { mapped, .. } => mapped.is_activated(),
+                                Data::Mapped { mapped, .. } => mapped.is_activated(false),
                                 _ => unreachable!(),
                             })
                             .map(|node| match node.data() {
@@ -1480,7 +1480,7 @@ impl TilingLayout {
                                     .unwrap()
                                     .filter(|node| node.data().is_mapped(None))
                                     .filter(|node| match node.data() {
-                                        Data::Mapped { mapped, .. } => !mapped.is_activated(),
+                                        Data::Mapped { mapped, .. } => !mapped.is_activated(false),
                                         _ => unreachable!(),
                                     })
                                     .map(|node| match node.data() {

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -143,7 +143,7 @@ impl Workspace {
             assert!(was_floating != was_tiling);
         }
 
-        if mapped.is_maximized() || mapped.is_fullscreen() {
+        if mapped.is_maximized(true) || mapped.is_fullscreen(true) {
             self.unmaximize_request(&mapped.active_window());
         }
 
@@ -324,7 +324,7 @@ impl Workspace {
         start_data: PointerGrabStartData<State>,
         edges: ResizeEdge,
     ) -> Option<ResizeGrab> {
-        if mapped.is_fullscreen() || mapped.is_maximized() {
+        if mapped.is_fullscreen(true) || mapped.is_maximized(true) {
             return None;
         }
 
@@ -355,7 +355,7 @@ impl Workspace {
         let mapped = self.element_for_surface(&window)?.clone();
         let mut initial_window_location = self.element_geometry(&mapped).unwrap().loc;
 
-        if mapped.is_fullscreen() || mapped.is_maximized() {
+        if mapped.is_fullscreen(true) || mapped.is_maximized(true) {
             // If surface is maximized then unmaximize it
             let new_size = self.unmaximize_request(window);
             let ratio = pos.x / output.geometry().size.w as f64;

--- a/src/wayland/handlers/toplevel_info.rs
+++ b/src/wayland/handlers/toplevel_info.rs
@@ -31,15 +31,15 @@ impl Window for CosmicSurface {
     }
 
     fn is_activated(&self) -> bool {
-        CosmicSurface::is_activated(self)
+        CosmicSurface::is_activated(self, false)
     }
 
     fn is_maximized(&self) -> bool {
-        CosmicSurface::is_maximized(self)
+        CosmicSurface::is_maximized(self, false)
     }
 
     fn is_fullscreen(&self) -> bool {
-        CosmicSurface::is_fullscreen(self)
+        CosmicSurface::is_fullscreen(self, false)
     }
 
     fn is_minimized(&self) -> bool {


### PR DESCRIPTION
Superseeds #131, should fix #125.

Fixes the intent of the `is_maximized || is_fullscreen`-checks of the tiling layer, causing the geometry to be correctly restored by `recalculate`.