### PR TITLE
Add support for profiling using tracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,7 @@ dependencies = [
  "once_cell",
  "ordered-float",
  "png",
+ "profiling",
  "puffin",
  "puffin_egui",
  "regex",
@@ -1889,6 +1890,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,7 +2052,7 @@ dependencies = [
  "presser",
  "thiserror",
  "winapi",
- "windows",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -2881,6 +2895,19 @@ checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
  "backtrace",
  "log",
+]
+
+[[package]]
+name = "loom"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e045d70ddfbc984eacfa964ded019534e8f6cbf36f6410aee0ed5cefa5a9175"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3802,18 +3829,19 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135ede8821cf6376eb7a64148901e1690b788c11ae94dc297ae917dbc91dc0e"
+checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
 dependencies = [
  "profiling-procmacros",
+ "tracy-client",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b322d7d65c1ab449be3c890fcbd0db6e1092d0dd05d79dba2dd28032cebeb05"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -4219,6 +4247,12 @@ dependencies = [
  "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rustybuzz"
@@ -5018,6 +5052,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracy-client"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb931a64ff88984f86d3e9bcd1ae8843aa7fe44dd0f8097527bc172351741d"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d104d610dfa9dd154535102cc9c6164ae1fa37842bc2d9e83f9ac82b0ae0882"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5709,6 +5763,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ xdg = "^2.1"
 xdg-user = "0.2.1"
 xkbcommon = "0.7"
 zbus = "3.15.0"
+profiling = { version = "1.0" }
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"
@@ -96,6 +97,7 @@ rev = "cdc652e0"
 debug = ["egui", "egui_plot", "smithay-egui", "renderdoc", "puffin", "puffin_egui", "anyhow/backtrace"]
 default = ["systemd"]
 systemd = ["libsystemd"]
+profile-with-tracy = ["profiling/profile-with-tracy"]
 
 [profile.dev]
 lto = "thin"

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -1153,6 +1153,7 @@ fn get_surface_dmabuf_feedback(
 }
 
 impl Surface {
+    #[profiling::function]
     pub fn render_output(
         &mut self,
         api: &mut GpuManager<GbmGlesBackend<GlowRenderer, DrmDeviceFd>>,
@@ -1359,6 +1360,7 @@ impl KmsState {
         self.session.change_vt(num).map_err(Into::into)
     }
 
+    #[profiling::function]
     pub fn apply_config_for_output(
         &mut self,
         output: &Output,
@@ -1587,6 +1589,7 @@ impl KmsState {
         Err(last_err)
     }
 
+    #[profiling::function]
     pub fn schedule_render(
         &mut self,
         loop_handle: &LoopHandle<'_, State>,
@@ -1626,6 +1629,7 @@ impl KmsState {
                         )
                     },
                     move |_time, _, state| {
+                        profiling::scope!("render_timer");
                         let backend = state.backend.kms();
                         let (mut device, mut other) = backend
                             .devices
@@ -1665,6 +1669,8 @@ impl KmsState {
                                     screencopy_sessions.as_deref(),
                                 )
                             };
+
+                            profiling::finish_frame!();
 
                             match result {
                                 Ok(_) => {

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -184,6 +184,7 @@ where
     )
 }
 
+#[profiling::function]
 pub fn draw_dnd_icon<R>(
     renderer: &mut R,
     surface: &wl_surface::WlSurface,
@@ -301,6 +302,7 @@ impl Default for CursorState {
     }
 }
 
+#[profiling::function]
 pub fn draw_cursor<R>(
     renderer: &mut R,
     seat: &Seat<State>,

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -389,6 +389,7 @@ pub enum CursorMode {
     All,
 }
 
+#[profiling::function]
 pub fn cursor_elements<'frame, E, R>(
     renderer: &mut R,
     state: &Common,
@@ -464,6 +465,7 @@ where
     elements
 }
 
+#[profiling::function]
 pub fn workspace_elements<R>(
     _gpu: Option<&DrmNode>,
     renderer: &mut R,
@@ -965,6 +967,7 @@ where
     }
 }
 
+#[profiling::function]
 pub fn render_output<R, Target, OffTarget, Source>(
     gpu: Option<&DrmNode>,
     renderer: &mut R,
@@ -1020,6 +1023,7 @@ where
     result
 }
 
+#[profiling::function]
 pub fn render_workspace<R, Target, OffTarget, Source>(
     gpu: Option<&DrmNode>,
     renderer: &mut R,

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -51,6 +51,7 @@ pub struct WinitState {
 }
 
 impl WinitState {
+    #[profiling::function]
     pub fn render_output(&mut self, state: &mut Common) -> Result<()> {
         self.backend
             .bind()
@@ -197,6 +198,7 @@ pub fn init_backend(
                     error!(?err, "Failed to render frame.");
                     render_ping.ping();
                 }
+                profiling::finish_frame!();
             })
             .map_err(|_| anyhow::anyhow!("Failed to init eventloop timer for winit"))?,
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,11 @@ pub mod utils;
 pub mod wayland;
 pub mod xwayland;
 
+#[cfg(feature = "profile-with-tracy")]
+#[global_allocator]
+static GLOBAL: profiling::tracy_client::ProfiledAllocator<std::alloc::System> =
+    profiling::tracy_client::ProfiledAllocator::new(std::alloc::System, 10);
+
 fn main() -> Result<()> {
     // setup logger
     logger::init_logger()?;
@@ -79,6 +84,11 @@ fn main() -> Result<()> {
     if let Err(err) = theme::watch_theme(event_loop.handle()) {
         warn!(?err, "Failed to watch theme");
     }
+
+    #[cfg(feature = "profile-with-tracy")]
+    profiling::tracy_client::Client::start();
+
+    profiling::register_thread!("Main Thread");
 
     // run the event loop
     event_loop.run(None, &mut state, |state| {

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -847,6 +847,7 @@ impl SpaceElement for CosmicMapped {
     fn z_index(&self) -> u8 {
         SpaceElement::z_index(&self.element)
     }
+    #[profiling::function]
     fn refresh(&self) {
         SpaceElement::refresh(&self.element)
     }

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -641,6 +641,7 @@ impl SpaceElement for CosmicSurface {
         SpaceElement::output_leave(&self.0, output)
     }
 
+    #[profiling::function]
     fn refresh(&self) {
         SpaceElement::refresh(&self.0)
     }

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -490,11 +490,13 @@ impl SpaceElement for CosmicWindow {
             });
         }
     }
+    #[profiling::function]
     fn output_enter(&self, output: &Output, overlap: Rectangle<i32, Logical>) {
         SpaceElement::output_enter(&self.0, output, overlap);
         self.0
             .with_program(|p| SpaceElement::output_enter(&p.window, output, overlap));
     }
+    #[profiling::function]
     fn output_leave(&self, output: &Output) {
         SpaceElement::output_leave(&self.0, output);
         self.0
@@ -512,6 +514,7 @@ impl SpaceElement for CosmicWindow {
     fn z_index(&self) -> u8 {
         self.0.with_program(|p| SpaceElement::z_index(&p.window))
     }
+    #[profiling::function]
     fn refresh(&self) {
         SpaceElement::refresh(&self.0);
         if self.0.with_program(|p| {

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -61,6 +61,7 @@ pub struct MoveGrabState {
 }
 
 impl MoveGrabState {
+    #[profiling::function]
     pub fn render<I, R>(
         &self,
         renderer: &mut R,

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1095,6 +1095,7 @@ impl FloatingLayout {
         self.mapped().flat_map(|e| e.windows().map(|(w, _)| w))
     }
 
+    #[profiling::function]
     pub fn refresh(&mut self) {
         #[cfg(feature = "debug")]
         puffin::profile_function!();
@@ -1150,6 +1151,7 @@ impl FloatingLayout {
         self.refresh(); //fixup any out of bounds elements
     }
 
+    #[profiling::function]
     pub fn render<R>(
         &self,
         renderer: &mut R,

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -2303,6 +2303,7 @@ impl TilingLayout {
         self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
     }
 
+    #[profiling::function]
     pub fn refresh(&mut self) {
         #[cfg(feature = "debug")]
         puffin::profile_function!();
@@ -2934,6 +2935,7 @@ impl TilingLayout {
         }
     }
 
+    #[profiling::function]
     fn update_positions(
         output: &Output,
         tree: &mut Tree<Data>,
@@ -3801,6 +3803,7 @@ impl TilingLayout {
         }
     }
 
+    #[profiling::function]
     pub fn render<R>(
         &self,
         renderer: &mut R,

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1515,6 +1515,7 @@ impl Shell {
         }
     }
 
+    #[profiling::function]
     pub fn refresh(&mut self) {
         #[cfg(feature = "debug")]
         puffin::profile_function!();

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -286,6 +286,7 @@ impl Workspace {
         }
     }
 
+    #[profiling::function]
     pub fn refresh(&mut self, xdg_activation_state: &XdgActivationState) {
         #[cfg(feature = "debug")]
         puffin::profile_function!();
@@ -1059,6 +1060,7 @@ impl Workspace {
         }
     }
 
+    #[profiling::function]
     pub fn render<'a, R>(
         &self,
         renderer: &mut R,

--- a/src/state.rs
+++ b/src/state.rs
@@ -353,7 +353,15 @@ impl State {
             .with_context(|| "Failed to load languages")
             .unwrap();
 
+        #[cfg(feature = "profile-with-tracy")]
+        unsafe {
+            time::util::local_offset::set_soundness(time::util::local_offset::Soundness::Unsound);
+        }
         let local_offset = UtcOffset::current_local_offset().expect("No yet multithreaded");
+        #[cfg(feature = "profile-with-tracy")]
+        unsafe {
+            time::util::local_offset::set_soundness(time::util::local_offset::Soundness::Sound);
+        }
         let clock = Clock::new();
         let config = Config::load(&handle);
         let compositor_state = CompositorState::new::<Self>(dh);

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -358,6 +358,7 @@ impl<P: Program + Send + 'static + Clone> IcedElement<P> {
 }
 
 impl<P: Program + Send + 'static> IcedElementInternal<P> {
+    #[profiling::function]
     fn update(&mut self, mut force: bool) -> Vec<Action<<P as Program>::Message>> {
         while let Ok(message) = self.rx.try_recv() {
             self.state.queue_message(message);
@@ -691,6 +692,7 @@ impl<P: Program + Send + 'static> SpaceElement for IcedElement<P> {
         RenderZindex::Shell as u8
     }
 
+    #[profiling::function]
     fn refresh(&self) {
         let mut internal = self.0.lock().unwrap();
         // makes partial borrows easier

--- a/src/wayland/handlers/screencopy.rs
+++ b/src/wayland/handlers/screencopy.rs
@@ -593,6 +593,7 @@ where
     Ok(())
 }
 
+#[profiling::function]
 pub fn render_session<F, R>(
     node: Option<DrmNode>,
     renderer: &mut R,
@@ -637,6 +638,7 @@ where
     }
 }
 
+#[profiling::function]
 pub fn render_output_to_buffer(
     state: &mut State,
     session: &Session,
@@ -767,6 +769,7 @@ pub fn render_output_to_buffer(
     }
 }
 
+#[profiling::function]
 pub fn render_workspace_to_buffer(
     state: &mut State,
     session: &Session,
@@ -916,6 +919,7 @@ smithay::render_elements! {
     CursorElement=cursor::CursorRenderElement<R>,
 }
 
+#[profiling::function]
 pub fn render_window_to_buffer(
     state: &mut State,
     session: &Session,


### PR DESCRIPTION
I'm not sure entirely how to deal with `profiling::finish_frame!` when there are multiple outputs rendering frames, and some more functions could be annotated, but Tracy seems generally useful for profiling with these changes. So they might as well be merged.