### PR TITLE
xwm: Don't pass override-redirect surfaces to `update_stacking_order*`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=b77ef9a7ee#b77ef9a7ee655ad021004abdd4668c653d7543c7"
+source = "git+https://github.com/smithay//smithay?rev=cd2f688a0d#cd2f688a0d56a762cf1c3e4606898d0eb5cbe964"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,4 +80,4 @@ debug = true
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "b77ef9a7ee" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "cd2f688a0d" }

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -547,11 +547,7 @@ impl Workspace {
 
             if let Some(xwm) = xwm_state.and_then(|state| state.xwm.as_mut()) {
                 if let Err(err) = xwm.update_stacking_order_upwards(
-                    popup_elements
-                        .iter()
-                        .rev()
-                        .map(|e| e.id())
-                        .chain(window_elements.iter().rev().map(|e| e.id())),
+                    window_elements.iter().rev().map(|e| e.id()),
                 ) {
                     warn!(
                         wm_id = ?xwm.id(),
@@ -629,11 +625,7 @@ impl Workspace {
 
             if let Some(xwm) = xwm_state.and_then(|state| state.xwm.as_mut()) {
                 if let Err(err) = xwm.update_stacking_order_upwards(
-                    popup_elements
-                        .iter()
-                        .rev()
-                        .map(|e| e.id())
-                        .chain(window_elements.iter().rev().map(|e| e.id())),
+                    window_elements.iter().rev().map(|e| e.id()),
                 ) {
                     warn!(
                         wm_id = ?xwm.id(),


### PR DESCRIPTION
We shouldn't be sending configures to override-redirect surfaces.

Requires https://github.com/Smithay/smithay/pull/1094 to behave correctly.