### PR TITLE
Fix output filtering of override-redirect windows

### DIFF
--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -35,7 +35,7 @@ use smithay::{
         glow::{GlowFrame, GlowRenderer},
         ImportAll, ImportMem, Renderer,
     },
-    desktop::{layer_map_for_output, space::SpaceElement},
+    desktop::layer_map_for_output,
     input::{pointer::GrabStartData as PointerGrabStartData, Seat},
     output::Output,
     reexports::wayland_server::{protocol::wl_surface::WlSurface, Client},
@@ -521,7 +521,7 @@ impl Workspace {
             popup_elements.extend(
                 override_redirect_windows
                     .iter()
-                    .filter(|or| or.geometry().intersection(output.geometry()).is_some())
+                    .filter(|or| (*or).geometry().intersection(output.geometry()).is_some())
                     .flat_map(|or| {
                         AsRenderElements::<R>::render_elements::<WorkspaceRenderElement<R>>(
                             or,
@@ -569,7 +569,7 @@ impl Workspace {
             popup_elements.extend(
                 override_redirect_windows
                     .iter()
-                    .filter(|or| or.geometry().intersection(output.geometry()).is_some())
+                    .filter(|or| (*or).geometry().intersection(output.geometry()).is_some())
                     .flat_map(|or| {
                         AsRenderElements::<R>::render_elements::<WorkspaceRenderElement<R>>(
                             or,


### PR DESCRIPTION
`or.geometry()` was actually calling a different method in `filter` than in `.flat_map`. Apparently since `or` in `filter` is an `&&X11Surface` instead of `&X11Surface`, that invoked the trait method on `SpaceElement`...

Smithay should be changed in some way so that can't happen, but this improves some of the behavior in cosmic-comp for now, at least. There may be other issues related to this.

The `SpaceElement::geometry` was also returning a `loc` of `(0, 0)`, which presumably isn't correct either.