### PR TITLE
wayland: map windows with correct geometry

### DIFF
--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -184,6 +184,7 @@ impl CompositorHandler for State {
                         && with_renderer_surface_state(&surface, |state| state.buffer().is_some())
                     {
                         let output = seat.active_output();
+                        window.on_commit();
                         Shell::map_window(self, &window, &output);
                     } else {
                         return;


### PR DESCRIPTION
Consider a simple client that doesn't use `set_window_geometry`, committing after attaching a buffer to a window surface.

`Window::geometry` falls back to `Window::bbox`, but when `Shell::map_window` called `Window::geometry`, `Window::bbox` hadn't been set yet, because that only happened later in `<State as CompositorHandler>::commit`, so the window would be mapped with a size of (0, 0).

This resulted in server-side decorations not being drawn for such clients until they were re-focused or resized.

The fix is to add an extra call to `Window::on_commit` before mapping it, so that its bbox is set correctly when `Shell::map_window` asks for its geometry.