### PR TITLE
Fix use of `ImportNotifier`

### DIFF
--- a/src/wayland/handlers/dmabuf.rs
+++ b/src/wayland/handlers/dmabuf.rs
@@ -20,6 +20,8 @@ impl DmabufHandler for State {
     ) {
         if self.backend.dmabuf_imported(global, dmabuf).is_err() {
             import_notifier.failed();
+        } else {
+            let _ = import_notifier.successful::<State>();
         }
     }
 }


### PR DESCRIPTION
Somehow when updating to this API, I missed the call to `successful`.

This doesn't seem to make a difference for most clients since `create_immed` is normally used. But should correct anything using `create`.