### PR TITLE
Ignore caps/num lock in key bindings

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -903,8 +903,6 @@ pub enum KeyModifier {
     Alt,
     Shift,
     Super,
-    CapsLock,
-    NumLock,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
@@ -913,8 +911,6 @@ pub struct KeyModifiers {
     pub alt: bool,
     pub shift: bool,
     pub logo: bool,
-    pub caps_lock: bool,
-    pub num_lock: bool,
 }
 
 impl PartialEq<ModifiersState> for KeyModifiers {
@@ -923,8 +919,6 @@ impl PartialEq<ModifiersState> for KeyModifiers {
             && self.alt == other.alt
             && self.shift == other.shift
             && self.logo == other.logo
-            && self.caps_lock == other.caps_lock
-            && self.num_lock == other.num_lock
     }
 }
 
@@ -935,8 +929,6 @@ impl std::ops::AddAssign<KeyModifier> for KeyModifiers {
             KeyModifier::Alt => self.alt = true,
             KeyModifier::Shift => self.shift = true,
             KeyModifier::Super => self.logo = true,
-            KeyModifier::CapsLock => self.caps_lock = true,
-            KeyModifier::NumLock => self.num_lock = true,
         };
     }
 }
@@ -957,9 +949,7 @@ impl Into<KeyModifiers> for KeyModifier {
             ctrl: false,
             alt: false,
             shift: false,
-            caps_lock: false,
             logo: false,
-            num_lock: false,
         };
         modifiers += self;
         modifiers

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -212,9 +212,7 @@ impl From<KeyModifiersDef> for KeyModifiers {
                 ctrl: false,
                 alt: false,
                 shift: false,
-                caps_lock: false,
                 logo: false,
-                num_lock: false,
             },
             |mut modis, modi: KeyModifier| {
                 modis += modi;


### PR DESCRIPTION
I noticed https://github.com/pop-os/cosmic-comp/issues/17 again, but this time I realized num lock was on. Hopefully this is the only cause of that issue (and caps lock, but that is easier to notice).

I don't think we would event want either of these states to be part of a key binding. And `KeyModifiers` doesn't seem to be used anywhere else this would be relevant. So they can be ignored. This should be more similar to how keybindings are handled elsewhere.