### PR TITLE
cosmic: Provide `CosmicConfigEntry` impl, use `_` in property names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
 name = "cosmic-comp-config"
 version = "0.1.0"
 dependencies = [
+ "cosmic-config",
  "input",
  "serde",
 ]

--- a/cosmic-comp-config/Cargo.toml
+++ b/cosmic-comp-config/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+cosmic-config = { git = "https://github.com/pop-os/libcosmic/" }
 input = "0.8.3"
 serde = { version = "1", features = ["derive"] }

--- a/cosmic-comp-config/src/input.rs
+++ b/cosmic-comp-config/src/input.rs
@@ -5,7 +5,7 @@
 pub use input::{AccelProfile, ClickMethod, ScrollMethod, TapButtonMap};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct InputConfig {
     pub state: DeviceState,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -29,14 +29,14 @@ pub struct InputConfig {
     pub tap_config: Option<TapConfig>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct AccelConfig {
     #[serde(with = "AccelProfileDef")]
     pub profile: Option<AccelProfile>,
     pub speed: f64,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct ScrollConfig {
     #[serde(with = "ScrollMethodDef")]
     pub method: Option<ScrollMethod>,
@@ -45,7 +45,7 @@ pub struct ScrollConfig {
     pub scroll_factor: Option<f64>,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum DeviceState {
     Enabled,
     Disabled,
@@ -58,7 +58,7 @@ impl Default for DeviceState {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TapConfig {
     pub enabled: bool,
     #[serde(with = "TapButtonMapDef")]

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -1,11 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use cosmic_config::{cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub mod input;
 pub mod workspace;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, CosmicConfigEntry)]
+pub struct CosmicCompConfig {
+    pub workspaces: workspace::WorkspaceConfig,
+    pub input_default: input::InputConfig,
+    pub input_touchpad: input::InputConfig,
+    pub input_devices: HashMap<String, input::InputConfig>,
+    pub xkb_config: XkbConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct XkbConfig {
     pub rules: String,
     pub model: String,

--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -6,7 +6,7 @@ fn default_workspace_layout() -> WorkspaceLayout {
     WorkspaceLayout::Vertical
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
     pub workspace_mode: WorkspaceMode,
     pub workspace_amount: WorkspaceAmount,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -175,10 +175,10 @@ impl Config {
         Config {
             static_conf: Self::load_static(xdg.as_ref(), workspace.workspace_layout),
             dynamic_conf: Self::load_dynamic(xdg.as_ref()),
-            xkb: get_config(&config, "xkb-config"),
-            input_default: get_config(&config, "input-default"),
-            input_touchpad: get_config(&config, "input-touchpad"),
-            input_devices: get_config(&config, "input-devices"),
+            xkb: get_config(&config, "xkb_config"),
+            input_default: get_config(&config, "input_default"),
+            input_touchpad: get_config(&config, "input_touchpad"),
+            input_devices: get_config(&config, "input_devices"),
             workspace,
             config,
         }
@@ -517,18 +517,18 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                 }
                 state.common.config.xkb = value;
             }
-            "input-default" => {
-                let value = get_config::<InputConfig>(&config, "input-default");
+            "input_default" => {
+                let value = get_config::<InputConfig>(&config, "input_default");
                 state.common.config.input_default = value;
                 update_input(state);
             }
-            "input-touchpad" => {
-                let value = get_config::<InputConfig>(&config, "input-touchpad");
+            "input_touchpad" => {
+                let value = get_config::<InputConfig>(&config, "input_touchpad");
                 state.common.config.input_touchpad = value;
                 update_input(state);
             }
-            "input-devices" => {
-                let value = get_config::<HashMap<String, InputConfig>>(&config, "input-devices");
+            "input_devices" => {
+                let value = get_config::<HashMap<String, InputConfig>>(&config, "input_devices");
                 state.common.config.input_devices = value;
                 update_input(state);
             }


### PR DESCRIPTION
It seems to derive `CosmicConfigEntry`, we need to use `_` in property names, because `_` isn't mapped to `-` and there doesn't seem to be a mechanism like `#[serde(rename)]`.

It seems good to be consistent anyway. So this seems good to change, unless we really like using `-` for names on disk, then cosmic-panel needs to be changed.

`CosmicConfigEntry` also requires `PartialEq`, which is easy enough to add.

This will break existing input settings, which will have to be re-applied with the new locations. Cosmic-settings also need to be updated for this.