### PR TITLE
Send `SCANOUT` flag in dmabuf feedback when target_node != render_node

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -1004,7 +1004,11 @@ fn get_surface_dmabuf_feedback(
     let target_node = surface.device_fd().dev_id().unwrap();
     let mut builder = DmabufFeedbackBuilder::new(render_node.dev_id(), render_formats);
     if target_node != render_node.dev_id() && !combined_formats.is_empty() {
-        builder = builder.add_preference_tranche(target_node, None, combined_formats);
+        builder = builder.add_preference_tranche(
+            target_node,
+            Some(zwp_linux_dmabuf_feedback_v1::TrancheFlags::Scanout),
+            combined_formats,
+        );
     };
     let render_feedback = builder.clone().build().unwrap();
 


### PR DESCRIPTION
The Intel driver (at least) pads the stride to meet the requirements for scanout on AMD or Nvidia cards, when this flag is set.

This works around the bug I've seen in the Nvidia driver with corruption importing an unaligned dmabuf. This presumably is an issue in the Nvidia driver, but presumably it the fix would be for the import to fail, so using a stride that allows it to succeed is better anyway.