### PR TITLE
Fix generation of `axis_stop` events 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.1",
 ]
 
 [[package]]
@@ -4010,7 +4010,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=d5782e1#d5782e1a643b36ab59267c05bb89526e29b4bf9d"
+source = "git+https://github.com/smithay//smithay?rev=1ebe4e8#1ebe4e8fdcc910aba85e5222da1c1102d4f50e41"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,4 +91,4 @@ debug = true
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "d5782e1" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "1ebe4e8" }


### PR DESCRIPTION
`axis_stop` should only be sent if the value is `Some(0)`, while this also sent it for `None`. So every scroll event on one axis generated stop events for the other.

This fixes scrolling with a touchpad in Alacritty.

Anvil already does this, comparing against `Some(0.0)`.