### PR TITLE
fix: bind media playback keys to `playerctl`

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -85,6 +85,14 @@
         (modifiers: [], key: "XF86AudioRaiseVolume"): Spawn("amixer sset Master 5%+"),
         (modifiers: [], key: "XF86AudioLowerVolume"): Spawn("amixer sset Master 5%-"),
         (modifiers: [], key: "XF86AudioMute"): Spawn("amixer sset Master toggle"),
+
+        (modifiers: [], key: "XF86AudioNext"): Spawn("playerctl next"),
+        (modifiers: [], key: "XF86AudioPlay"): Spawn("playerctl play-pause"),
+        (modifiers: [], key: "XF86AudioPrev"): Spawn("playerctl previous"),
+        (modifiers: [], key: "XF86AudioStop"): Spawn("playerctl stop"),
+        (modifiers: [], key: "XF86AudioRewind"): Spawn("playerctl position -10"),
+        (modifiers: [], key: "XF86AudioForward"): Spawn("playerctl position +10"),
+        
         (modifiers: [], key: "XF86MonBrightnessUp"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness"),
         (modifiers: [], key: "XF86MonBrightnessDown"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness"),
     },


### PR DESCRIPTION
- add default keybindings for `playerctl`: https://github.com/altdesktop/playerctl
- tested to confirm that playback in Spotify in Firefox in flatpak can be controlled with the keyboard (play/pause, stop, next, previous)
- alternatively, similar to https://github.com/pop-os/cosmic-comp/pull/283 , such functionality could be implemented across `xdg-desktop-portal-cosmic` (GlobalShortcuts portal) and `cosmic-settings-daemon` so that third-party `playerctl` is not required/involved