### PR TITLE
Add the XF86AudioMicMute keyboard event to config.ron

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -85,6 +85,7 @@
         (modifiers: [], key: "XF86AudioRaiseVolume"): Spawn("amixer sset Master 5%+"),
         (modifiers: [], key: "XF86AudioLowerVolume"): Spawn("amixer sset Master 5%-"),
         (modifiers: [], key: "XF86AudioMute"): Spawn("amixer sset Master toggle"),
+        (modifiers: [], key: "XF86AudioMicMute"): Spawn("amixer sset Capture toggle"),
         (modifiers: [], key: "XF86MonBrightnessUp"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness"),
         (modifiers: [], key: "XF86MonBrightnessDown"): Spawn("busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness"),
     },


### PR DESCRIPTION
This adds the XF86AudioMicMute keyboard event to config.ron, pretty simple.