### PR TITLE
fix(stack): set correct colors for light theme

### DIFF
--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -861,7 +861,9 @@ impl Program for CosmicStackInternal {
                 theme::Container::custom(|theme| iced_widget::container::Appearance {
                     icon_color: Some(Color::from(theme.cosmic().background.on)),
                     text_color: Some(Color::from(theme.cosmic().background.on)),
-                    background: Some(Background::Color(theme.cosmic().palette.neutral_3.into())),
+                    background: Some(Background::Color(tab::primary_container_color(
+                        theme.cosmic(),
+                    ))),
                     border_radius: BorderRadius::from([8.0, 8.0, 0.0, 0.0]),
                     border_width: 0.0,
                     border_color: Color::TRANSPARENT,

--- a/src/shell/element/stack/tab.rs
+++ b/src/shell/element/stack/tab.rs
@@ -225,17 +225,12 @@ impl<Message: TabMessage + 'static> Tab<Message> {
                 .padding([2, 4])
                 .center_y()
                 .into(),
-            cosmic::Element::<Message>::new(
-                tab_text(self.title)
-                    .font(self.font)
-                    .font_size(14.0)
-                    .background(
-                        self.background_theme
-                            .background_color(&cosmic::theme::active()),
-                    )
-                    .height(Length::Fill)
-                    .width(Length::Fill),
-            ),
+            tab_text(self.title)
+                .font(self.font)
+                .font_size(14.0)
+                .height(Length::Fill)
+                .width(Length::Fill)
+                .into(),
             close_button
                 .apply(widget::container)
                 .height(Length::Fill)

--- a/src/shell/element/stack/tab_text.rs
+++ b/src/shell/element/stack/tab_text.rs
@@ -1,53 +1,63 @@
+use std::hash::{Hash, Hasher};
+
 use cosmic::{
-    iced::Element,
+    iced::{alignment, Point},
     iced_core::{
         gradient,
         layout::{Layout, Limits, Node},
         mouse::Cursor,
         renderer::{self, Renderer as IcedRenderer},
-        widget::{Tree, Widget},
-        Background, Color, Degrees, Gradient, Length, Point, Rectangle, Size,
+        text::{LineHeight, Paragraph, Renderer as TextRenderer, Shaping},
+        widget::{tree, Tree, Widget},
+        Background, Color, Degrees, Gradient, Length, Rectangle, Size, Text,
     },
-    iced_widget::text::StyleSheet as TextStyleSheet,
 };
 
-pub struct TabText<'a, Message, Renderer>
-where
-    Renderer: IcedRenderer,
-    Renderer::Theme: TextStyleSheet,
-{
-    text: Element<'a, Message, Renderer>,
+/// Text in a stack tab with an overflow gradient.
+pub fn tab_text(text: String) -> TabText {
+    TabText::new(text, Color::TRANSPARENT)
+}
+
+struct LocalState {
+    text_hash: u64,
+    paragraph: <cosmic::Renderer as TextRenderer>::Paragraph,
+    overflowed: bool,
+}
+
+/// Text in a stack tab with an overflow gradient.
+pub struct TabText {
+    text: String,
     background: Color,
+    font: cosmic::font::Font,
+    font_size: f32,
     height: Length,
     width: Length,
 }
 
-pub fn tab_text<'a, Message, Renderer>(
-    text: impl Into<Element<'a, Message, Renderer>>,
-) -> TabText<'a, Message, Renderer>
-where
-    Renderer: IcedRenderer,
-    Renderer::Theme: TextStyleSheet,
-{
-    TabText::new(text, Color::TRANSPARENT)
-}
-
-impl<'a, Message, Renderer> TabText<'a, Message, Renderer>
-where
-    Renderer: IcedRenderer,
-    Renderer::Theme: TextStyleSheet,
-{
-    pub fn new(text: impl Into<Element<'a, Message, Renderer>>, background: Color) -> Self {
+impl TabText {
+    pub fn new(text: String, background: Color) -> Self {
         TabText {
             width: Length::Shrink,
             height: Length::Shrink,
             background,
-            text: text.into(),
+            font: cosmic::font::DEFAULT,
+            font_size: 14.0,
+            text,
         }
     }
 
     pub fn background(mut self, background: Color) -> Self {
         self.background = background;
+        self
+    }
+
+    pub fn font(mut self, font: cosmic::font::Font) -> Self {
+        self.font = font;
+        self
+    }
+
+    pub fn font_size(mut self, font_size: f32) -> Self {
+        self.font_size = font_size;
         self
     }
 
@@ -62,13 +72,40 @@ where
         self.height = height;
         self
     }
+
+    fn create_hash(&self) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.text.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn create_paragraph(&self) -> <cosmic::Renderer as TextRenderer>::Paragraph {
+        <cosmic::Renderer as TextRenderer>::Paragraph::with_text(Text {
+            content: &self.text,
+            size: cosmic::iced_core::Pixels(self.font_size),
+            bounds: Size::INFINITY,
+            font: self.font,
+            horizontal_alignment: alignment::Horizontal::Left,
+            vertical_alignment: alignment::Vertical::Center,
+            shaping: Shaping::Advanced,
+            line_height: LineHeight::default(),
+        })
+    }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer> for TabText<'a, Message, Renderer>
-where
-    Renderer: IcedRenderer,
-    Renderer::Theme: TextStyleSheet,
-{
+impl<Message> Widget<Message, cosmic::Renderer> for TabText {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<LocalState>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(LocalState {
+            text_hash: self.create_hash(),
+            paragraph: self.create_paragraph(),
+            overflowed: false,
+        })
+    }
+
     fn width(&self) -> Length {
         self.width
     }
@@ -76,86 +113,77 @@ where
         self.height
     }
 
-    fn children(&self) -> Vec<Tree> {
-        vec![Tree::new(&self.text)]
+    fn layout(&self, tree: &mut Tree, _renderer: &cosmic::Renderer, limits: &Limits) -> Node {
+        let limits = limits.width(self.width).height(self.height);
+
+        let state = tree.state.downcast_mut::<LocalState>();
+        let text_bounds = state.paragraph.min_bounds();
+        state.overflowed = limits.max().width < text_bounds.width;
+        let actual_size = limits.resolve(text_bounds);
+
+        Node::new(actual_size)
     }
 
     fn diff(&mut self, tree: &mut Tree) {
-        tree.diff_children(std::slice::from_mut(&mut self.text))
-    }
-
-    fn layout(&self, tree: &mut Tree, renderer: &Renderer, limits: &Limits) -> Node {
-        let limits = limits.width(self.width).height(self.height);
-        let child_limits = Limits::new(
-            Size::new(limits.min().width, limits.min().height - 4.),
-            Size::new(limits.max().width * 2., limits.max().height - 4.),
-        );
-        let mut content =
-            self.text
-                .as_widget()
-                .layout(&mut tree.children[0], renderer, &child_limits);
-        content.move_to(Point::new(0., 2.));
-        let size = limits.resolve(content.size());
-
-        Node::with_children(size, vec![content])
+        // If the text changes, update the paragraph.
+        let state = tree.state.downcast_mut::<LocalState>();
+        let text_hash = self.create_hash();
+        if state.text_hash != text_hash {
+            state.text_hash = text_hash;
+            state.paragraph = self.create_paragraph();
+        }
     }
 
     fn draw(
         &self,
         tree: &Tree,
-        renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        renderer: &mut cosmic::Renderer,
+        _theme: &cosmic::Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
-        cursor: Cursor,
+        _cursor: Cursor,
         _viewport: &Rectangle,
     ) {
         let bounds = layout.bounds();
-        let content_layout = layout.children().next().unwrap();
+        let state = tree.state.downcast_ref::<LocalState>();
 
         renderer.with_layer(bounds, |renderer| {
-            self.text.as_widget().draw(
-                &tree.children[0],
-                renderer,
-                theme,
-                style,
-                content_layout,
-                cursor,
-                &bounds,
+            renderer.fill_paragraph(
+                &state.paragraph,
+                Point::new(bounds.x, bounds.y + bounds.height / 2.0),
+                style.text_color,
+                bounds,
             );
         });
 
-        let gradient_bounds = Rectangle {
-            x: (bounds.x + bounds.width - 24.).max(bounds.x),
-            width: 24.0_f32.min(bounds.width),
-            ..bounds
-        };
+        if state.overflowed {
+            let gradient_bounds = Rectangle {
+                x: (bounds.x + bounds.width - 24.).max(bounds.x),
+                width: 24.0_f32.min(bounds.width),
+                ..bounds
+            };
 
-        let mut transparent_background = self.background;
-        transparent_background.a = 0.0;
-        renderer.fill_quad(
-            renderer::Quad {
-                bounds: gradient_bounds,
-                border_radius: 0.0.into(),
-                border_width: 0.0,
-                border_color: Color::TRANSPARENT,
-            },
-            Background::Gradient(Gradient::Linear(
-                gradient::Linear::new(Degrees(90.))
-                    .add_stop(0.0, transparent_background)
-                    .add_stop(1.0, self.background),
-            )),
-        );
+            let mut transparent_background = self.background;
+            transparent_background.a = 0.0;
+            renderer.fill_quad(
+                renderer::Quad {
+                    bounds: gradient_bounds,
+                    border_radius: 0.0.into(),
+                    border_width: 0.0,
+                    border_color: Color::TRANSPARENT,
+                },
+                Background::Gradient(Gradient::Linear(
+                    gradient::Linear::new(Degrees(90.))
+                        .add_stop(0.0, transparent_background)
+                        .add_stop(1.0, self.background),
+                )),
+            );
+        }
     }
 }
 
-impl<'a, Message, Renderer> Into<Element<'a, Message, Renderer>> for TabText<'a, Message, Renderer>
-where
-    Renderer: IcedRenderer + 'a,
-    Renderer::Theme: TextStyleSheet,
-    Message: 'a,
-{
-    fn into(self) -> Element<'a, Message, Renderer> {
-        Element::new(self)
+impl<Message: 'static> From<TabText> for cosmic::Element<'_, Message> {
+    fn from(value: TabText) -> Self {
+        Self::new(value)
     }
 }

--- a/src/shell/element/stack/tab_text.rs
+++ b/src/shell/element/stack/tab_text.rs
@@ -131,7 +131,7 @@ where
             ..bounds
         };
 
-        let mut transparent_background = self.background.clone();
+        let mut transparent_background = self.background;
         transparent_background.a = 0.0;
         renderer.fill_quad(
             renderer::Quad {

--- a/src/shell/element/stack/tab_text.rs
+++ b/src/shell/element/stack/tab_text.rs
@@ -141,7 +141,7 @@ where
                 border_color: Color::TRANSPARENT,
             },
             Background::Gradient(Gradient::Linear(
-                gradient::Linear::new(Degrees(180.))
+                gradient::Linear::new(Degrees(90.))
                     .add_stop(0.0, transparent_background)
                     .add_stop(1.0, self.background),
             )),

--- a/src/shell/element/stack/tab_text.rs
+++ b/src/shell/element/stack/tab_text.rs
@@ -15,7 +15,7 @@ use cosmic::{
 
 /// Text in a stack tab with an overflow gradient.
 pub fn tab_text(text: String) -> TabText {
-    TabText::new(text, Color::TRANSPARENT)
+    TabText::new(text)
 }
 
 struct LocalState {
@@ -27,7 +27,6 @@ struct LocalState {
 /// Text in a stack tab with an overflow gradient.
 pub struct TabText {
     text: String,
-    background: Color,
     font: cosmic::font::Font,
     font_size: f32,
     height: Length,
@@ -35,20 +34,14 @@ pub struct TabText {
 }
 
 impl TabText {
-    pub fn new(text: String, background: Color) -> Self {
+    pub fn new(text: String) -> Self {
         TabText {
             width: Length::Shrink,
             height: Length::Shrink,
-            background,
             font: cosmic::font::DEFAULT,
             font_size: 14.0,
             text,
         }
-    }
-
-    pub fn background(mut self, background: Color) -> Self {
-        self.background = background;
-        self
     }
 
     pub fn font(mut self, font: cosmic::font::Font) -> Self {
@@ -138,7 +131,7 @@ impl<Message> Widget<Message, cosmic::Renderer> for TabText {
         &self,
         tree: &Tree,
         renderer: &mut cosmic::Renderer,
-        _theme: &cosmic::Theme,
+        theme: &cosmic::Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: Cursor,
@@ -157,25 +150,27 @@ impl<Message> Widget<Message, cosmic::Renderer> for TabText {
         });
 
         if state.overflowed {
-            let gradient_bounds = Rectangle {
-                x: (bounds.x + bounds.width - 24.).max(bounds.x),
-                width: 24.0_f32.min(bounds.width),
-                ..bounds
+            let background = super::tab::primary_container_color(theme.cosmic());
+            let transparent = Color {
+                a: 0.0,
+                ..background
             };
 
-            let mut transparent_background = self.background;
-            transparent_background.a = 0.0;
             renderer.fill_quad(
                 renderer::Quad {
-                    bounds: gradient_bounds,
+                    bounds: Rectangle {
+                        x: (bounds.x + bounds.width - 24.).max(bounds.x),
+                        width: 24.0_f32.min(bounds.width),
+                        ..bounds
+                    },
                     border_radius: 0.0.into(),
                     border_width: 0.0,
                     border_color: Color::TRANSPARENT,
                 },
                 Background::Gradient(Gradient::Linear(
                     gradient::Linear::new(Degrees(90.))
-                        .add_stop(0.0, transparent_background)
-                        .add_stop(1.0, self.background),
+                        .add_stop(0.0, transparent)
+                        .add_stop(1.0, background),
                 )),
             );
         }

--- a/src/shell/element/stack/tabs.rs
+++ b/src/shell/element/stack/tabs.rs
@@ -340,7 +340,7 @@ where
 
         let mut nodes = self.elements[2..self.elements.len() - 2]
             .iter()
-            .zip(tree.children.iter_mut())
+            .zip(tree.children.iter_mut().skip(2))
             .map(|(tab, tab_tree)| tab.as_widget().layout(tab_tree, renderer, &child_limits))
             .collect::<Vec<_>>();
 

--- a/src/shell/element/stack/tabs.rs
+++ b/src/shell/element/stack/tabs.rs
@@ -526,8 +526,8 @@ where
             &theme::Container::custom(|theme| widget::container::Appearance {
                 icon_color: None,
                 text_color: None,
-                background: Some(Background::Color(Color::from(
-                    theme.cosmic().palette.neutral_3,
+                background: Some(Background::Color(super::tab::primary_container_color(
+                    theme.cosmic(),
                 ))),
                 border_radius: 0.0.into(),
                 border_width: 0.0,


### PR DESCRIPTION
Updates colors for the stack tabs to match the current values from the design documentation.
This will noticeably improve visibility of tabs when using a light theme.