### PR TITLE
chore: Update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,10 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "ab_glyph"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5110f1c78cf582855d895ecd0746b653db010cec6d9f5575293f27934d980a39"
+checksum = "b1061f3ff92c2f65800df1f12fc7b4ff44ee14783104187dd04dfee6f11b0fd2"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -26,9 +20,9 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -63,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -75,6 +69,18 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "almost"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa2999eb46af81abb65c2d30d446778d7e613b60bbf4e174a027e80f90a3c14"
 
 [[package]]
 name = "android-activity"
@@ -111,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 dependencies = [
  "backtrace",
 ]
@@ -176,10 +182,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.10"
+name = "async-task"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
+checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905"
 
 [[package]]
 name = "atomicwrites"
@@ -187,7 +199,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1163d9d7c51de51a2b79d6df5e8888d11e9df17c752ce4a285fb6ca1580734e"
 dependencies = [
- "rustix 0.37.23",
+ "rustix 0.37.24",
  "tempfile",
  "windows-sys 0.48.0",
 ]
@@ -200,9 +212,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -221,9 +233,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bincode"
@@ -263,9 +275,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block"
@@ -303,28 +318,28 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
+checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -340,7 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e0d00eb1ea24371a97d2da6201c6747a633dc6dc1988ef503403b4c59504a8"
 dependencies = [
  "bitflags 1.3.2",
- "futures-util",
  "log",
  "nix 0.25.1",
  "slotmap",
@@ -349,12 +363,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.79"
+name = "calloop"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "aadd183e815348c0649051b1c43418643208f8ed13c8a84da7215b4e1cf42714"
+dependencies = [
+ "async-task",
+ "bitflags 2.4.0",
+ "log",
+ "polling",
+ "rustix 0.38.14",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -397,15 +427,14 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
  "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
  "libc",
  "objc",
 ]
@@ -431,6 +460,15 @@ name = "com-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "core-foundation"
@@ -477,10 +515,9 @@ name = "cosmic-comp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "apply",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "bytemuck",
- "calloop",
+ "calloop 0.12.2",
  "cosmic-comp-config",
  "cosmic-config",
  "cosmic-protocols",
@@ -491,7 +528,7 @@ dependencies = [
  "i18n-embed-fl",
  "iced_tiny_skia",
  "id_tree",
- "indexmap 1.9.3",
+ "indexmap 2.0.1",
  "keyframe",
  "lazy_static",
  "libcosmic",
@@ -512,15 +549,15 @@ dependencies = [
  "smithay",
  "smithay-egui",
  "thiserror",
- "tiny-skia 0.9.1",
+ "tiny-skia 0.10.0",
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
- "wayland-backend",
- "wayland-scanner 0.30.1",
+ "wayland-backend 0.3.2",
+ "wayland-scanner 0.31.0",
  "xcursor",
  "xdg",
- "xkbcommon 0.4.1",
+ "xkbcommon",
 ]
 
 [[package]]
@@ -534,22 +571,22 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "atomicwrites",
- "calloop",
+ "calloop 0.12.2",
  "cosmic-config-derive",
  "dirs 5.0.1",
  "iced_futures",
  "notify",
- "ron 0.8.0",
+ "ron 0.8.1",
  "serde",
 ]
 
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -558,26 +595,27 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#e39748e1312d74ab8b4c26f4813b858413500b59"
+source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#5c03417a08ef04755ad7bc2285d07968d89d69f8"
 dependencies = [
- "bitflags 1.3.2",
- "wayland-backend",
- "wayland-protocols 0.30.1",
- "wayland-scanner 0.30.1",
+ "bitflags 2.4.0",
+ "wayland-backend 0.3.2",
+ "wayland-protocols 0.31.0",
+ "wayland-scanner 0.31.0",
  "wayland-server",
 ]
 
 [[package]]
 name = "cosmic-text"
-version = "0.8.0"
-source = "git+https://github.com/hecrj/cosmic-text.git?rev=b85d6a4f2376f8a8a7dadc0f8bcb89d4db10a1c9#b85d6a4f2376f8a8a7dadc0f8bcb89d4db10a1c9"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b68966c2543609f8d92f9d33ac3b719b2a67529b0c6c0b3e025637b477eef9"
 dependencies = [
+ "aliasable",
  "fontdb",
  "libm",
  "log",
- "ouroboros 0.15.6",
  "rangemap",
- "rustybuzz",
+ "rustybuzz 0.8.0",
  "swash",
  "sys-locale",
  "unicode-bidi",
@@ -589,15 +627,14 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
- "anyhow",
+ "almost",
  "cosmic-config",
  "csscolorparser",
- "directories",
  "lazy_static",
  "palette",
- "ron 0.8.0",
+ "ron 0.8.1",
  "serde",
 ]
 
@@ -679,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "css-color"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d101c65424c856131a3cb818da2ddde03500dc3656972269cdf79f018ef77eb4"
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,7 +763,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -731,17 +774,17 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.0"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -755,9 +798,9 @@ checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "deranged"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "derive_setters"
@@ -768,7 +811,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -780,15 +823,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "directories"
-version = "4.0.1"
-source = "git+https://github.com/edfloreshz/directories-rs#6a6d83d853a35ee3273034215c4defaf61286fe5"
-dependencies = [
- "anyhow",
- "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -846,7 +880,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -872,25 +906,25 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drm"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf9159ef4bcecd0c5e4cbeb573b8d0037493403d542780dba5d840bbf9df56f"
+checksum = "97fb1b703ffbc7ebd216eba7900008049a56ace55580ecb2ee7fa801e8d8be87"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
- "nix 0.26.2",
+ "nix 0.27.1",
 ]
 
 [[package]]
 name = "drm-ffi"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1352481b7b90e27a8a1bf8ef6b33cf18b98dba7c410e75c24bb3eef2f0d8d525"
+checksum = "ba7d1c19c4b6270e89d59fb27dc6d02a317c658a8a54e54781e1db9b5947595d"
 dependencies = [
  "drm-sys",
- "nix 0.26.2",
+ "nix 0.27.1",
 ]
 
 [[package]]
@@ -901,12 +935,9 @@ checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
 
 [[package]]
 name = "drm-sys"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1369f1679d6b706d234c4c1e0613c415c2c74b598a09ad28080ba2474b72e42d"
-dependencies = [
- "libc",
-]
+checksum = "3a4f1c0468062a56cd5705f1e3b5409eb286d5596a2028ec8e947595d7e715ae"
 
 [[package]]
 name = "ecolor"
@@ -1065,9 +1096,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1105,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.7.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
+checksum = "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8"
 dependencies = [
  "bit_field",
  "flume",
@@ -1136,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdeflate"
@@ -1151,13 +1182,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1172,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1194,6 +1225,15 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float_next_after"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fluent"
@@ -1241,14 +1281,10 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
  "spin",
 ]
 
@@ -1260,24 +1296,25 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fontconfig-parser"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab2e12762761366dcb876ab8b6e0cfa4797ddcd890575919f008b5ba655672a"
+checksum = "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4"
 dependencies = [
  "roxmltree 0.18.0",
 ]
 
 [[package]]
 name = "fontdb"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237ff9f0813bbfc9de836016472e0c9ae7802f174a51594607e5f4ff334cb2f5"
+checksum = "af8d8cbea8f21307d7e84bca254772981296f058a1d36b461bf4d83a7499fc9e"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.5.10",
+ "memmap2 0.6.2",
  "slotmap",
- "ttf-parser 0.18.1",
+ "tinyvec",
+ "ttf-parser 0.19.2",
 ]
 
 [[package]]
@@ -1296,6 +1333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fraction"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-icons"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e61ac115df4632b592d36b71fda3c259f4c8061c70b7fa429bac145890e880"
+checksum = "3f9d46a9ae065c46efb83854bb10315de6d333bb6f4526ebe320c004dab7857e"
 dependencies = [
  "dirs 4.0.0",
  "once_cell",
@@ -1384,7 +1430,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1419,16 +1465,16 @@ dependencies = [
 
 [[package]]
 name = "gbm"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ec389cda876966cf824111bf6e533fb934c711d473498279964a990853b3c6"
+checksum = "57c97c1672f2d951da311cd20b148794c4157a8879c7650e65f76c7826e2b1c1"
 dependencies = [
  "bitflags 1.3.2",
  "drm",
  "drm-fourcc",
  "gbm-sys",
  "libc",
- "wayland-backend",
+ "wayland-backend 0.3.2",
  "wayland-server",
 ]
 
@@ -1462,16 +1508,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1486,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gl_generator"
@@ -1503,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42218cb640844e3872cc3c153dc975229e080a6c4733b34709ef445610550226"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
 
 [[package]]
 name = "glow"
@@ -1533,8 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "glyphon"
-version = "0.2.0"
-source = "git+https://github.com/hecrj/glyphon.git?rev=26f92369da3704988e3e27f0b35e705c6b2de203#26f92369da3704988e3e27f0b35e705c6b2de203"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e87caa7459145f5e5f167bf34db4532901404c679e62339fb712a0e3ccf722a"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -1576,22 +1631,22 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
+checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "gpu-descriptor-types",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
+checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
 ]
 
 [[package]]
@@ -1624,18 +1679,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
  "ahash 0.8.3",
+ "allocator-api2",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hassle-rs"
@@ -1653,10 +1703,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
+name = "heck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hexf-parse"
@@ -1675,15 +1731,15 @@ dependencies = [
 
 [[package]]
 name = "i18n-config"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b987084cadad6e2f2b1e6ea62c44123591a3c044793a1beabf71a8356ea768d5"
+checksum = "0c9ce3c48cbc21fd5b22b9331f32b5b51f6ad85d969b99e793427332e76e7640"
 dependencies = [
  "log",
  "serde",
  "serde_derive",
  "thiserror",
- "toml 0.7.6",
+ "toml 0.8.1",
  "unic-langid",
 ]
 
@@ -1726,27 +1782,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.28",
+ "syn 2.0.37",
  "unic-langid",
 ]
 
 [[package]]
 name = "i18n-embed-impl"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a95d065e6be4499e50159172395559a388d20cf13c84c77e4a1e341786f219"
+checksum = "a2a4d5bff745c9a6e1459c490059281b353a4ab0a4e1e58b3eeeaef71f97d07b"
 dependencies = [
  "find-crate",
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "iced"
-version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.10.0"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1758,8 +1814,8 @@ dependencies = [
 
 [[package]]
 name = "iced_core"
-version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.10.0"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "bitflags 1.3.2",
  "instant",
@@ -1771,8 +1827,8 @@ dependencies = [
 
 [[package]]
 name = "iced_futures"
-version = "0.6.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.7.0"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "futures",
  "iced_core",
@@ -1783,37 +1839,39 @@ dependencies = [
 
 [[package]]
 name = "iced_graphics"
-version = "0.8.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.9.0"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
  "glam",
+ "half",
  "iced_core",
  "image",
  "kamadak-exif",
  "log",
+ "lyon_path",
  "raw-window-handle",
  "thiserror",
- "tiny-skia 0.9.1",
 ]
 
 [[package]]
 name = "iced_renderer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
  "iced_wgpu",
+ "log",
  "raw-window-handle",
  "thiserror",
 ]
 
 [[package]]
 name = "iced_runtime"
-version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.1.1"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1822,8 +1880,8 @@ dependencies = [
 
 [[package]]
 name = "iced_style"
-version = "0.8.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.9.0"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1833,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1841,17 +1899,17 @@ dependencies = [
  "kurbo 0.9.5",
  "log",
  "raw-window-handle",
- "resvg 0.32.0",
+ "resvg 0.35.0",
  "rustc-hash",
  "softbuffer",
- "tiny-skia 0.9.1",
+ "tiny-skia 0.10.0",
  "twox-hash",
 ]
 
 [[package]]
 name = "iced_wgpu"
-version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.11.1"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1861,9 +1919,10 @@ dependencies = [
  "guillotiere",
  "iced_graphics",
  "log",
+ "lyon",
  "once_cell",
  "raw-window-handle",
- "resvg 0.32.0",
+ "resvg 0.35.0",
  "rustc-hash",
  "twox-hash",
  "wgpu",
@@ -1871,14 +1930,14 @@ dependencies = [
 
 [[package]]
 name = "iced_widget"
-version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+version = "0.1.3"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
  "iced_style",
  "num-traits",
- "ouroboros 0.13.0",
+ "ouroboros",
  "thiserror",
  "unicode-segmentation",
 ]
@@ -1898,10 +1957,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "image"
-version = "0.24.6"
+name = "idna"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "image"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1924,9 +1993,9 @@ checksum = "df19da1e92fbfec043ca97d622955381b1f3ee72a180ec999912df31b1ccd951"
 
 [[package]]
 name = "imagesize"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "indexmap"
@@ -1941,12 +2010,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -1977,10 +2046,10 @@ checksum = "e6e74cd82cedcd66db78742a8337bdc48f188c4d2c12742cbc5cd85113f0b059"
 dependencies = [
  "bitflags 1.3.2",
  "input-sys",
- "io-lifetimes",
+ "io-lifetimes 1.0.11",
  "libc",
  "log",
- "udev",
+ "udev 0.7.0",
 ]
 
 [[package]]
@@ -2033,6 +2102,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb4def18c48926ccac55c1223e02865ce1a821751a95920448662696e7472c"
 
 [[package]]
 name = "itoa"
@@ -2111,9 +2186,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kqueue"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2121,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -2161,18 +2236,19 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=4895b0c#4895b0c9bda9e46fc7db173e239d155dac957186"
+source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
 dependencies = [
  "apply",
  "cosmic-config",
  "cosmic-theme",
+ "css-color",
  "derive_setters",
  "fraction",
  "freedesktop-icons",
@@ -2189,6 +2265,8 @@ dependencies = [
  "slotmap",
  "thiserror",
  "tracing",
+ "unicode-segmentation",
+ "url",
 ]
 
 [[package]]
@@ -2273,9 +2351,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "locale_config"
@@ -2302,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-panics"
@@ -2318,11 +2396,63 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.1",
+]
+
+[[package]]
+name = "lyon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7f9cda98b5430809e63ca5197b06c7d191bf7e26dfc467d5a3f0290e2a74f"
+dependencies = [
+ "lyon_algorithms",
+ "lyon_tessellation",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a0349cd8f0270781bb93a824b63df6178e3b4a27794e7be3ce3763f5a44d6e"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74df1ff0a0147282eb10699537a03baa7d31972b58984a1d44ce0624043fe8ad"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca507745ba7ccbc76e5c44e7b63b1a29d2b0d6126f375806a5bbaf657c7d6c45"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2124218d5428149f9e09520b9acc024334a607e671f032d06567b61008977c"
+dependencies = [
+ "float_next_after",
+ "lyon_path",
+ "thiserror",
 ]
 
 [[package]]
@@ -2351,15 +2481,24 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
 dependencies = [
  "libc",
 ]
@@ -2475,15 +2614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,16 +2688,27 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
- "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -2588,20 +2729,21 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.0.1"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2630,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2641,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -2740,7 +2882,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2810,9 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -2831,18 +2973,18 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221d488cd70617f1bd599ed8ceb659df2147d9393717954d82a0f5e8032a6ab1"
+checksum = "8378ac0dfbd4e7895f2d2c1f1345cab3836910baf3a300b000d04250f0c8428f"
 dependencies = [
  "redox_syscall 0.3.5",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "3.7.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
 dependencies = [
  "num-traits",
 ]
@@ -2859,49 +3001,26 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.13.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f357ef82d1b4db66fbed0b8d542cbd3c22d0bf5b393b3c257b9ba4568e70c9c3"
+checksum = "e2ba07320d39dfea882faa70554b4bd342a5f273ed59ba7c1c6b4c840492c954"
 dependencies = [
  "aliasable",
- "ouroboros_macro 0.13.0",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "ouroboros"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
-dependencies = [
- "aliasable",
- "ouroboros_macro 0.15.6",
+ "ouroboros_macro",
+ "static_assertions",
 ]
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.13.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a0b52c2cbaef7dffa5fec1a43274afe8bd2a644fa9fc50a9ef4ff0269b1257"
+checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
 dependencies = [
- "Inflector",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
-dependencies = [
- "Inflector",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2916,14 +3035,14 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
 dependencies = [
- "ttf-parser 0.19.1",
+ "ttf-parser 0.19.2",
 ]
 
 [[package]]
 name = "palette"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1641aee47803391405d0a1250e837d2336fdddd18b27f3ddb8c1d80ce8d7f43"
+checksum = "b2e2f34147767aa758aa649415b50a69eeb46a67f9dc7db8011eeb3d84b351dc"
 dependencies = [
  "approx 0.5.1",
  "fast-srgb8",
@@ -2934,13 +3053,13 @@ dependencies = [
 
 [[package]]
 name = "palette_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c02bfa6b3ba8af5434fa0531bf5701f750d983d4260acd6867faca51cdc4484"
+checksum = "b7db010ec5ff3d4385e4f133916faacd9dad0f6a09394c92d825b3aed310fa0a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2988,7 +3107,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3027,7 +3146,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3046,30 +3165,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
-name = "pin-project"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3085,15 +3184,29 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "png"
-version = "0.17.9"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
+checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7571075a670bb8e02350c4d1c27d934aabdce416aa91a95d58dc9e21267dad3c"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.14",
+ "tracing",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3109,7 +3222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -3138,30 +3251,30 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
+checksum = "f89dff0959d98c9758c88826cc002e2c3d0b9dfac4139711d1f30de442f1139b"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10adb8d151bb1280afb8bed41ae5db26be1b056964947133c7525b0bf39c0b0"
+checksum = "eb156a45b6b9fe8027497422179fb65afc84d36707a7ca98297bf06bccb8d43f"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3227,10 +3340,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.32"
+name = "quick-xml"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -3273,9 +3395,9 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "rangemap"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9283c6b06096b47afc7109834fdedab891175bb5241ee5d4f7d2546549f263"
+checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
 
 [[package]]
 name = "raw-window-handle"
@@ -3285,9 +3407,9 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -3295,14 +3417,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -3342,14 +3462,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.4",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.8",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -3363,13 +3483,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -3380,9 +3500,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "renderdoc"
@@ -3427,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142e83d8ae8c8c639f304698a5567b229ba65caba867bf4387bbc0ae158827cf"
+checksum = "b6554f47c38eca56827eea7f285c2a3018b4e12e0e195cc105833c008be338f1"
 dependencies = [
  "gif",
  "jpeg-decoder",
@@ -3437,10 +3557,9 @@ dependencies = [
  "pico-args",
  "png",
  "rgb",
- "svgfilters",
  "svgtypes 0.11.0",
- "tiny-skia 0.9.1",
- "usvg 0.32.0",
+ "tiny-skia 0.10.0",
+ "usvg 0.35.0",
 ]
 
 [[package]]
@@ -3465,26 +3584,14 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.4",
+ "bitflags 2.4.0",
  "serde",
-]
-
-[[package]]
-name = "rosvgtree"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad747e7384940e7bf33b15ba433b7bad9f44c0c6d5287a67c2cb22cd1743d497"
-dependencies = [
- "log",
- "roxmltree 0.18.0",
- "simplecss",
- "siphasher",
- "svgtypes 0.11.0",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3525,7 +3632,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.28",
+ "syn 2.0.37",
  "walkdir",
 ]
 
@@ -3563,13 +3670,13 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "4279d76516df406a8bd37e7dff53fd37d1a093f997a3c34a5c21658c126db06d"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 1.0.11",
  "libc",
  "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
@@ -3577,14 +3684,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.7",
  "windows-sys 0.48.0",
 ]
 
@@ -3596,9 +3703,25 @@ checksum = "162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
- "libm",
  "smallvec",
  "ttf-parser 0.18.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-general-category",
+ "unicode-script",
+]
+
+[[package]]
+name = "rustybuzz"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82eea22c8f56965eeaf3a209b3d24508256c7b920fb3b6211b8ba0f7c0583250"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser 0.19.2",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-general-category",
@@ -3655,29 +3778,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.179"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.179"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -3695,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3706,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
 dependencies = [
  "lazy_static",
 ]
@@ -3730,15 +3853,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -3754,19 +3877,19 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=d3e1ef9#d3e1ef9584cb3eadec80e8961552447cb919d6aa"
+source = "git+https://github.com/smithay//smithay?rev=74ef59a3f#74ef59a3f8b6a1f86a74388590f2f852040354e4"
 dependencies = [
  "appendlist",
  "ash",
- "bitflags 2.3.3",
- "calloop",
+ "bitflags 2.4.0",
+ "calloop 0.12.2",
  "cc",
  "cgmath",
  "downcast-rs",
@@ -3777,13 +3900,13 @@ dependencies = [
  "gbm",
  "gl_generator",
  "glow 0.12.3",
- "indexmap 1.9.3",
+ "indexmap 2.0.1",
  "input",
  "lazy_static",
  "libc",
  "libloading 0.8.0",
  "libseat",
- "nix 0.26.2",
+ "nix 0.27.1",
  "once_cell",
  "pkg-config",
  "profiling",
@@ -3794,27 +3917,27 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "udev",
- "wayland-backend",
+ "udev 0.8.0",
+ "wayland-backend 0.3.2",
  "wayland-egl",
- "wayland-protocols 0.30.1",
+ "wayland-protocols 0.31.0",
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-server",
- "wayland-sys 0.30.1",
+ "wayland-sys 0.31.1",
  "winit",
- "x11rb",
- "xkbcommon 0.5.1",
+ "x11rb 0.12.0",
+ "xkbcommon",
 ]
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
+checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
 dependencies = [
  "bitflags 1.3.2",
- "calloop",
+ "calloop 0.10.6",
  "dlib",
  "lazy_static",
  "log",
@@ -3829,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "smithay-egui"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay-egui.git?rev=dab5c1b#dab5c1b4323e35389500996a8119906b54f63fda"
+source = "git+https://github.com/Smithay/smithay-egui.git?rev=114d8db6#114d8db655094f89a3e9821dcc74bd8eb2e26406"
 dependencies = [
  "cgmath",
  "egui",
@@ -3839,7 +3962,7 @@ dependencies = [
  "log",
  "memoffset 0.9.0",
  "smithay",
- "xkbcommon 0.5.1",
+ "xkbcommon",
 ]
 
 [[package]]
@@ -3860,19 +3983,19 @@ dependencies = [
  "fastrand 1.9.0",
  "foreign-types",
  "log",
- "nix 0.26.2",
+ "nix 0.26.4",
  "objc",
  "raw-window-handle",
  "redox_syscall 0.3.5",
  "thiserror",
  "wasm-bindgen",
- "wayland-backend",
+ "wayland-backend 0.1.2",
  "wayland-client 0.30.2",
  "wayland-sys 0.30.1",
  "web-sys",
  "windows-sys 0.42.0",
  "x11-dl",
- "x11rb",
+ "x11rb 0.11.1",
 ]
 
 [[package]]
@@ -3893,12 +4016,6 @@ dependencies = [
  "bitflags 1.3.2",
  "num-traits",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3932,16 +4049,6 @@ name = "svg_fmt"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
-
-[[package]]
-name = "svgfilters"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce"
-dependencies = [
- "float-cmp 0.9.0",
- "rgb",
-]
 
 [[package]]
 name = "svgtypes"
@@ -3985,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3996,54 +4103,53 @@ dependencies = [
 
 [[package]]
 name = "sys-locale"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b9eefabb91675082b41eb94c3ecd91af7656caee3fb4961a07c0ec8c7ca6f"
+checksum = "e801cf239ecd6ccd71f03d270d67dd53d13e90aab208bf4b8fe4ad957ea949b0"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
+ "fastrand 2.0.1",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.14",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4058,9 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
+checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -4069,9 +4175,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.24"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa",
@@ -4082,15 +4188,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -4111,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2986c82f77818c7b9144c70818fdde98db15308e329ae2f7204d767808fd3c"
+checksum = "7db11798945fa5c3e5490c794ccca7c6de86d3afdd54b4eb324109939c6f37bc"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -4121,7 +4227,7 @@ dependencies = [
  "cfg-if",
  "log",
  "png",
- "tiny-skia-path 0.9.0",
+ "tiny-skia-path 0.10.0",
 ]
 
 [[package]]
@@ -4137,9 +4243,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7acb0ccda1ac91084353a56d0b69b0e29c311fd809d2088b1ed2f9ae1841c47"
+checksum = "2f60aa35c89ac2687ace1a2556eaaea68e8c0d47408a2e3e7f5c98a489e7281c"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -4148,12 +4254,27 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac3f5b6856e931e15e07b478e98c8045239829a65f9156d4fa7e7788197a5ef"
+checksum = "b07bb54ef1f8ff27564b08b861144d3b8d40263efe07684f64987f4c0d044e3e"
 dependencies = [
  "displaydoc",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -4166,14 +4287,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "1bc1433177506450fe920e46a4f9812d0c211f5dd556da10e731a0a3dfa151f0"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.1",
 ]
 
 [[package]]
@@ -4187,11 +4308,22 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca676d9ba1a322c1b64eb8045a5ec5c0cfb0c9d08e15e9ff622589ad5221c8fe"
+dependencies = [
+ "indexmap 2.0.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4218,7 +4350,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4279,9 +4411,9 @@ checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
+checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
 
 [[package]]
 name = "twox-hash"
@@ -4305,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udev"
@@ -4315,6 +4447,18 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a"
 dependencies = [
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "udev"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50051c6e22be28ee6f217d50014f3bc29e81c20dc66ff7ca0d5c5226e1dcc5a1"
+dependencies = [
+ "io-lifetimes 1.0.11",
  "libc",
  "libudev-sys",
  "pkg-config",
@@ -4365,15 +4509,24 @@ checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-script"
@@ -4395,15 +4548,26 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "usvg"
@@ -4427,11 +4591,11 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b44e14b7678bcc5947b397991432d0c4e02a103958a0ed5e1b9b961ddd08b21"
+checksum = "14d09ddfb0d93bf84824c09336d32e42f80961a9d1680832eb24fdf249ce11e6"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
  "log",
  "pico-args",
  "usvg-parser",
@@ -4442,31 +4606,32 @@ dependencies = [
 
 [[package]]
 name = "usvg-parser"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c8251d965c2882a636ffcc054340b1f13a6bce68779cb5b2084d8ffc2535be"
+checksum = "d19bf93d230813599927d88557014e0908ecc3531666d47c634c6838bc8db408"
 dependencies = [
  "data-url",
  "flate2",
- "imagesize 0.11.0",
+ "imagesize 0.12.0",
  "kurbo 0.9.5",
  "log",
- "rosvgtree",
- "strict-num",
+ "roxmltree 0.18.0",
+ "simplecss",
+ "siphasher",
  "svgtypes 0.11.0",
  "usvg-tree",
 ]
 
 [[package]]
 name = "usvg-text-layout"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fed019d1af07bfe0f3bac13d120d7b51bc65b38cb24809cf4ed0b8b631138"
+checksum = "035044604e89652c0a2959b8b356946997a52649ba6cade45928c2842376feb4"
 dependencies = [
  "fontdb",
  "kurbo 0.9.5",
  "log",
- "rustybuzz",
+ "rustybuzz 0.7.0",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -4475,14 +4640,14 @@ dependencies = [
 
 [[package]]
 name = "usvg-tree"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7371265c467cdae0ccc3655e2e3f310c695fb9f717c0d25187bf3b333f7b5159"
+checksum = "7939a7e4ed21cadb5d311d6339730681c3e24c3e81d60065be80e485d3fc8b92"
 dependencies = [
- "kurbo 0.9.5",
  "rctree",
  "strict-num",
  "svgtypes 0.11.0",
+ "tiny-skia-path 0.10.0",
 ]
 
 [[package]]
@@ -4520,9 +4685,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4555,7 +4720,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -4589,7 +4754,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4623,11 +4788,25 @@ checksum = "41b48e27457e8da3b2260ac60d0a94512f5cba36448679f3747c0865b7893ed8"
 dependencies = [
  "cc",
  "downcast-rs",
- "io-lifetimes",
- "nix 0.26.2",
+ "io-lifetimes 1.0.11",
+ "nix 0.26.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys 0.30.1",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19152ddd73f45f024ed4534d9ca2594e0ef252c1847695255dae47f34df9fbe4"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "nix 0.26.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys 0.31.1",
 ]
 
 [[package]]
@@ -4653,8 +4832,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489c9654770f674fc7e266b3c579f4053d7551df0ceb392f153adb1f9ed06ac8"
 dependencies = [
  "bitflags 1.3.2",
- "nix 0.26.2",
- "wayland-backend",
+ "nix 0.26.4",
+ "wayland-backend 0.1.2",
  "wayland-scanner 0.30.1",
 ]
 
@@ -4683,12 +4862,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-egl"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1187695fe81c3153c3163f9d2953149f638c5d7dbc6fe988914ca3f4961e28ed"
+checksum = "355f652e5a24ae02d2ad536c8fc2d3dcc6c2bd635027cd6103a193e7d75eeda2"
 dependencies = [
- "wayland-backend",
- "wayland-sys 0.30.1",
+ "wayland-backend 0.3.2",
+ "wayland-sys 0.31.1",
 ]
 
 [[package]]
@@ -4705,39 +4884,39 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b28101e5ca94f70461a6c2d610f76d85ad223d042dd76585ab23d3422dd9b4d"
+checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
 dependencies = [
- "bitflags 1.3.2",
- "wayland-backend",
- "wayland-scanner 0.30.1",
+ "bitflags 2.4.0",
+ "wayland-backend 0.3.2",
+ "wayland-scanner 0.31.0",
  "wayland-server",
 ]
 
 [[package]]
 name = "wayland-protocols-misc"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897d4e99645e1ed9245e9e6b5efa78828d2b23b661016d63d55251243d812f8b"
+checksum = "bfa5933740b200188c9b4c38601b8212e8c154d7de0d2cb171944e137a77de1e"
 dependencies = [
- "bitflags 1.3.2",
- "wayland-backend",
- "wayland-protocols 0.30.1",
- "wayland-scanner 0.30.1",
+ "bitflags 2.4.0",
+ "wayland-backend 0.3.2",
+ "wayland-protocols 0.31.0",
+ "wayland-scanner 0.31.0",
  "wayland-server",
 ]
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce991093320e4a6a525876e6b629ab24da25f9baef0c2e0080ad173ec89588a"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 1.3.2",
- "wayland-backend",
- "wayland-protocols 0.30.1",
- "wayland-scanner 0.30.1",
+ "bitflags 2.4.0",
+ "wayland-backend 0.3.2",
+ "wayland-protocols 0.31.0",
+ "wayland-scanner 0.31.0",
  "wayland-server",
 ]
 
@@ -4759,22 +4938,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b873b257fbc32ec909c0eb80dea312076a67014e65e245f5eb69a6b8ab330e"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.28.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.30.0",
  "quote",
 ]
 
 [[package]]
 name = "wayland-server"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c43c28096fe1d49fff7d1079404fdd0f669cd1a5b00c615bdfe71bb1884d23a"
+checksum = "3f3f0c52a445936ca1184c98f1a69cf4ad9c9130788884531ef04428468cb1ce"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "downcast-rs",
- "io-lifetimes",
- "nix 0.26.2",
- "wayland-backend",
- "wayland-scanner 0.30.1",
+ "io-lifetimes 2.0.2",
+ "nix 0.26.4",
+ "wayland-backend 0.3.2",
+ "wayland-scanner 0.31.0",
 ]
 
 [[package]]
@@ -4796,9 +4986,20 @@ checksum = "96b2a02ac608e07132978689a6f9bf4214949c85998c247abadd4f4129b1aa06"
 dependencies = [
  "dlib",
  "lazy_static",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+dependencies = [
+ "dlib",
  "libc",
  "log",
- "memoffset 0.7.1",
+ "memoffset 0.9.0",
  "pkg-config",
 ]
 
@@ -4850,7 +5051,7 @@ checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "codespan-reporting",
  "log",
  "naga",
@@ -4875,7 +5076,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "block",
  "core-graphics-types",
  "d3d12",
@@ -4913,7 +5114,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "js-sys",
  "web-sys",
 ]
@@ -4942,9 +5143,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -5003,7 +5204,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5023,17 +5224,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5044,9 +5245,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5056,9 +5257,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5068,9 +5269,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5080,9 +5281,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5092,9 +5293,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5104,9 +5305,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5116,15 +5317,15 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winit"
-version = "0.28.6"
+version = "0.28.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
+checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
  "android-activity",
  "bitflags 1.3.2",
@@ -5156,9 +5357,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.2"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd122eb777186e60c3fdf765a58ac76e41c582f1f535fbf3314434c6b58f3f7"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]
@@ -5189,14 +5390,27 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf3c79412dd91bae7a7366b8ad1565a85e35dd049affc3a6a2c549e97419617"
 dependencies = [
- "gethostname",
+ "gethostname 0.2.3",
  "libc",
  "libloading 0.7.4",
  "nix 0.25.1",
  "once_cell",
  "winapi",
  "winapi-wsapoll",
- "x11rb-protocol",
+ "x11rb-protocol 0.11.1",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
+dependencies = [
+ "gethostname 0.3.0",
+ "nix 0.26.4",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol 0.12.0",
 ]
 
 [[package]]
@@ -5206,6 +5420,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1513b141123073ce54d5bb1d33f801f17508fbd61e02060b1214e96d39c56"
 dependencies = [
  "nix 0.25.1",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
+dependencies = [
+ "nix 0.26.4",
 ]
 
 [[package]]
@@ -5225,28 +5448,26 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xkbcommon"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032ed00cc755c31221bbd6aaf9fa4196a01bf33bca185f9316e14f26d28c28cf"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "xkbcommon"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52db25b599e92bf6e3904134618728eeb7b49a5a4f38f107f92399bb9c496b88"
+checksum = "c286371c44b3572d19b09196c129a8fff47d7704d6494daefb44fec10f0278ab"
 dependencies = [
  "libc",
  "memmap2 0.7.1",
+ "xkeysym",
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.16"
+name = "xkeysym"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
+checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "xmlparser"
@@ -5268,9 +5489,9 @@ checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
 
 [[package]]
 name = "zeno"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c110ba09c9b3a43edd4803d570df0da2414fed6e822e22b976a4e3ef50860701"
+checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905"
+checksum = "76f2bfe491d41d45507b8431da8274f7feeca64a49e86d980eed2937ec2ff020"
 
 [[package]]
 name = "atomicwrites"
@@ -372,7 +372,7 @@ dependencies = [
  "bitflags 2.4.0",
  "log",
  "polling",
- "rustix 0.38.14",
+ "rustix 0.38.15",
  "slab",
  "thiserror",
 ]
@@ -528,7 +528,7 @@ dependencies = [
  "i18n-embed-fl",
  "iced_tiny_skia",
  "id_tree",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "keyframe",
  "lazy_static",
  "libcosmic",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "atomicwrites",
  "calloop 0.12.2",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -889,7 +889,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.0",
+ "libloading 0.8.1",
 ]
 
 [[package]]
@@ -1096,9 +1096,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.71.0"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8"
+checksum = "279d3efcc55e19917fff7ab3ddd6c14afb6a90881a0078465196fe2f99d08c56"
 dependencies = [
  "bit_field",
  "flume",
@@ -1281,10 +1281,14 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
  "spin",
 ]
 
@@ -1300,7 +1304,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4"
 dependencies = [
- "roxmltree 0.18.0",
+ "roxmltree 0.18.1",
 ]
 
 [[package]]
@@ -1524,8 +1528,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1650,6 +1656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "grid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df00eed8d1f0db937f6be10e46e8072b0671accb504cf0f959c5c52c679f5b9"
+
+[[package]]
 name = "guillotiere"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,10 +1673,11 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
 dependencies = [
+ "cfg-if",
  "crunchy",
 ]
 
@@ -1802,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1815,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.10.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "bitflags 1.3.2",
  "instant",
@@ -1828,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.7.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "futures",
  "iced_core",
@@ -1840,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1858,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1871,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.1.1"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1881,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.9.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1891,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1909,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.11.1"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1931,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.1.3"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -2010,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
@@ -2243,7 +2256,7 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/?rev=188b7c2b#188b7c2bbc35d0e9f1e218f52c1dc9cf89490744"
+source = "git+https://github.com/pop-os/libcosmic/?rev=f91287d#f91287dec2297df41a339c1106850c4cf179f67f"
 dependencies = [
  "apply",
  "cosmic-config",
@@ -2263,6 +2276,7 @@ dependencies = [
  "lazy_static",
  "palette",
  "slotmap",
+ "taffy",
  "thiserror",
  "tracing",
  "unicode-segmentation",
@@ -2281,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -2351,9 +2365,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "locale_config"
@@ -2481,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
@@ -2611,6 +2625,15 @@ dependencies = [
  "termcolor",
  "thiserror",
  "unicode-xid",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -3165,6 +3188,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pin-project"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,14 +3240,14 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7571075a670bb8e02350c4d1c27d934aabdce416aa91a95d58dc9e21267dad3c"
+checksum = "62a79e457c9898100b4298d57d69ec53d06f9a6ed352431ce5f377e082d2e846"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.14",
+ "rustix 0.38.15",
  "tracing",
  "windows-sys 0.48.0",
 ]
@@ -3462,13 +3505,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
+ "regex-automata 0.3.9",
  "regex-syntax 0.7.5",
 ]
 
@@ -3483,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3605,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8"
+checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
 dependencies = [
  "xmlparser",
 ]
@@ -3684,14 +3727,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.7",
+ "linux-raw-sys 0.4.8",
  "windows-sys 0.48.0",
 ]
 
@@ -3900,11 +3943,11 @@ dependencies = [
  "gbm",
  "gl_generator",
  "glow 0.12.3",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "input",
  "lazy_static",
  "libc",
- "libloading 0.8.0",
+ "libloading 0.8.1",
  "libseat",
  "nix 0.27.1",
  "once_cell",
@@ -4111,6 +4154,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "taffy"
+version = "0.3.11"
+source = "git+https://github.com/DioxusLabs/taffy#65bedf128ec8cef40c1a21b6f141f2c771842cca"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "num-traits",
+ "slotmap",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4119,7 +4173,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall 0.3.5",
- "rustix 0.38.14",
+ "rustix 0.38.15",
  "windows-sys 0.48.0",
 ]
 
@@ -4312,7 +4366,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "toml_datetime",
  "winnow",
 ]
@@ -4323,7 +4377,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca676d9ba1a322c1b64eb8045a5ec5c0cfb0c9d08e15e9ff622589ad5221c8fe"
 dependencies = [
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4615,7 +4669,7 @@ dependencies = [
  "imagesize 0.12.0",
  "kurbo 0.9.5",
  "log",
- "roxmltree 0.18.0",
+ "roxmltree 0.18.1",
  "simplecss",
  "siphasher",
  "svgtypes 0.11.0",
@@ -5089,7 +5143,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.0",
+ "libloading 0.8.1",
  "log",
  "metal",
  "naga",
@@ -5471,9 +5525,9 @@ checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "xmlparser"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ libsystemd = { version = "0.5", optional = true }
 wayland-backend = "0.3.0"
 wayland-scanner = "0.31.0"
 cosmic-comp-config = { path = "cosmic-comp-config" }
-cosmic-config = { git = "https://github.com/pop-os/libcosmic/", rev = "188b7c2b", features = ["calloop"] }
+cosmic-config = { git = "https://github.com/pop-os/libcosmic/", rev = "f91287d", features = ["calloop"] }
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"] }
-libcosmic = { git = "https://github.com/pop-os/libcosmic/", rev = "188b7c2b", default-features = false }
-iced_tiny_skia = { git = "https://github.com/pop-os/libcosmic/", rev = "188b7c2b" }
+libcosmic = { git = "https://github.com/pop-os/libcosmic/", rev = "f91287d", default-features = false }
+iced_tiny_skia = { git = "https://github.com/pop-os/libcosmic/", rev = "f91287d" }
 tiny-skia = "0.10"
 ordered-float = "3.0"
 glow = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ members = [
 ]
 
 [dependencies]
-apply = "0.3.0"
 anyhow = { version = "1.0.51", features = ["backtrace"] }
-bitflags = "1.3.2"
+bitflags = "2.4"
 bytemuck = "1.12"
-calloop = { version = "0.10.1", features = ["executor"] }
+calloop = { version = "0.12.2", features = ["executor"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sendfd = "0.4.1"
@@ -28,19 +27,19 @@ log-panics = { version = "2", features = ["with-backtrace"] }
 thiserror = "1.0.26"
 regex = "1"
 xcursor = "0.3.3"
-xkbcommon = "0.4"
-indexmap = "1.8.0"
+xkbcommon = "0.6"
+indexmap = "2.0"
 xdg = "^2.1"
 ron = "0.7"
 libsystemd = { version = "0.5", optional = true }
-wayland-backend = "0.1.0"
-wayland-scanner = "0.30.0"
+wayland-backend = "0.3.0"
+wayland-scanner = "0.31.0"
 cosmic-comp-config = { path = "cosmic-comp-config" }
-cosmic-config = { git = "https://github.com/pop-os/libcosmic/", rev = "4895b0c", features = ["calloop"] }
+cosmic-config = { git = "https://github.com/pop-os/libcosmic/", rev = "188b7c2b", features = ["calloop"] }
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"] }
-libcosmic = { git = "https://github.com/pop-os/libcosmic/", rev = "4895b0c", default-features = false }
-iced_tiny_skia = { git = "https://github.com/pop-os/libcosmic/", rev = "4895b0c" }
-tiny-skia = "0.9"
+libcosmic = { git = "https://github.com/pop-os/libcosmic/", rev = "188b7c2b", default-features = false }
+iced_tiny_skia = { git = "https://github.com/pop-os/libcosmic/", rev = "188b7c2b" }
+tiny-skia = "0.10"
 ordered-float = "3.0"
 glow = "0.11.2"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "tracing-log"] }
@@ -61,13 +60,13 @@ branch = "feature/copy_clone"
 [dependencies.smithay]
 version = "0.3"
 git = "https://github.com/smithay/smithay.git"
-rev = "58d5bdc"
+rev = "74ef59a3f"
 default-features = false
 features = ["backend_drm", "backend_gbm", "backend_egl", "backend_libinput", "backend_session_libseat", "backend_udev", "backend_winit", "backend_vulkan", "backend_x11", "desktop", "use_system_lib", "renderer_glow", "renderer_multi", "wayland_frontend", "xwayland"]
 
 [dependencies.smithay-egui]
 git = "https://github.com/Smithay/smithay-egui.git"
-rev = "dab5c1b"
+rev = "114d8db6"
 features = ["svg"]
 optional = true
 
@@ -87,4 +86,4 @@ debug = true
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "d3e1ef9" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "74ef59a3f" }

--- a/src/backend/kms/socket.rs
+++ b/src/backend/kms/socket.rs
@@ -19,10 +19,7 @@ use smithay::{
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use crate::{
-    state::{ClientState, Data},
-    utils::prelude::*,
-};
+use crate::state::{ClientState, State};
 
 #[derive(Debug)]
 pub struct Socket {
@@ -96,10 +93,10 @@ impl State {
         let token = self
             .common
             .event_loop_handle
-            .insert_source(listener, move |client_stream, _, data: &mut Data| {
-                if let Err(err) = data.display.handle().insert_client(
+            .insert_source(listener, move |client_stream, _, state: &mut State| {
+                if let Err(err) = state.common.display_handle.insert_client(
                     client_stream,
-                    Arc::new(data.state.new_client_state_with_node(render_node)),
+                    Arc::new(state.new_client_state_with_node(render_node)),
                 ) {
                     warn!(
                         socket_name = socket_name_clone,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::state::{Data, State};
+use crate::state::State;
 use anyhow::{Context, Result};
 use smithay::reexports::{calloop::EventLoop, wayland_server::DisplayHandle};
 use tracing::{info, warn};
@@ -15,7 +15,7 @@ pub mod x11;
 
 pub fn init_backend_auto(
     dh: &DisplayHandle,
-    event_loop: &mut EventLoop<'static, Data>,
+    event_loop: &mut EventLoop<'static, State>,
     state: &mut State,
 ) -> Result<()> {
     let res = match std::env::var("COSMIC_BACKEND") {

--- a/src/config/key_bindings.rs
+++ b/src/config/key_bindings.rs
@@ -4,7 +4,7 @@ use crate::shell::{focus::FocusDirection, grabs::ResizeEdge, Direction, ResizeDi
 use serde::Deserialize;
 use smithay::{
     backend::input::KeyState,
-    input::keyboard::{keysyms as KeySyms, xkb::keysym_get_name, ModifiersState},
+    input::keyboard::{xkb::keysym_get_name, ModifiersState},
 };
 use std::collections::HashMap;
 
@@ -90,11 +90,11 @@ pub struct KeyPattern {
     pub modifiers: KeyModifiers,
     /// The actual key, that was pressed
     #[serde(deserialize_with = "deserialize_Keysym", default)]
-    pub key: Option<u32>,
+    pub key: Option<Keysym>,
 }
 
 impl KeyPattern {
-    pub fn new(modifiers: impl Into<KeyModifiers>, key: Option<u32>) -> KeyPattern {
+    pub fn new(modifiers: impl Into<KeyModifiers>, key: Option<Keysym>) -> KeyPattern {
         KeyPattern {
             modifiers: modifiers.into(),
             key,
@@ -174,7 +174,7 @@ pub enum Action {
 fn insert_binding(
     key_bindings: &mut HashMap<KeyPattern, Action>,
     modifiers: KeyModifiers,
-    keys: impl Iterator<Item = u32>,
+    keys: impl Iterator<Item = Keysym>,
     action: Action,
 ) {
     if !key_bindings.values().any(|a| a == &action) {
@@ -197,16 +197,16 @@ pub fn add_default_bindings(
     let (workspace_previous, workspace_next, output_previous, output_next) = match workspace_layout
     {
         WorkspaceLayout::Horizontal => (
-            [KeySyms::KEY_Left, KeySyms::KEY_h],
-            [KeySyms::KEY_Right, KeySyms::KEY_l],
-            [KeySyms::KEY_Up, KeySyms::KEY_k],
-            [KeySyms::KEY_Down, KeySyms::KEY_j],
+            [Keysym::Left, Keysym::h],
+            [Keysym::Right, Keysym::l],
+            [Keysym::Up, Keysym::k],
+            [Keysym::Down, Keysym::j],
         ),
         WorkspaceLayout::Vertical => (
-            [KeySyms::KEY_Up, KeySyms::KEY_k],
-            [KeySyms::KEY_Down, KeySyms::KEY_j],
-            [KeySyms::KEY_Left, KeySyms::KEY_h],
-            [KeySyms::KEY_Right, KeySyms::KEY_l],
+            [Keysym::Up, Keysym::k],
+            [Keysym::Down, Keysym::j],
+            [Keysym::Left, Keysym::h],
+            [Keysym::Right, Keysym::l],
         ),
     };
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     shell::{Shell, WorkspaceAmount},
-    state::{BackendData, Data, State},
+    state::{BackendData, State},
     wayland::protocols::output_configuration::OutputConfigurationState,
 };
 use cosmic_config::ConfigGet;
@@ -158,12 +158,12 @@ impl OutputConfig {
 }
 
 impl Config {
-    pub fn load(loop_handle: &LoopHandle<'_, Data>) -> Config {
+    pub fn load(loop_handle: &LoopHandle<'_, State>) -> Config {
         let config = cosmic_config::Config::new("com.system76.CosmicComp", 1).unwrap();
         let source = cosmic_config::calloop::ConfigWatchSource::new(&config).unwrap();
         loop_handle
-            .insert_source(source, |(config, keys), (), shared_data| {
-                config_changed(config, keys, &mut shared_data.state);
+            .insert_source(source, |(config, keys), (), state| {
+                config_changed(config, keys, state);
             })
             .expect("Failed to add cosmic-config to the event loop");
         let xdg = xdg::BaseDirectories::new().ok();
@@ -260,7 +260,7 @@ impl Config {
         backend: &mut BackendData,
         shell: &mut Shell,
         seats: impl Iterator<Item = Seat<State>>,
-        loop_handle: &LoopHandle<'_, Data>,
+        loop_handle: &LoopHandle<'_, State>,
     ) {
         let seats = seats.collect::<Vec<_>>();
         let outputs = output_state.outputs().collect::<Vec<_>>();

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -539,7 +539,7 @@ impl CosmicMapped {
         self.element = CosmicMappedInternal::Window(window);
     }
 
-    pub(super) fn loop_handle(&self) -> LoopHandle<'static, crate::state::Data> {
+    pub(super) fn loop_handle(&self) -> LoopHandle<'static, crate::state::State> {
         match &self.element {
             CosmicMappedInternal::Stack(stack) => stack.loop_handle(),
             CosmicMappedInternal::Window(window) => window.loop_handle(),

--- a/src/shell/element/resize_indicator.rs
+++ b/src/shell/element/resize_indicator.rs
@@ -22,7 +22,7 @@ pub type ResizeIndicator = IcedElement<ResizeIndicatorInternal>;
 pub fn resize_indicator(
     direction: ResizeDirection,
     config: &Config,
-    evlh: LoopHandle<'static, crate::state::Data>,
+    evlh: LoopHandle<'static, crate::state::State>,
 ) -> ResizeIndicator {
     ResizeIndicator::new(
         ResizeIndicatorInternal {

--- a/src/shell/element/resize_indicator.rs
+++ b/src/shell/element/resize_indicator.rs
@@ -7,13 +7,13 @@ use crate::{
     utils::iced::{IcedElement, Program},
 };
 
-use apply::Apply;
 use calloop::LoopHandle;
 use cosmic::{
     iced::widget::{column, container, horizontal_space, row, vertical_space},
     iced_core::{Background, Color, Length},
     theme,
-    widget::{icon, text},
+    widget::{icon::from_name, text},
+    Apply,
 };
 use smithay::utils::Size;
 
@@ -64,26 +64,29 @@ impl Program for ResizeIndicatorInternal {
 
     fn view(&self) -> crate::utils::iced::Element<'_, Self::Message> {
         let edges = self.edges.lock().unwrap();
+        let icon_container_style = || {
+            theme::Container::custom(|theme| container::Appearance {
+                icon_color: Some(Color::from(theme.cosmic().accent.on)),
+                text_color: Some(Color::from(theme.cosmic().accent.on)),
+                background: Some(Background::Color(theme.cosmic().accent_color().into())),
+                border_radius: 18.0.into(),
+                border_width: 0.0,
+                border_color: Color::TRANSPARENT,
+            })
+        };
+
         column(vec![
             if edges.contains(ResizeEdge::TOP) {
-                icon(
-                    if self.direction == ResizeDirection::Outwards {
-                        "go-up-symbolic"
-                    } else {
-                        "go-down-symbolic"
-                    },
-                    32,
-                )
-                .force_svg(true)
+                from_name(if self.direction == ResizeDirection::Outwards {
+                    "go-up-symbolic"
+                } else {
+                    "go-down-symbolic"
+                })
+                .size(32)
+                .prefer_svg(true)
                 .apply(container)
                 .padding(2)
-                .style(theme::Container::custom(|theme| container::Appearance {
-                    text_color: Some(Color::from(theme.cosmic().accent.on)),
-                    background: Some(Background::Color(theme.cosmic().accent_color().into())),
-                    border_radius: 18.0.into(),
-                    border_width: 0.0,
-                    border_color: Color::TRANSPARENT,
-                }))
+                .style(icon_container_style())
                 .width(Length::Shrink)
                 .apply(container)
                 .center_x()
@@ -94,24 +97,16 @@ impl Program for ResizeIndicatorInternal {
             },
             row(vec![
                 if edges.contains(ResizeEdge::LEFT) {
-                    icon(
-                        if self.direction == ResizeDirection::Outwards {
-                            "go-previous-symbolic"
-                        } else {
-                            "go-next-symbolic"
-                        },
-                        32,
-                    )
-                    .force_svg(true)
+                    from_name(if self.direction == ResizeDirection::Outwards {
+                        "go-previous-symbolic"
+                    } else {
+                        "go-next-symbolic"
+                    })
+                    .size(32)
+                    .prefer_svg(true)
                     .apply(container)
                     .padding(4)
-                    .style(theme::Container::custom(|theme| container::Appearance {
-                        text_color: Some(Color::from(theme.cosmic().accent.on)),
-                        background: Some(Background::Color(theme.cosmic().accent_color().into())),
-                        border_radius: 18.0.into(),
-                        border_width: 0.0,
-                        border_color: Color::TRANSPARENT,
-                    }))
+                    .style(icon_container_style())
                     .width(Length::Shrink)
                     .apply(container)
                     .center_y()
@@ -144,13 +139,7 @@ impl Program for ResizeIndicatorInternal {
                 .center_y()
                 .padding(16)
                 .apply(container)
-                .style(theme::Container::custom(|theme| container::Appearance {
-                    text_color: Some(Color::from(theme.cosmic().accent.on)),
-                    background: Some(Background::Color(theme.cosmic().accent_color().into())),
-                    border_radius: 18.0.into(),
-                    border_width: 0.0,
-                    border_color: Color::TRANSPARENT,
-                }))
+                .style(icon_container_style())
                 .width(Length::Shrink)
                 .height(Length::Shrink)
                 .apply(container)
@@ -160,24 +149,16 @@ impl Program for ResizeIndicatorInternal {
                 .center_y()
                 .into(),
                 if edges.contains(ResizeEdge::RIGHT) {
-                    icon(
-                        if self.direction == ResizeDirection::Outwards {
-                            "go-next-symbolic"
-                        } else {
-                            "go-previous-symbolic"
-                        },
-                        32,
-                    )
-                    .force_svg(true)
+                    from_name(if self.direction == ResizeDirection::Outwards {
+                        "go-next-symbolic"
+                    } else {
+                        "go-previous-symbolic"
+                    })
+                    .size(32)
+                    .prefer_svg(true)
                     .apply(container)
                     .padding(4)
-                    .style(theme::Container::custom(|theme| container::Appearance {
-                        text_color: Some(Color::from(theme.cosmic().accent.on)),
-                        background: Some(Background::Color(theme.cosmic().accent_color().into())),
-                        border_radius: 18.0.into(),
-                        border_width: 0.0,
-                        border_color: Color::TRANSPARENT,
-                    }))
+                    .style(icon_container_style())
                     .height(Length::Shrink)
                     .apply(container)
                     .center_y()
@@ -191,24 +172,16 @@ impl Program for ResizeIndicatorInternal {
             .height(Length::Fill)
             .into(),
             if edges.contains(ResizeEdge::BOTTOM) {
-                icon(
-                    if self.direction == ResizeDirection::Outwards {
-                        "go-down-symbolic"
-                    } else {
-                        "go-up-symbolic"
-                    },
-                    32,
-                )
-                .force_svg(true)
+                from_name(if self.direction == ResizeDirection::Outwards {
+                    "go-down-symbolic"
+                } else {
+                    "go-up-symbolic"
+                })
+                .size(32)
+                .prefer_svg(true)
                 .apply(container)
                 .padding(4)
-                .style(theme::Container::custom(|theme| container::Appearance {
-                    text_color: Some(Color::from(theme.cosmic().accent.on)),
-                    background: Some(Background::Color(theme.cosmic().accent_color().into())),
-                    border_radius: 18.0.into(),
-                    border_width: 0.0,
-                    border_color: Color::TRANSPARENT,
-                }))
+                .style(icon_container_style())
                 .width(Length::Shrink)
                 .apply(container)
                 .center_x()

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -8,14 +8,13 @@ use crate::{
     utils::prelude::SeatExt,
     wayland::handlers::screencopy::ScreencopySessions,
 };
-use apply::Apply;
 use calloop::LoopHandle;
 use cosmic::{
     iced::{id::Id, widget as iced_widget},
     iced_core::{Background, BorderRadius, Color, Length},
     iced_runtime::Command,
     iced_widget::scrollable::AbsoluteOffset,
-    theme, widget as cosmic_widget, Element as CosmicElement,
+    theme, widget as cosmic_widget, Apply, Element as CosmicElement,
 };
 use cosmic_protocols::screencopy::v1::server::zcosmic_screencopy_session_v1::InputType;
 use once_cell::sync::Lazy;
@@ -652,8 +651,10 @@ impl Program for CosmicStackInternal {
         let group_focused = self.group_focused.load(Ordering::SeqCst);
 
         let elements = vec![
-            cosmic_widget::icon("window-stack-symbolic", 16)
-                .force_svg(true)
+            cosmic_widget::icon::from_name("window-stack-symbolic")
+                .size(16)
+                .prefer_svg(true)
+                .icon()
                 .style(if group_focused {
                     theme::Svg::custom(|theme| iced_widget::svg::Appearance {
                         color: Some(if theme.cosmic().is_dark {
@@ -663,7 +664,7 @@ impl Program for CosmicStackInternal {
                         }),
                     })
                 } else {
-                    theme::Svg::Symbolic
+                    theme::Svg::Default
                 })
                 .apply(iced_widget::container)
                 .padding([4, 24])
@@ -712,6 +713,7 @@ impl Program for CosmicStackInternal {
             .center_y()
             .style(if self.group_focused.load(Ordering::SeqCst) {
                 theme::Container::custom(|theme| iced_widget::container::Appearance {
+                    icon_color: Some(Color::from(theme.cosmic().background.on)),
                     text_color: Some(Color::from(theme.cosmic().background.on)),
                     background: Some(Background::Color(theme.cosmic().accent_color().into())),
                     border_radius: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
@@ -720,6 +722,7 @@ impl Program for CosmicStackInternal {
                 })
             } else {
                 theme::Container::custom(|theme| iced_widget::container::Appearance {
+                    icon_color: Some(Color::from(theme.cosmic().background.on)),
                     text_color: Some(Color::from(theme.cosmic().background.on)),
                     background: Some(Background::Color(theme.cosmic().palette.neutral_3.into())),
                     border_radius: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -122,14 +122,14 @@ pub enum Focus {
 
 pub enum MoveResult {
     Handled,
-    MoveOut(CosmicSurface, LoopHandle<'static, crate::state::Data>),
+    MoveOut(CosmicSurface, LoopHandle<'static, crate::state::State>),
     Default,
 }
 
 impl CosmicStack {
     pub fn new<I: Into<CosmicSurface>>(
         windows: impl Iterator<Item = I>,
-        handle: LoopHandle<'static, crate::state::Data>,
+        handle: LoopHandle<'static, crate::state::State>,
     ) -> CosmicStack {
         let windows = windows.map(Into::into).collect::<Vec<_>>();
         assert!(!windows.is_empty());
@@ -498,7 +498,7 @@ impl CosmicStack {
             .with_program(|p| p.group_focused.store(true, Ordering::SeqCst));
     }
 
-    pub(in super::super) fn loop_handle(&self) -> LoopHandle<'static, crate::state::Data> {
+    pub(in super::super) fn loop_handle(&self) -> LoopHandle<'static, crate::state::State> {
         self.0.loop_handle()
     }
 
@@ -603,7 +603,7 @@ impl Program for CosmicStackInternal {
     fn update(
         &mut self,
         message: Self::Message,
-        loop_handle: &LoopHandle<'static, crate::state::Data>,
+        loop_handle: &LoopHandle<'static, crate::state::State>,
     ) -> Command<Self::Message> {
         match message {
             Message::DragStart => {
@@ -612,8 +612,8 @@ impl Program for CosmicStackInternal {
                         [self.active.load(Ordering::SeqCst)]
                     .wl_surface()
                     {
-                        loop_handle.insert_idle(move |data| {
-                            Shell::move_request(&mut data.state, &surface, &seat, serial);
+                        loop_handle.insert_idle(move |state| {
+                            Shell::move_request(state, &surface, &seat, serial);
                         });
                     }
                 }
@@ -1080,9 +1080,9 @@ impl PointerTarget<State> for CosmicStack {
                                     }
 
                                     let seat = seat.clone();
-                                    data.common.event_loop_handle.insert_idle(move |data| {
+                                    data.common.event_loop_handle.insert_idle(move |state| {
                                         seat.get_pointer().unwrap().set_grab(
-                                            &mut data.state,
+                                            state,
                                             grab,
                                             event.serial,
                                             smithay::input::pointer::Focus::Clear,

--- a/src/shell/element/stack/tab_text.rs
+++ b/src/shell/element/stack/tab_text.rs
@@ -4,7 +4,7 @@ use cosmic::{
         gradient,
         layout::{Layout, Limits, Node},
         mouse::Cursor,
-        renderer,
+        renderer::{self, Renderer as IcedRenderer},
         widget::{Tree, Widget},
         Background, Color, Degrees, Gradient, Length, Point, Rectangle, Size,
     },
@@ -13,7 +13,7 @@ use cosmic::{
 
 pub struct TabText<'a, Message, Renderer>
 where
-    Renderer: cosmic::iced_core::Renderer,
+    Renderer: IcedRenderer,
     Renderer::Theme: TextStyleSheet,
 {
     text: Element<'a, Message, Renderer>,
@@ -26,7 +26,7 @@ pub fn tab_text<'a, Message, Renderer>(
     text: impl Into<Element<'a, Message, Renderer>>,
 ) -> TabText<'a, Message, Renderer>
 where
-    Renderer: cosmic::iced_core::Renderer,
+    Renderer: IcedRenderer,
     Renderer::Theme: TextStyleSheet,
 {
     TabText::new(text, Color::TRANSPARENT)
@@ -34,7 +34,7 @@ where
 
 impl<'a, Message, Renderer> TabText<'a, Message, Renderer>
 where
-    Renderer: cosmic::iced_core::Renderer,
+    Renderer: IcedRenderer,
     Renderer::Theme: TextStyleSheet,
 {
     pub fn new(text: impl Into<Element<'a, Message, Renderer>>, background: Color) -> Self {
@@ -66,7 +66,7 @@ where
 
 impl<'a, Message, Renderer> Widget<Message, Renderer> for TabText<'a, Message, Renderer>
 where
-    Renderer: cosmic::iced_core::Renderer,
+    Renderer: IcedRenderer,
     Renderer::Theme: TextStyleSheet,
 {
     fn width(&self) -> Length {
@@ -148,7 +148,7 @@ where
 
 impl<'a, Message, Renderer> Into<Element<'a, Message, Renderer>> for TabText<'a, Message, Renderer>
 where
-    Renderer: cosmic::iced_core::Renderer + 'a,
+    Renderer: IcedRenderer + 'a,
     Renderer::Theme: TextStyleSheet,
     Message: 'a,
 {

--- a/src/shell/element/stack_hover.rs
+++ b/src/shell/element/stack_hover.rs
@@ -16,7 +16,7 @@ use smithay::utils::{Logical, Size};
 pub type StackHover = IcedElement<StackHoverInternal>;
 
 pub fn stack_hover(
-    evlh: LoopHandle<'static, crate::state::Data>,
+    evlh: LoopHandle<'static, crate::state::State>,
     size: Size<i32, Logical>,
 ) -> StackHover {
     StackHover::new(StackHoverInternal, size, evlh)

--- a/src/shell/element/stack_hover.rs
+++ b/src/shell/element/stack_hover.rs
@@ -3,13 +3,13 @@ use crate::{
     utils::iced::{IcedElement, Program},
 };
 
-use apply::Apply;
 use calloop::LoopHandle;
 use cosmic::{
     iced::widget::{container, row},
     iced_core::{Background, Color, Length},
     theme,
-    widget::{icon, text},
+    widget::{icon::from_name, text},
+    Apply,
 };
 use smithay::utils::{Logical, Size};
 
@@ -29,8 +29,10 @@ impl Program for StackHoverInternal {
 
     fn view(&self) -> crate::utils::iced::Element<'_, Self::Message> {
         row(vec![
-            icon("window-stack-symbolic", 24)
-                .force_svg(true)
+            from_name("window-stack-symbolic")
+                .size(24)
+                .prefer_svg(true)
+                .icon()
                 .apply(container)
                 .padding([0, 8, 0, 0])
                 .width(Length::Shrink)
@@ -54,6 +56,7 @@ impl Program for StackHoverInternal {
         .apply(container)
         .padding([8, 16])
         .style(theme::Container::custom(|theme| container::Appearance {
+            icon_color: Some(Color::from(theme.cosmic().accent.on)),
             text_color: Some(Color::from(theme.cosmic().accent.on)),
             background: Some(Background::Color(theme.cosmic().accent_color().into())),
             border_radius: 24.0.into(),

--- a/src/shell/element/swap_indicator.rs
+++ b/src/shell/element/swap_indicator.rs
@@ -15,7 +15,7 @@ use smithay::utils::Size;
 
 pub type SwapIndicator = IcedElement<SwapIndicatorInternal>;
 
-pub fn swap_indicator(evlh: LoopHandle<'static, crate::state::Data>) -> SwapIndicator {
+pub fn swap_indicator(evlh: LoopHandle<'static, crate::state::State>) -> SwapIndicator {
     SwapIndicator::new(SwapIndicatorInternal, Size::from((1, 1)), evlh)
 }
 

--- a/src/shell/element/swap_indicator.rs
+++ b/src/shell/element/swap_indicator.rs
@@ -3,13 +3,13 @@ use crate::{
     utils::iced::{IcedElement, Program},
 };
 
-use apply::Apply;
 use calloop::LoopHandle;
 use cosmic::{
     iced::widget::{container, horizontal_space, row},
     iced_core::{Alignment, Background, Color, Length},
     theme,
-    widget::{icon, text},
+    widget::{icon::from_name, text},
+    Apply,
 };
 use smithay::utils::Size;
 
@@ -26,7 +26,11 @@ impl Program for SwapIndicatorInternal {
 
     fn view(&self) -> crate::utils::iced::Element<'_, Self::Message> {
         row(vec![
-            icon("window-swap-symbolic", 32).force_svg(true).into(),
+            from_name("window-swap-symbolic")
+                .size(32)
+                .prefer_svg(true)
+                .icon()
+                .into(),
             horizontal_space(16).into(),
             text(fl!("swap-windows"))
                 .font(cosmic::font::FONT)
@@ -40,6 +44,7 @@ impl Program for SwapIndicatorInternal {
         .padding(16)
         .apply(container)
         .style(theme::Container::custom(|theme| container::Appearance {
+            icon_color: Some(Color::from(theme.cosmic().accent.on)),
             text_color: Some(Color::from(theme.cosmic().accent.on)),
             background: Some(Background::Color(theme.cosmic().accent_color().into())),
             border_radius: 18.0.into(),

--- a/src/shell/grabs/mod.rs
+++ b/src/shell/grabs/mod.rs
@@ -21,17 +21,18 @@ mod moving;
 pub use self::moving::*;
 
 bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ResizeEdge: u32 {
         const TOP          = 0b0001;
         const BOTTOM       = 0b0010;
         const LEFT         = 0b0100;
         const RIGHT        = 0b1000;
 
-        const TOP_LEFT     = Self::TOP.bits | Self::LEFT.bits;
-        const BOTTOM_LEFT  = Self::BOTTOM.bits | Self::LEFT.bits;
+        const TOP_LEFT     = Self::TOP.bits() | Self::LEFT.bits();
+        const BOTTOM_LEFT  = Self::BOTTOM.bits() | Self::LEFT.bits();
 
-        const TOP_RIGHT    = Self::TOP.bits | Self::RIGHT.bits;
-        const BOTTOM_RIGHT = Self::BOTTOM.bits | Self::RIGHT.bits;
+        const TOP_RIGHT    = Self::TOP.bits() | Self::RIGHT.bits();
+        const BOTTOM_RIGHT = Self::BOTTOM.bits() | Self::RIGHT.bits();
     }
 }
 

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -366,6 +366,7 @@ impl FloatingLayout {
             KeyboardFocusTarget::Popup(popup) => {
                 let Some(toplevel_surface) = (match popup {
                     PopupKind::Xdg(xdg) => get_popup_toplevel(&xdg),
+                    PopupKind::InputMethod(_) => unreachable!(),
                 }) else {
                     return FocusResult::None
                 };
@@ -436,6 +437,7 @@ impl FloatingLayout {
             KeyboardFocusTarget::Popup(popup) => {
                 let Some(toplevel_surface) = (match popup {
                     PopupKind::Xdg(xdg) => get_popup_toplevel(&xdg),
+                    PopupKind::InputMethod(_) => unreachable!(),
                 }) else {
                     return MoveResult::None
                 };

--- a/src/shell/layout/tiling/grabs/resize.rs
+++ b/src/shell/layout/tiling/grabs/resize.rs
@@ -69,11 +69,11 @@ impl PointerTarget<State> for ResizeForkTarget {
             let orientation = self.orientation;
             let serial = event.serial;
             let button = event.button;
-            data.common.event_loop_handle.insert_idle(move |data| {
+            data.common.event_loop_handle.insert_idle(move |state| {
                 let pointer = seat.get_pointer().unwrap();
                 let location = pointer.current_location();
                 pointer.set_grab(
-                    &mut data.state,
+                    state,
                     ResizeForkGrab {
                         start_data: PointerGrabStartData {
                             focus: None,

--- a/src/shell/layout/tiling/grabs/swap.rs
+++ b/src/shell/layout/tiling/grabs/swap.rs
@@ -9,6 +9,7 @@ use smithay::{
     },
     utils::Serial,
 };
+use xkbcommon::xkb::Keysym;
 
 use crate::{
     config::{Action, KeyPattern},
@@ -71,7 +72,7 @@ impl KeyboardGrab<State> for SwapWindowGrab {
             time,
             KeyPattern {
                 modifiers: modifiers.map(Into::into).unwrap_or_default(),
-                key: Some(keycode),
+                key: Some(Keysym::new(keycode)),
             },
             None,
         );

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -2660,6 +2660,7 @@ impl TilingLayout {
         if let KeyboardFocusTarget::Popup(popup) = target {
             let toplevel_surface = match popup {
                 PopupKind::Xdg(xdg) => get_popup_toplevel(&xdg),
+                PopupKind::InputMethod(_) => unreachable!(),
             }?;
             let root_id = tree.root_node_id()?;
             let node =

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1219,7 +1219,7 @@ impl Shell {
     pub fn set_overview_mode(
         &mut self,
         enabled: Option<Trigger>,
-        evlh: LoopHandle<'static, crate::state::Data>,
+        evlh: LoopHandle<'static, crate::state::State>,
     ) {
         if let Some(trigger) = enabled {
             if !matches!(self.overview_mode, OverviewMode::Started(_, _)) {
@@ -1261,7 +1261,7 @@ impl Shell {
         &mut self,
         enabled: Option<(KeyPattern, ResizeDirection)>,
         config: &Config,
-        evlh: LoopHandle<'static, crate::state::Data>,
+        evlh: LoopHandle<'static, crate::state::State>,
     ) {
         if let Some((pattern, direction)) = enabled {
             if let ResizeMode::Started(old_pattern, _, old_direction) = &mut self.resize_mode {

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -430,7 +430,7 @@ impl Workspace {
         &mut self,
         window: &CosmicSurface,
         output: &Output,
-        evlh: LoopHandle<'static, crate::state::Data>,
+        evlh: LoopHandle<'static, crate::state::State>,
     ) {
         if self.fullscreen.contains_key(output) {
             return;
@@ -459,7 +459,7 @@ impl Workspace {
         &mut self,
         window: &CosmicSurface,
         output: &Output,
-        evlh: LoopHandle<'static, crate::state::Data>,
+        evlh: LoopHandle<'static, crate::state::State>,
     ) {
         if self
             .fullscreen
@@ -484,7 +484,7 @@ impl Workspace {
         window: &'a CosmicSurface,
         output: &Output,
         exclusive: bool,
-        evlh: LoopHandle<'static, crate::state::Data>,
+        evlh: LoopHandle<'static, crate::state::State>,
     ) {
         if let Some(mapped) = self
             .mapped()
@@ -635,7 +635,7 @@ impl Workspace {
         &mut self,
         window: &CosmicSurface,
         output: &Output,
-        evlh: LoopHandle<'static, crate::state::Data>,
+        evlh: LoopHandle<'static, crate::state::State>,
     ) {
         if self.fullscreen.contains_key(output) {
             self.unmaximize_request(window);

--- a/src/state.rs
+++ b/src/state.rs
@@ -54,7 +54,7 @@ use smithay::{
         wayland_server::{
             backend::{ClientData, ClientId, DisconnectReason},
             protocol::wl_shm,
-            Client, Display, DisplayHandle,
+            Client, DisplayHandle,
         },
     },
     utils::{Clock, IsAlive, Monotonic},
@@ -114,11 +114,6 @@ impl ClientData for ClientState {
     }
 }
 
-pub struct Data {
-    pub display: Display<State>,
-    pub state: State,
-}
-
 #[derive(Debug)]
 pub struct State {
     pub backend: BackendData,
@@ -131,7 +126,7 @@ pub struct Common {
 
     pub socket: OsString,
     pub display_handle: DisplayHandle,
-    pub event_loop_handle: LoopHandle<'static, Data>,
+    pub event_loop_handle: LoopHandle<'static, State>,
     pub event_loop_signal: LoopSignal,
 
     //pub output_conf: ConfigurationManager,
@@ -212,7 +207,7 @@ impl BackendData {
         test_only: bool,
         shell: &mut Shell,
         seats: impl Iterator<Item = Seat<State>>,
-        loop_handle: &LoopHandle<'_, Data>,
+        loop_handle: &LoopHandle<'_, State>,
     ) -> Result<(), anyhow::Error> {
         let result = match self {
             BackendData::Kms(ref mut state) => {
@@ -252,7 +247,7 @@ impl BackendData {
 
     pub fn schedule_render(
         &mut self,
-        loop_handle: &LoopHandle<'_, Data>,
+        loop_handle: &LoopHandle<'_, State>,
         output: &Output,
         screencopy: Option<Vec<(ScreencopySession, BufferParams)>>,
     ) {
@@ -281,7 +276,7 @@ impl State {
     pub fn new(
         dh: &DisplayHandle,
         socket: OsString,
-        handle: LoopHandle<'static, Data>,
+        handle: LoopHandle<'static, State>,
         signal: LoopSignal,
     ) -> State {
         let requested_languages = DesktopLanguageRequester::requested_languages();

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -98,7 +98,7 @@ pub trait Program {
     fn update(
         &mut self,
         message: Self::Message,
-        loop_handle: &LoopHandle<'static, crate::state::Data>,
+        loop_handle: &LoopHandle<'static, crate::state::State>,
     ) -> Command<Self::Message> {
         let _ = (message, loop_handle);
         Command::none()
@@ -119,7 +119,7 @@ pub trait Program {
     }
 }
 
-struct ProgramWrapper<P: Program>(P, LoopHandle<'static, crate::state::Data>);
+struct ProgramWrapper<P: Program>(P, LoopHandle<'static, crate::state::State>);
 impl<P: Program> IcedProgram for ProgramWrapper<P> {
     type Message = <P as Program>::Message;
     type Renderer = IcedRenderer;
@@ -150,7 +150,7 @@ struct IcedElementInternal<P: Program + Send + 'static> {
     debug: Debug,
 
     // futures
-    handle: LoopHandle<'static, crate::state::Data>,
+    handle: LoopHandle<'static, crate::state::State>,
     scheduler: Scheduler<<P as Program>::Message>,
     executor_token: Option<RegistrationToken>,
     rx: Receiver<<P as Program>::Message>,
@@ -228,7 +228,7 @@ impl<P: Program + Send + 'static> IcedElement<P> {
     pub fn new(
         program: P,
         size: impl Into<Size<i32, Logical>>,
-        handle: LoopHandle<'static, crate::state::Data>,
+        handle: LoopHandle<'static, crate::state::State>,
     ) -> IcedElement<P> {
         let size = size.into();
         let mut renderer =
@@ -276,7 +276,7 @@ impl<P: Program + Send + 'static> IcedElement<P> {
         func(&internal.state.program().0)
     }
 
-    pub fn loop_handle(&self) -> LoopHandle<'static, crate::state::Data> {
+    pub fn loop_handle(&self) -> LoopHandle<'static, crate::state::State> {
         self.0.lock().unwrap().handle.clone()
     }
 

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -15,19 +15,19 @@ use cosmic::{
         Command, Point as IcedPoint, Rectangle as IcedRectangle, Size as IcedSize,
     },
     iced_core::{clipboard::Null as NullClipboard, renderer::Style, Color},
-    iced_renderer::Backend as BackendWrapper,
+    iced_renderer::{graphics::Renderer as IcedGraphicsRenderer, Renderer as IcedRenderer},
     iced_runtime::{
         command::Action,
         program::{Program as IcedProgram, State},
         Debug,
     },
-    Renderer as IcedRenderer, Theme,
+    Theme,
 };
 use iced_tiny_skia::{
-    graphics::{damage, Primitive, Viewport},
-    Backend,
+    graphics::{damage, Viewport},
+    Backend, Primitive,
 };
-pub type Element<'a, Message> = cosmic::iced::Element<'a, Message, IcedRenderer>;
+pub type Element<'a, Message> = cosmic::iced::Element<'a, Message, IcedRenderer<Theme>>;
 
 use ordered_float::OrderedFloat;
 use smithay::{
@@ -122,7 +122,7 @@ pub trait Program {
 struct ProgramWrapper<P: Program>(P, LoopHandle<'static, crate::state::State>);
 impl<P: Program> IcedProgram for ProgramWrapper<P> {
     type Message = <P as Program>::Message;
-    type Renderer = IcedRenderer;
+    type Renderer = IcedRenderer<Theme>;
 
     fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
         self.0.update(message, &self.1)
@@ -145,7 +145,7 @@ struct IcedElementInternal<P: Program + Send + 'static> {
 
     // iced
     theme: Theme,
-    renderer: IcedRenderer,
+    renderer: IcedRenderer<Theme>,
     state: State<ProgramWrapper<P>>,
     debug: Debug,
 
@@ -171,7 +171,7 @@ impl<P: Program + Send + Clone + 'static> Clone for IcedElementInternal<P> {
             tracing::warn!("Missing force_update call");
         }
         let mut renderer =
-            IcedRenderer::new(BackendWrapper::TinySkia(Backend::new(Default::default())));
+            IcedRenderer::TinySkia(IcedGraphicsRenderer::new(Backend::new(Default::default())));
         let mut debug = Debug::new();
         let state = State::new(
             Id(0),
@@ -232,7 +232,7 @@ impl<P: Program + Send + 'static> IcedElement<P> {
     ) -> IcedElement<P> {
         let size = size.into();
         let mut renderer =
-            IcedRenderer::new(BackendWrapper::TinySkia(Backend::new(Default::default())));
+            IcedRenderer::TinySkia(IcedGraphicsRenderer::new(Backend::new(Default::default())));
         let mut debug = Debug::new();
 
         let state = State::new(
@@ -353,6 +353,8 @@ impl<P: Program + Send + 'static> IcedElementInternal<P> {
                 &mut self.renderer,
                 &self.theme,
                 &Style {
+                    scale_factor: 1.0, //TODO: why is this
+                    icon_color: self.theme.cosmic().on_bg_color().into(),
                     text_color: self.theme.cosmic().on_bg_color().into(),
                 },
                 &mut NullClipboard,
@@ -738,7 +740,7 @@ where
                 .to_i32_round();
 
             if size.w > 0 && size.h > 0 {
-                let renderer = &mut internal_ref.renderer;
+                let IcedRenderer::TinySkia(renderer) = &mut internal_ref.renderer;
                 let state_ref = &internal_ref.state;
                 let mut clip_mask = tiny_skia::Mask::new(size.w as u32, size.h as u32).unwrap();
                 let overlay = internal_ref.debug.overlay();
@@ -751,7 +753,6 @@ where
                                 .expect("Failed to create pixel map");
 
                         renderer.with_primitives(|backend, primitives| {
-                            let BackendWrapper::TinySkia(ref mut backend) = backend;
                             let background_color = state_ref.program().0.background_color();
                             let bounds = IcedSize::new(size.w as u32, size.h as u32);
                             let viewport = Viewport::with_physical_size(bounds, scale.x);

--- a/src/wayland/handlers/output_configuration.rs
+++ b/src/wayland/handlers/output_configuration.rs
@@ -137,8 +137,8 @@ impl State {
         self.common
             .config
             .write_outputs(self.common.output_configuration_state.outputs());
-        self.common.event_loop_handle.insert_idle(move |data| {
-            data.state.common.output_configuration_state.update();
+        self.common.event_loop_handle.insert_idle(move |state| {
+            state.common.output_configuration_state.update();
         });
 
         true

--- a/src/wayland/handlers/security_context.rs
+++ b/src/wayland/handlers/security_context.rs
@@ -16,12 +16,12 @@ impl SecurityContextHandler for State {
     ) {
         self.common
             .event_loop_handle
-            .insert_source(source, move |client_stream, _, data| {
-                if let Err(err) = data.display.handle().insert_client(
+            .insert_source(source, move |client_stream, _, state| {
+                if let Err(err) = state.common.display_handle.insert_client(
                     client_stream,
                     Arc::new(ClientState {
                         security_context: Some(security_context.clone()),
-                        ..data.state.new_client_state()
+                        ..state.new_client_state()
                     }),
                 ) {
                     warn!(?err, "Error adding wayland client");

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -95,6 +95,7 @@ pub fn update_reactive_popups<'a>(
                     }
                 }
             }
+            PopupKind::InputMethod(_) => {}
         }
     }
 }

--- a/src/wayland/protocols/output_configuration.rs
+++ b/src/wayland/protocols/output_configuration.rs
@@ -11,7 +11,7 @@ use smithay::{
             zwlr_output_mode_v1::{self, ZwlrOutputModeV1},
         },
         wayland_server::{
-            backend::{ClientId, GlobalId, ObjectId},
+            backend::{ClientId, GlobalId},
             protocol::wl_output::WlOutput,
             Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
         },
@@ -247,9 +247,9 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _client: ClientId, resource: ObjectId, _data: &Output) {
+    fn destroyed(state: &mut D, _client: ClientId, resource: &ZwlrOutputHeadV1, _data: &Output) {
         for instance in &mut state.output_configuration_state().instances {
-            instance.heads.retain(|h| h.head.id() != resource);
+            instance.heads.retain(|h| &h.head != resource);
         }
     }
 }

--- a/src/wayland/protocols/screencopy.rs
+++ b/src/wayland/protocols/screencopy.rs
@@ -883,18 +883,18 @@ where
     fn destroyed(
         state: &mut D,
         _client: wayland_backend::server::ClientId,
-        resource: wayland_backend::server::ObjectId,
+        resource: &ZcosmicScreencopySessionV1,
         data: &SessionData,
     ) {
         if data.inner.lock().unwrap().is_cursor() {
             let session = CursorSession {
-                obj: SessionResource::Destroyed(resource),
+                obj: SessionResource::Destroyed(resource.id()),
                 data: data.clone(),
             };
             state.cursor_session_destroyed(session)
         } else {
             let session = Session {
-                obj: SessionResource::Destroyed(resource),
+                obj: SessionResource::Destroyed(resource.id()),
                 data: data.clone(),
             };
             state.session_destroyed(session)

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, sync::Mutex};
 use smithay::{
     output::Output,
     reexports::wayland_server::{
-        backend::{ClientId, GlobalId, ObjectId},
+        backend::{ClientId, GlobalId},
         protocol::wl_surface::WlSurface,
         Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
     },
@@ -139,11 +139,11 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _client: ClientId, resource: ObjectId, _data: &()) {
+    fn destroyed(state: &mut D, _client: ClientId, resource: &ZcosmicToplevelInfoV1, _data: &()) {
         state
             .toplevel_info_state_mut()
             .instances
-            .retain(|i| i.id() != resource);
+            .retain(|i| i != resource);
     }
 }
 
@@ -174,16 +174,12 @@ where
     fn destroyed(
         state: &mut D,
         _client: ClientId,
-        resource: ObjectId,
+        resource: &ZcosmicToplevelHandleV1,
         _data: &ToplevelHandleState<W>,
     ) {
         for toplevel in &state.toplevel_info_state_mut().toplevels {
             if let Some(state) = toplevel.user_data().get::<ToplevelState>() {
-                state
-                    .lock()
-                    .unwrap()
-                    .instances
-                    .retain(|i| i.id() != resource);
+                state.lock().unwrap().instances.retain(|i| i != resource);
             }
         }
     }

--- a/src/wayland/protocols/toplevel_management.rs
+++ b/src/wayland/protocols/toplevel_management.rs
@@ -4,7 +4,7 @@ use smithay::{
     input::{Seat, SeatHandler},
     output::Output,
     reexports::wayland_server::{
-        backend::{ClientId, GlobalId, ObjectId},
+        backend::{ClientId, GlobalId},
         protocol::wl_surface::WlSurface,
         Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
     },
@@ -225,9 +225,9 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, client: ClientId, resource: ObjectId, _data: &()) {
+    fn destroyed(state: &mut D, client: ClientId, resource: &ZcosmicToplevelManagerV1, _data: &()) {
         let mng_state = state.toplevel_management_state();
-        mng_state.instances.retain(|i| i.id() != resource);
+        mng_state.instances.retain(|i| i != resource);
         if !mng_state
             .instances
             .iter()

--- a/src/wayland/protocols/workspace.rs
+++ b/src/wayland/protocols/workspace.rs
@@ -211,11 +211,16 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _client: ClientId, resource: ObjectId, _data: &()) {
+    fn destroyed(
+        state: &mut D,
+        _client: ClientId,
+        resource: &ZcosmicWorkspaceManagerV1,
+        _data: &(),
+    ) {
         state
             .workspace_state_mut()
             .instances
-            .retain(|i| i.id() != resource);
+            .retain(|i| i != resource);
     }
 }
 
@@ -268,9 +273,14 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _client: ClientId, resource: ObjectId, _data: &WorkspaceGroupData) {
+    fn destroyed(
+        state: &mut D,
+        _client: ClientId,
+        resource: &ZcosmicWorkspaceGroupHandleV1,
+        _data: &WorkspaceGroupData,
+    ) {
         for group in &mut state.workspace_state_mut().groups {
-            group.instances.retain(|i| i.id() != resource)
+            group.instances.retain(|i| i != resource)
         }
     }
 }
@@ -361,10 +371,15 @@ where
         }
     }
 
-    fn destroyed(state: &mut D, _client: ClientId, resource: ObjectId, _data: &WorkspaceData) {
+    fn destroyed(
+        state: &mut D,
+        _client: ClientId,
+        resource: &ZcosmicWorkspaceHandleV1,
+        _data: &WorkspaceData,
+    ) {
         for group in &mut state.workspace_state_mut().groups {
             for workspace in &mut group.workspaces {
-                workspace.instances.retain(|i| i.id() != resource)
+                workspace.instances.retain(|i| i != resource)
             }
         }
     }


### PR DESCRIPTION
Looks scarier, than it is, but the update had some larger impact:

- Changes due to how the `Display` is registered to the event loop with the latest wayland-rs version, let us get rid of `Data`. Finally making the state of the EventLoop and of our wayland components the same type
- xkbcommon now uses proper types instead of aliases, changing the input and config code around a bit.

Draft because waiting on https://github.com/pop-os/cosmic-protocols/pull/19