### PR TITLE
feat: workspace switching touchpad gestures

### DIFF
--- a/src/backend/render/animations/mod.rs
+++ b/src/backend/render/animations/mod.rs
@@ -1,0 +1,1 @@
+pub mod spring;

--- a/src/backend/render/animations/spring.rs
+++ b/src/backend/render/animations/spring.rs
@@ -1,0 +1,138 @@
+// From Niri (GPL-3.0) https://github.com/YaLTeR/niri/tree/db49deb7fd2fbe805ceec060aa4dec65009ad7a7
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy)]
+pub struct SpringParams {
+    pub damping: f64,
+    pub mass: f64,
+    pub stiffness: f64,
+    pub epsilon: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Spring {
+    pub from: f64,
+    pub to: f64,
+    pub initial_velocity: f64,
+    pub params: SpringParams,
+}
+
+impl SpringParams {
+    pub fn new(damping_ratio: f64, stiffness: f64, epsilon: f64) -> Self {
+        let damping_ratio = damping_ratio.max(0.);
+        let stiffness = stiffness.max(0.);
+        let epsilon = epsilon.max(0.);
+
+        let mass = 1.;
+        let critical_damping = 2. * (mass * stiffness).sqrt();
+        let damping = damping_ratio * critical_damping;
+
+        Self {
+            damping,
+            mass,
+            stiffness,
+            epsilon,
+        }
+    }
+}
+
+impl Spring {
+    pub fn value_at(&self, t: Duration) -> f64 {
+        self.oscillate(t.as_secs_f64())
+    }
+
+    // Based on libadwaita (LGPL-2.1-or-later):
+    // https://gitlab.gnome.org/GNOME/libadwaita/-/blob/1.4.4/src/adw-spring-animation.c,
+    // which itself is based on (MIT):
+    // https://github.com/robb/RBBAnimation/blob/master/RBBAnimation/RBBSpringAnimation.m
+    /// Computes and returns the duration until the spring is at rest.
+    pub fn duration(&self) -> Duration {
+        const DELTA: f64 = 0.001;
+
+        let beta = self.params.damping / (2. * self.params.mass);
+
+        if beta.abs() <= f64::EPSILON || beta < 0. {
+            return Duration::MAX;
+        }
+
+        let omega0 = (self.params.stiffness / self.params.mass).sqrt();
+
+        // As first ansatz for the overdamped solution,
+        // and general estimation for the oscillating ones
+        // we take the value of the envelope when it's < epsilon.
+        let mut x0 = -self.params.epsilon.ln() / beta;
+
+        // f64::EPSILON is too small for this specific comparison, so we use
+        // f32::EPSILON even though it's doubles.
+        if (beta - omega0).abs() <= f64::from(f32::EPSILON) || beta < omega0 {
+            return Duration::from_secs_f64(x0);
+        }
+
+        // Since the overdamped solution decays way slower than the envelope
+        // we need to use the value of the oscillation itself.
+        // Newton's root finding method is a good candidate in this particular case:
+        // https://en.wikipedia.org/wiki/Newton%27s_method
+        let mut y0 = self.oscillate(x0);
+        let m = (self.oscillate(x0 + DELTA) - y0) / DELTA;
+
+        let mut x1 = (self.to - y0 + m * x0) / m;
+        let mut y1 = self.oscillate(x1);
+
+        let mut i = 0;
+        while (self.to - y1).abs() > self.params.epsilon {
+            if i > 1000 {
+                return Duration::ZERO;
+            }
+
+            x0 = x1;
+            y0 = y1;
+
+            let m = (self.oscillate(x0 + DELTA) - y0) / DELTA;
+
+            x1 = (self.to - y0 + m * x0) / m;
+            y1 = self.oscillate(x1);
+            i += 1;
+        }
+
+        Duration::from_secs_f64(x1)
+    }
+
+    /// Returns the spring position at a given time in seconds.
+    fn oscillate(&self, t: f64) -> f64 {
+        let b = self.params.damping;
+        let m = self.params.mass;
+        let k = self.params.stiffness;
+        let v0 = self.initial_velocity;
+
+        let beta = b / (2. * m);
+        let omega0 = (k / m).sqrt();
+
+        let x0 = self.from - self.to;
+
+        let envelope = (-beta * t).exp();
+
+        // Solutions of the form C1*e^(lambda1*x) + C2*e^(lambda2*x)
+        // for the differential equation m*ẍ+b*ẋ+kx = 0
+
+        // f64::EPSILON is too small for this specific comparison, so we use
+        // f32::EPSILON even though it's doubles.
+        if (beta - omega0).abs() <= f64::from(f32::EPSILON) {
+            // Critically damped.
+            self.to + envelope * (x0 + (beta * x0 + v0) * t)
+        } else if beta < omega0 {
+            // Underdamped.
+            let omega1 = ((omega0 * omega0) - (beta * beta)).sqrt();
+
+            self.to
+                + envelope
+                    * (x0 * (omega1 * t).cos() + ((beta * x0 + v0) / omega1) * (omega1 * t).sin())
+        } else {
+            // Overdamped.
+            let omega2 = ((beta * beta) - (omega0 * omega0)).sqrt();
+
+            self.to
+                + envelope
+                    * (x0 * (omega2 * t).cosh() + ((beta * x0 + v0) / omega2) * (omega2 * t).sinh())
+        }
+    }
+}

--- a/src/input/gestures/mod.rs
+++ b/src/input/gestures/mod.rs
@@ -1,0 +1,176 @@
+use smithay::utils::{Logical, Point};
+use std::{collections::VecDeque, time::Duration};
+use tracing::trace;
+
+use crate::shell::Direction;
+
+const HISTORY_LIMIT: Duration = Duration::from_millis(150);
+const DECELERATION_TOUCHPAD: f64 = 0.997;
+
+#[derive(Debug, Clone, Copy)]
+pub struct SwipeEvent {
+    delta: f64,
+    timestamp: Duration,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SwipeAction {
+    NextWorkspace,
+    PrevWorkspace,
+}
+
+#[derive(Debug, Clone)]
+pub struct GestureState {
+    pub fingers: u32,
+    pub direction: Option<Direction>,
+    pub action: Option<SwipeAction>,
+    pub delta: f64,
+    // Delta tracking inspired by Niri (GPL-3.0) https://github.com/YaLTeR/niri/tree/v0.1.3
+    pub history: VecDeque<SwipeEvent>,
+}
+
+impl GestureState {
+    pub fn new(fingers: u32) -> Self {
+        GestureState {
+            fingers,
+            direction: None,
+            action: None,
+            delta: 0.0,
+            history: VecDeque::new(),
+        }
+    }
+
+    pub fn update(&mut self, movement: Point<f64, Logical>, timestamp: Duration) -> bool {
+        let first_update = self.direction.is_none();
+
+        if first_update {
+            // Find proper direction
+            self.direction = if movement.x.abs() > movement.y.abs() {
+                if movement.x > 0.0 {
+                    Some(Direction::Right)
+                } else {
+                    Some(Direction::Left)
+                }
+            } else {
+                if movement.y > 0.0 {
+                    Some(Direction::Down)
+                } else {
+                    Some(Direction::Up)
+                }
+            }
+        }
+
+        let delta = match self.direction {
+            Some(Direction::Left) => -movement.x,
+            Some(Direction::Right) => movement.x,
+            Some(Direction::Up) => -movement.y,
+            Some(Direction::Down) => movement.y,
+            None => 0.0,
+        };
+
+        self.push(delta, timestamp);
+        first_update
+    }
+
+    /// Pushes a new reading into the tracker.
+    fn push(&mut self, delta: f64, timestamp: Duration) {
+        // For the events that we care about, timestamps should always increase
+        // monotonically.
+        if let Some(last) = self.history.back() {
+            if timestamp < last.timestamp {
+                trace!(
+                    "ignoring event with timestamp {timestamp:?} earlier than last {:?}",
+                    last.timestamp
+                );
+                return;
+            }
+        }
+
+        self.history.push_back(SwipeEvent { delta, timestamp });
+        self.delta += delta;
+
+        self.trim_history();
+    }
+
+    /// Computes the current gesture velocity.
+    pub fn velocity(&self) -> f64 {
+        let (Some(first), Some(last)) = (self.history.front(), self.history.back()) else {
+            return 0.;
+        };
+
+        let total_time = (last.timestamp - first.timestamp).as_secs_f64();
+        if total_time == 0. {
+            return 0.;
+        }
+
+        let total_delta = self.history.iter().map(|event| event.delta).sum::<f64>();
+        total_delta / total_time
+    }
+
+    /// Computes the gesture end position after decelerating to a halt.
+    pub fn projected_end_pos(&self) -> f64 {
+        let vel = self.velocity();
+        self.delta - vel / (1000. * DECELERATION_TOUCHPAD.ln())
+    }
+
+    fn trim_history(&mut self) {
+        let Some(&SwipeEvent { timestamp, .. }) = self.history.back() else {
+            return;
+        };
+
+        while let Some(first) = self.history.front() {
+            if timestamp <= first.timestamp + HISTORY_LIMIT {
+                break;
+            }
+
+            let _ = self.history.pop_front();
+        }
+    }
+}
+
+impl Default for GestureState {
+    fn default() -> Self {
+        GestureState::new(0)
+    }
+}
+
+// rubber_band.rs from Niri (GPL-3.0) https://github.com/YaLTeR/niri/blob/db49deb7fd2fbe805ceec060aa4dec65009ad7a7/src/rubber_band.rs
+#[derive(Debug, Clone, Copy)]
+pub struct RubberBand {
+    pub stiffness: f64,
+    pub limit: f64,
+}
+
+impl RubberBand {
+    pub fn band(&self, x: f64) -> f64 {
+        let c = self.stiffness;
+        let d = self.limit;
+
+        (1. - (1. / (x * c / d + 1.))) * d
+    }
+
+    pub fn derivative(&self, x: f64) -> f64 {
+        let c = self.stiffness;
+        let d = self.limit;
+
+        c * d * d / (c * x + d).powi(2)
+    }
+
+    pub fn clamp(&self, min: f64, max: f64, x: f64) -> f64 {
+        let clamped = x.clamp(min, max);
+        let sign = if x < clamped { -1. } else { 1. };
+        let diff = (x - clamped).abs();
+
+        clamped + sign * self.band(diff)
+    }
+
+    pub fn clamp_derivative(&self, min: f64, max: f64, x: f64) -> f64 {
+        if min <= x && x <= max {
+            return 1.;
+        }
+
+        let clamped = x.clamp(min, max);
+        let diff = (x - clamped).abs();
+        self.derivative(diff)
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@
 use crate::{
     backend::{kms::KmsState, winit::WinitState, x11::X11State},
     config::{Config, OutputConfig},
-    input::Devices,
+    input::{gestures::GestureState, Devices},
     shell::{grabs::SeatMoveGrabState, Shell},
     utils::prelude::*,
     wayland::protocols::{
@@ -159,6 +159,7 @@ pub struct Common {
     pub clock: Clock<Monotonic>,
     pub should_stop: bool,
     pub local_offset: time::UtcOffset,
+    pub gesture_state: Option<GestureState>,
 
     pub theme: cosmic::Theme,
 
@@ -423,6 +424,7 @@ impl State {
 
                 clock,
                 should_stop: false,
+                gesture_state: None,
 
                 theme: cosmic::theme::system_preference(),
 

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -10,7 +10,7 @@ use smithay::{
 };
 
 use crate::{
-    shell::{CosmicSurface, Shell},
+    shell::{CosmicSurface, Shell, WorkspaceDelta},
     utils::prelude::*,
     wayland::protocols::{
         toplevel_info::ToplevelInfoHandler,
@@ -60,7 +60,11 @@ impl ToplevelManagementHandler for State {
                     .unwrap()
                     .clone();
 
-                let _ = self.common.shell.activate(&output, idx as usize); // TODO: Move pointer?
+                let _ = self.common.shell.activate(
+                    &output,
+                    idx as usize,
+                    WorkspaceDelta::new_shortcut(),
+                ); // TODO: Move pointer?
                 mapped.focus_window(window);
                 Common::set_focus(self, Some(&mapped.clone().into()), &seat, None);
                 return;

--- a/src/wayland/handlers/workspace.rs
+++ b/src/wayland/handlers/workspace.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
+    shell::WorkspaceDelta,
     state::ClientState,
     utils::prelude::*,
     wayland::protocols::workspace::{
@@ -38,7 +39,11 @@ impl WorkspaceHandler for State {
                     });
 
                     if let Some((output, idx)) = maybe {
-                        let _ = self.common.shell.activate(&output, idx); // TODO: move cursor?
+                        let _ = self.common.shell.activate(
+                            &output,
+                            idx,
+                            WorkspaceDelta::new_shortcut(),
+                        ); // TODO: move cursor?
                     }
                 }
                 Request::SetTilingState { workspace, state } => {


### PR DESCRIPTION
This PR implements the next workspace and previous workspace touchpad gestures.

To-do:

- [x] Cleanup/refactoring needed. I'll need some feedback on how it's currently implemented
- [x] ~~Fix a visual bug where the screen turns gray when letting go of the gesture in between workspaces~~
- [x] Factor in velocity possibly? If the gesture is let go at a fast velocity then always continue the switch workspaces action
- [x] Spring animations when letting go of gesture

Left for a future PR:
- [ ] Invalid gestures (i.e. trying to switch to a workspace that doesn't exist, rubber banding, etc.)

Implementation details (OUTDATED):

* A new enum WorkspaceDelta is created (name can be changed) that can have either an Instant (with optional offset) or a delta from 0.0 to 1.0.
* A new tuple is added to State::Common called gesture_state which contains the number of fingers used, the total delta, and the direction the gesture is in.
* New constants GESTURE_MAX_LENGTH and GESTURE_THRESHOLD
  * GESTURE_MAX_LENGTH is the maximum length of the gesture that moves the screen
  * GESTURE_THRESHOLD is the percentage of the maximum length required to complete the workspace switch
* New functions in Shell that help update deltas for workspaces
