### PR TITLE
Fix `TilingLayout::element_under` position with global workspaces

### DIFF
--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -3055,7 +3055,7 @@ impl TilingLayout {
                         mapped.is_in_input_region(&test_point).then(|| {
                             (
                                 mapped.clone().into(),
-                                last_geometry.loc - output_data.location - mapped.geometry().loc,
+                                last_geometry.loc + output_data.location - mapped.geometry().loc,
                             )
                         })
                     }
@@ -3086,7 +3086,8 @@ impl TilingLayout {
                                 orientation,
                             }
                             .into(),
-                            last_geometry.loc - output_data.location
+                            last_geometry.loc
+                                + output_data.location
                                 + tree
                                     .children(&id)
                                     .unwrap()


### PR DESCRIPTION
I didn't see any issue with how mouse events were handled, but a bisect showed b818a68a91c83cd3ab5da79cebb5f144cb2feeee caused the issue. Reverting the definition of `element_under` to the version before that change fixed the behavior.

Comparing what both versions return, the right element is returned, but the location returned is wrong. This makes the return value match the position that was returned by the previous implementation. It seems to be working correctly now.

Fixes https://github.com/pop-os/cosmic-comp/issues/161.