### PR TITLE
fix: Avoid crash on malformed keymap config

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -227,10 +227,19 @@ impl Config {
             }
         }
 
-        StaticConfig {
-            key_bindings: HashMap::new(),
-            data_control_enabled: false,
-        }
+        info!("No config found, consider installing a config file. Using default mapping.");
+
+        let mut config = ron::from_str(include_str!("../../config.ron")).unwrap_or_else(|err| {
+            debug!("Failed to load internal default config: {}", err);
+            StaticConfig {
+                // Small usefull keybindings by default
+                key_bindings: HashMap::new(),
+                data_control_enabled: false,
+            }
+        });
+
+        key_bindings::add_default_bindings(&mut config.key_bindings, workspace_layout);
+        config
     }
 
     fn load_dynamic(xdg: Option<&xdg::BaseDirectories>) -> DynamicConfig {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -232,7 +232,7 @@ impl Config {
         let mut config = ron::from_str(include_str!("../../config.ron")).unwrap_or_else(|err| {
             debug!("Failed to load internal default config: {}", err);
             StaticConfig {
-                // Small usefull keybindings by default
+                // Small useful keybindings by default
                 key_bindings: HashMap::new(),
                 data_control_enabled: false,
             }


### PR DESCRIPTION
I was testing cosmic DE and while configuring the keymaps I accidentally broke the keymap config file.
This makes cosmic-comp to crash and you must go through another desktop environment to change the config and fix it.
I think it's better to log the error and skip the file.

Also I was having a specific issue when installing from cosmic-epoch, they are no keymaps by default when no config is found. The second commit adds the default `config.ron` keymaps if no config file is found. It is a specific issue so I don't know if you want that.

Thanks for all of your amazing work, can't wait to see the alpha.
Also love the blog posts, they are really well made.