### PR TITLE
feat: drag regions for maximize and half tiling

### DIFF
--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -108,6 +108,7 @@ pub enum Usage {
     MoveGrabIndicator,
     FocusIndicator,
     PotentialGroupIndicator,
+    SnappingIndicator,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
this pr enables dragging the mouse to the output edges to maximize, or half tile in any direction

* ~~right now only maximize works, can't figure out why the half tiling isn't working~~ **fixed**
* ~~currently rendering an outline, not a shaded region, I'm looking for how to render a shaded region instead~~
* ~~the shaded region covers the whole output, not just the area between panels~~ **fixed**
* ~the drag regions don't extend into the panels, making it kind of awkward to maximize when there is a top panel for example~ **fixed**


https://github.com/pop-os/cosmic-comp/assets/56272643/32f0d6a0-c164-4f3b-91af-60db6c0b43aa


