### PR TITLE
Send `relative_pointer` in frame with `pointer`; update Smithay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=36a0ec69b1#36a0ec69b1a2331b1a2d0e046b026cb85d7d132c"
+source = "git+https://github.com/smithay//smithay?rev=1a61e1c13a#1a61e1c13a8d6996e28741a5ecdb09af4981c17d"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,4 @@ debug = true
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "36a0ec69b1" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "1a61e1c13a" }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -498,22 +498,24 @@ impl State {
                         }
                     }
                     let ptr = seat.get_pointer().unwrap();
-                    ptr.motion(
-                        self,
-                        under.clone(),
-                        &MotionEvent {
-                            location: position,
-                            serial,
-                            time: event.time_msec(),
-                        },
-                    );
+                    // Relative motion is sent first to ensure they're part of a `frame`
+                    // TODO: Find more correct solution
                     ptr.relative_motion(
                         self,
-                        under,
+                        under.clone(),
                         &RelativeMotionEvent {
                             delta: event.delta(),
                             delta_unaccel: event.delta_unaccel(),
                             utime: event.time(),
+                        },
+                    );
+                    ptr.motion(
+                        self,
+                        under,
+                        &MotionEvent {
+                            location: position,
+                            serial,
+                            time: event.time_msec(),
                         },
                     );
                     #[cfg(feature = "debug")]


### PR DESCRIPTION
The protocol doesn't specify this, but XWayland does assume relative pointer events are part of a frame.

This works for now, though a better solution will be needed in Smithay to also handle pointer constraints where a relative motion may occur alone, etc.

This seems to fix https://github.com/pop-os/cosmic-comp/issues/159.