### PR TITLE
fix: Super+Escape locks screen per Pop!_OS convention

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -1,7 +1,8 @@
 (
     key_bindings: {
         (modifiers: [Super, Shift], key: "Escape"): Terminate,
-        (modifiers: [Super], key: "Escape"): Debug,
+        (modifiers: [Super, Ctrl], key: "Escape"): Debug,
+        (modifiers: [Super], key: "Escape"): Spawn("cosmic-greeter"),
         (modifiers: [Super], key: "q"): Close,
 
         (modifiers: [Super], key: "1"): Workspace(1),


### PR DESCRIPTION
On Pop!_OS, Super+Escape locks the screen: https://support.system76.com/articles/pop-keyboard-shortcuts/

The PR moves the `Debug` action over to Super+Ctrl+Escape, and then wires up `cosmic-greeter` so that we get the same lock screen keyboard shortcut here