### PR TITLE
state: fix privileged access with sec context

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -308,7 +308,7 @@ pub fn client_should_see_privileged_protocols(client: &Client) -> bool {
     {
         client_is_privileged(client)
     } else {
-        client_has_no_security_context(client)
+        client_is_privileged(client) || client_has_no_security_context(client)
     }
 }
 


### PR DESCRIPTION
Otherwise we gain absolutely nothing by inheriting the privileged flag. :see_no_evil:

There is also the question, if we should allow privileged clients with a context to access the security-context protocol itself, but that is a far less important question.