### PR TITLE
Change "xkb-config" to "xkb_config" in remaining place

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -515,8 +515,8 @@ fn update_input(state: &mut State) {
 fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut State) {
     for key in &keys {
         match key.as_str() {
-            "xkb-config" => {
-                let value = get_config::<XkbConfig>(&config, "xkb-config");
+            "xkb_config" => {
+                let value = get_config::<XkbConfig>(&config, "xkb_config");
                 for seat in state.common.seats().cloned().collect::<Vec<_>>().iter() {
                     if let Some(keyboard) = seat.get_keyboard() {
                         if let Err(err) = keyboard.set_xkb_config(state, xkb_config_to_wl(&value)) {


### PR DESCRIPTION
It seems these two lines were omitted in https://github.com/pop-os/cosmic-comp/pull/254, so it was reading the "xkb_config" settings at startup, then watching "xkb-config".

The other settings seem to be consistent.

This should fix https://github.com/pop-os/cosmic-comp/issues/285 (though it will also be necessary to edit "xkb_config", rather than the old file.