### PR TITLE
Handle session lock surfaces in `visible_outputs_for_surface`

### DIFF
--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -13,9 +13,10 @@ use crate::debug::{fps_ui, profiler_ui};
 use crate::{
     shell::{
         focus::target::WindowGroup, grabs::SeatMoveGrabState, layout::tiling::ANIMATION_DURATION,
-        CosmicMapped, CosmicMappedRenderElement, OverviewMode, Trigger, WorkspaceRenderElement,
+        CosmicMapped, CosmicMappedRenderElement, OverviewMode, SessionLock, Trigger,
+        WorkspaceRenderElement,
     },
-    state::{Common, Fps, SessionLock},
+    state::{Common, Fps},
     utils::prelude::*,
     wayland::{
         handlers::{
@@ -487,7 +488,7 @@ where
     }
 
     // If session locked, only show session lock surfaces
-    if let Some(session_lock) = &state.session_lock {
+    if let Some(session_lock) = &state.shell.session_lock {
         elements.extend(
             session_lock_elements(renderer, output, session_lock)
                 .into_iter()

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -308,7 +308,7 @@ fn focus_target_is_valid(
     target: KeyboardFocusTarget,
 ) -> bool {
     // If a session lock is active, only lock surfaces can be focused
-    if state.common.session_lock.is_some() {
+    if state.common.shell.session_lock.is_some() {
         return matches!(target, KeyboardFocusTarget::LockSurface(_));
     }
 
@@ -361,7 +361,7 @@ fn update_focus_target(
     seat: &Seat<State>,
     output: &Output,
 ) -> Option<KeyboardFocusTarget> {
-    if let Some(session_lock) = &state.common.session_lock {
+    if let Some(session_lock) = &state.common.shell.session_lock {
         session_lock
             .surfaces
             .get(output)

--- a/src/wayland/handlers/session_lock.rs
+++ b/src/wayland/handlers/session_lock.rs
@@ -36,10 +36,20 @@ impl SessionLockHandler for State {
             ext_session_lock,
             surfaces: HashMap::new(),
         });
+
+        for output in self.common.shell.outputs() {
+            self.backend
+                .schedule_render(&self.common.event_loop_handle, &output, None);
+        }
     }
 
     fn unlock(&mut self) {
         self.common.shell.session_lock = None;
+
+        for output in self.common.shell.outputs() {
+            self.backend
+                .schedule_render(&self.common.event_loop_handle, &output, None);
+        }
     }
 
     fn new_surface(&mut self, lock_surface: LockSurface, wl_output: WlOutput) {

--- a/src/wayland/handlers/session_lock.rs
+++ b/src/wayland/handlers/session_lock.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{
-    state::{SessionLock, State},
-    utils::prelude::*,
-};
+use crate::{shell::SessionLock, state::State, utils::prelude::*};
 use smithay::{
     delegate_session_lock,
     output::Output,
@@ -22,7 +19,7 @@ impl SessionLockHandler for State {
 
     fn lock(&mut self, locker: SessionLocker) {
         // Reject lock if sesion lock exists and is still valid
-        if let Some(session_lock) = self.common.session_lock.as_ref() {
+        if let Some(session_lock) = self.common.shell.session_lock.as_ref() {
             if self
                 .common
                 .display_handle
@@ -35,18 +32,18 @@ impl SessionLockHandler for State {
 
         let ext_session_lock = locker.ext_session_lock().clone();
         locker.lock();
-        self.common.session_lock = Some(SessionLock {
+        self.common.shell.session_lock = Some(SessionLock {
             ext_session_lock,
             surfaces: HashMap::new(),
         });
     }
 
     fn unlock(&mut self) {
-        self.common.session_lock = None;
+        self.common.shell.session_lock = None;
     }
 
     fn new_surface(&mut self, lock_surface: LockSurface, wl_output: WlOutput) {
-        if let Some(session_lock) = &mut self.common.session_lock {
+        if let Some(session_lock) = &mut self.common.shell.session_lock {
             if let Some(output) = Output::from_resource(&wl_output) {
                 lock_surface.with_pending_state(|states| {
                     let size = output.geometry().size;


### PR DESCRIPTION
Fixes issue with re-draw not being queued on initial surface commit until cursor is moved.