### PR TITLE
config.ron: Add alternative screenshot hotkey (Super + Shift + P)

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -81,6 +81,7 @@
         (modifiers: [Super]): Spawn("cosmic-launcher"),
 
         (modifiers: [], key: "Print"): Spawn("cosmic-screenshot"),
+        (modifiers: [Super, Shift], key: "P"): Spawn("cosmic-screenshot"),
 
         (modifiers: [], key: "XF86AudioRaiseVolume"): Spawn("amixer sset Master 5%+"),
         (modifiers: [], key: "XF86AudioLowerVolume"): Spawn("amixer sset Master 5%-"),


### PR DESCRIPTION
This commit adds ~~Super + Shift + S~~ Super + Shift + P as a screenshot hotkey. Some computers (Macbooks, some ASUS laptops, etc) do not have a dedicated Print key. This ensures they can trigger a screenshot without opening a terminal to call cosmic-screenshot.