### PR TITLE
input: Add a `scroll_factor` config option

### DIFF
--- a/cosmic-comp-config/src/input.rs
+++ b/cosmic-comp-config/src/input.rs
@@ -42,6 +42,7 @@ pub struct ScrollConfig {
     pub method: Option<ScrollMethod>,
     pub natural_scroll: Option<bool>,
     pub scroll_button: Option<u32>,
+    pub scroll_factor: Option<f64>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/src/config/input_config.rs
+++ b/src/config/input_config.rs
@@ -64,6 +64,7 @@ pub fn for_device(device: &InputDevice) -> InputConfig {
                 } else {
                     None
                 },
+                scroll_factor: None,
             })
         } else {
             None
@@ -83,7 +84,7 @@ pub fn for_device(device: &InputDevice) -> InputConfig {
 
 // Get setting from `device_config` if present, then `default_config`
 // Returns `is_default` to indicate this is a default value.
-fn get_config<'a, T: 'a, F: Fn(&'a InputConfig) -> Option<T>>(
+pub fn get_config<'a, T: 'a, F: Fn(&'a InputConfig) -> Option<T>>(
     device_config: Option<&'a InputConfig>,
     default_config: &'a InputConfig,
     f: F,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -412,13 +412,26 @@ impl Config {
     }
 
     pub fn read_device(&self, device: &mut InputDevice) {
+        let (device_config, default_config) = self.get_device_config(device);
+        input_config::update_device(device, device_config, default_config);
+    }
+
+    pub fn scroll_factor(&self, device: &InputDevice) -> f64 {
+        let (device_config, default_config) = self.get_device_config(device);
+        input_config::get_config(device_config, default_config, |x| {
+            x.scroll_config.as_ref()?.scroll_factor
+        })
+        .map_or(1.0, |x| x.0)
+    }
+
+    fn get_device_config(&self, device: &InputDevice) -> (Option<&InputConfig>, &InputConfig) {
         let default_config = if device.config_tap_finger_count() > 0 {
             &self.input_touchpad
         } else {
             &self.input_default
         };
         let device_config = self.input_devices.get(device.name());
-        input_config::update_device(device, device_config, default_config);
+        (device_config, default_config)
     }
 }
 


### PR DESCRIPTION
This is not a setting handled by libinput; we have to scale the scrolling ourselves.

This should match the behavior of the `scroll_factor` defined in sway-input(5).