### PR TITLE
fix!: default config uses `pactl` instead of `amixer`

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -82,9 +82,9 @@
 
         (modifiers: [], key: "Print"): Spawn("cosmic-screenshot"),
 
-        (modifiers: [], key: "XF86AudioRaiseVolume"): Spawn("amixer sset Master 5%+"),
-        (modifiers: [], key: "XF86AudioLowerVolume"): Spawn("amixer sset Master 5%-"),
-        (modifiers: [], key: "XF86AudioMute"): Spawn("amixer sset Master toggle"),
+        (modifiers: [], key: "XF86AudioRaiseVolume"): Spawn("pactl set-sink-volume @DEFAULT_SINK@ +5%"),
+        (modifiers: [], key: "XF86AudioLowerVolume"): Spawn("pactl set-sink-volume @DEFAULT_SINK@ -5%"),
+        (modifiers: [], key: "XF86AudioMute"): Spawn("pactl set-sink-mute @DEFAULT_SINK@ toggle"),
         (modifiers: [], key: "XF86MonBrightnessUp"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness"),
         (modifiers: [], key: "XF86MonBrightnessDown"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness"),
     },


### PR DESCRIPTION
This might be controversial or unnecessary, so I understand completely if this PR isn't desirable

I assume that xdg-desktop-portal-cosmic already relies on pipewire for screensharing, therefore users will likely already have pipewire-pulse, and therefore are more likely to have `pactl` available than `amixer`

I've tested this and the keybindings do have the intended effect on my system

An alternative could be to send messages to `cosmic-settings-daemon`, and implement volume controls in a more portal manner over there...