### PR TITLE
Use cosmic-config for workspace settings

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -81,8 +81,5 @@
         (modifiers: [], key: "XF86MonBrightnessUp"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness"),
         (modifiers: [], key: "XF86MonBrightnessDown"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness"),
     },
-    workspace_mode: OutputBound,
-    workspace_amount: Dynamic,
-    workspace_layout: Vertical,
     tiling_enabled: false,
 )

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod input;
+pub mod workspace;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct XkbConfig {

--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use serde::{Deserialize, Serialize};
+
+fn default_workspace_layout() -> WorkspaceLayout {
+    WorkspaceLayout::Vertical
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceConfig {
+    pub workspace_mode: WorkspaceMode,
+    pub workspace_amount: WorkspaceAmount,
+    #[serde(default = "default_workspace_layout")]
+    pub workspace_layout: WorkspaceLayout,
+}
+
+impl Default for WorkspaceConfig {
+    fn default() -> Self {
+        Self {
+            workspace_mode: WorkspaceMode::OutputBound,
+            workspace_amount: WorkspaceAmount::Dynamic,
+            workspace_layout: WorkspaceLayout::Vertical,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkspaceAmount {
+    Dynamic,
+    Static(u8),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkspaceMode {
+    OutputBound,
+    Global,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkspaceLayout {
+    Vertical,
+    Horizontal,
+}

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -11,7 +11,6 @@ use std::{
 #[cfg(feature = "debug")]
 use crate::debug::{fps_ui, profiler_ui};
 use crate::{
-    config::WorkspaceLayout,
     shell::{
         focus::target::WindowGroup, grabs::SeatMoveGrabState, layout::tiling::ANIMATION_DURATION,
         CosmicMapped, CosmicMappedRenderElement, OverviewMode, Trigger, WorkspaceRenderElement,
@@ -32,6 +31,7 @@ use crate::{
     },
 };
 
+use cosmic_comp_config::workspace::WorkspaceLayout;
 use cosmic_protocols::screencopy::v1::server::zcosmic_screencopy_session_v1::FailureReason;
 use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
@@ -557,7 +557,7 @@ where
 
     let offset = match previous.as_ref() {
         Some((previous, previous_idx, start)) => {
-            let layout = state.config.static_conf.workspace_layout;
+            let layout = state.config.workspace.workspace_layout;
 
             let workspace = state
                 .shell

--- a/src/config/key_bindings.rs
+++ b/src/config/key_bindings.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::shell::{focus::FocusDirection, grabs::ResizeEdge, Direction, ResizeDirection};
+use cosmic_comp_config::workspace::WorkspaceLayout;
 use serde::Deserialize;
 use smithay::{
     backend::input::KeyState,
@@ -8,7 +9,7 @@ use smithay::{
 };
 use std::collections::HashMap;
 
-use super::{types::*, WorkspaceLayout};
+use super::types::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub enum KeyModifier {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     backend::render::cursor::CursorState,
-    config::{xkb_config_to_wl, Action, Config, KeyPattern, WorkspaceLayout},
+    config::{xkb_config_to_wl, Action, Config, KeyPattern},
     shell::{
         focus::{target::PointerFocusTarget, FocusDirection},
         grabs::{ResizeEdge, SeatMoveGrabState},
@@ -18,6 +18,7 @@ use crate::{
     wayland::{handlers::screencopy::ScreencopySessions, protocols::screencopy::Session},
 };
 use calloop::{timer::Timer, RegistrationToken};
+use cosmic_comp_config::workspace::WorkspaceLayout;
 use cosmic_protocols::screencopy::v1::server::zcosmic_screencopy_session_v1::InputType;
 #[allow(deprecated)]
 use smithay::{
@@ -1518,7 +1519,7 @@ impl State {
 
                 match result {
                     FocusResult::None => {
-                        match (focus, self.common.config.static_conf.workspace_layout) {
+                        match (focus, self.common.config.workspace.workspace_layout) {
                             (FocusDirection::Left, WorkspaceLayout::Horizontal)
                             | (FocusDirection::Up, WorkspaceLayout::Vertical) => self
                                 .handle_action(
@@ -1574,7 +1575,7 @@ impl State {
 
                 match workspace.move_current_element(direction, seat) {
                     MoveResult::MoveFurther(_move_further) => {
-                        match (direction, self.common.config.static_conf.workspace_layout) {
+                        match (direction, self.common.config.workspace.workspace_layout) {
                             (Direction::Left, WorkspaceLayout::Horizontal)
                             | (Direction::Up, WorkspaceLayout::Vertical) => self.handle_action(
                                 Action::MoveToPreviousWorkspace,

--- a/src/wayland/protocols/workspace.rs
+++ b/src/wayland/protocols/workspace.rs
@@ -70,6 +70,7 @@ pub struct WorkspaceGroupHandle {
 pub struct WorkspaceGroupDataInner {
     outputs: Vec<Output>,
     capabilities: Vec<GroupCapabilities>,
+    workspace_count: usize,
 }
 pub type WorkspaceGroupData = Mutex<WorkspaceGroupDataInner>;
 
@@ -869,6 +870,11 @@ where
         handle_state.capabilities = group.capabilities.clone();
         changed = true;
     }
+
+    if handle_state.workspace_count != group.workspaces.len() {
+        changed = true;
+    }
+    handle_state.workspace_count = group.workspaces.len();
 
     for workspace in &mut group.workspaces {
         if send_workspace_to_client::<D>(dh, instance, workspace) {


### PR DESCRIPTION
`WorkspaceAmount` now can be changed dynamically, which seems to basically work. We'll see how that works with `WorkspaceMode` and `WorkspaceLayout`.

If `WorkspaceLayout` can be changed at runtime, we'll have to update default keybindings in some way.