### PR TITLE
input: Rework PointerFocus to operate directly on WlSurface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,20 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
+ "bitflags 2.4.2",
+ "log",
+ "polling 3.3.2",
+ "rustix 0.38.30",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
  "async-task",
  "bitflags 2.4.2",
  "log",
@@ -563,7 +577,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
 dependencies = [
- "calloop",
+ "calloop 0.12.4",
  "rustix 0.38.30",
  "wayland-backend",
  "wayland-client",
@@ -827,7 +841,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.4.2",
  "bytemuck",
- "calloop",
+ "calloop 0.13.0",
  "cosmic-comp-config",
  "cosmic-config",
  "cosmic-protocols",
@@ -887,10 +901,10 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "atomicwrites",
- "calloop",
+ "calloop 0.13.0",
  "cosmic-config-derive",
  "dirs",
  "iced_futures",
@@ -905,7 +919,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -926,7 +940,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.11.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#b08676909f882f553ab574601b35b58276a52458"
+source = "git+https://github.com/pop-os/cosmic-text.git#ff5501d9a36e51c50d908413caf7632d8f7533b7"
 dependencies = [
  "bitflags 2.4.2",
  "fontdb",
@@ -948,7 +962,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2296,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2310,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "bitflags 1.3.2",
  "log",
@@ -2328,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "futures",
  "iced_core",
@@ -2340,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2364,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2376,7 +2390,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2387,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2397,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2414,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2433,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -2763,7 +2777,7 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#d02a4fefff319a3bd20936f9be30c4913bf49bab"
+source = "git+https://github.com/pop-os/libcosmic/#cc439b2ceaf41226ab86416ae0ad3651c9a6e10a"
 dependencies = [
  "apply",
  "chrono",
@@ -4491,12 +4505,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=c17297b#c17297b68e8bc761ebddf6900926d78b19a5d8d1"
+source = "git+https://github.com/smithay//smithay?rev=e5f0068#e5f006818df7ebb92d206985f45e713ba1e9c1c9"
 dependencies = [
  "appendlist",
  "ash",
  "bitflags 2.4.2",
- "calloop",
+ "calloop 0.13.0",
  "cc",
  "cgmath",
  "cursor-icon",
@@ -4546,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
 dependencies = [
  "bitflags 2.4.2",
- "calloop",
+ "calloop 0.12.4",
  "calloop-wayland-source",
  "cursor-icon",
  "libc",
@@ -6033,7 +6047,7 @@ dependencies = [
  "atomic-waker",
  "bitflags 2.4.2",
  "bytemuck",
- "calloop",
+ "calloop 0.12.4",
  "cfg_aliases 0.1.1",
  "core-foundation",
  "core-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 anyhow = {version = "1.0.51", features = ["backtrace"]}
 bitflags = "2.4"
 bytemuck = "1.12"
-calloop = {version = "0.12.2", features = ["executor"]}
+calloop = {version = "0.13.0", features = ["executor"]}
 cosmic-comp-config = {path = "cosmic-comp-config"}
 cosmic-config = {git = "https://github.com/pop-os/libcosmic/", features = ["calloop", "macro"]}
 cosmic-protocols = {git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"]}
@@ -117,4 +117,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = {git = "https://github.com/smithay//smithay", rev = "c17297b"}
+smithay = {git = "https://github.com/smithay//smithay", rev = "e5f0068"}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -5,7 +5,10 @@ use crate::{
     config::{xkb_config_to_wl, Action, Config, KeyModifiers, KeyPattern},
     input::gestures::{GestureState, SwipeAction},
     shell::{
-        focus::{target::PointerFocusTarget, FocusDirection},
+        focus::{
+            target::{KeyboardFocusTarget, PointerFocusTarget},
+            FocusDirection,
+        },
         grabs::{ResizeEdge, SeatMenuGrabState, SeatMoveGrabState},
         layout::{
             floating::ResizeGrabMarker,
@@ -32,7 +35,10 @@ use smithay::{
         TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState,
         TouchEvent,
     },
-    desktop::{layer_map_for_output, space::SpaceElement, WindowSurfaceType},
+    desktop::{
+        layer_map_for_output, space::SpaceElement, utils::under_from_surface_tree,
+        WindowSurfaceType,
+    },
     input::{
         keyboard::{FilterResult, KeysymHandle, LedState, XkbConfig},
         pointer::{
@@ -726,11 +732,15 @@ impl State {
                                 ptr.frame(self);
                                 return;
                             }
-                            if let PointerFocusTarget::Element(element) = surface {
-                                //if !element.is_in_input_region(&(position.to_i32_round() - *surface_loc).to_f64()) {
-                                if !element.is_in_input_region(
-                                    &(position.as_logical() - surface_loc.to_f64()),
-                                ) {
+                            if let PointerFocusTarget::WlSurface(surface) = surface {
+                                if under_from_surface_tree(
+                                    surface,
+                                    position.as_logical() - surface_loc.to_f64(),
+                                    (0, 0),
+                                    WindowSurfaceType::ALL,
+                                )
+                                .is_some()
+                                {
                                     ptr.frame(self);
                                     return;
                                 }
@@ -907,7 +917,7 @@ impl State {
 
                             let pos = seat.get_pointer().unwrap().current_location().as_global();
                             let relative_pos = pos.to_local(&output);
-                            let mut under = None;
+                            let mut under: Option<KeyboardFocusTarget> = None;
 
                             if let Some(session_lock) = self.common.shell.session_lock.as_ref() {
                                 under = session_lock
@@ -968,7 +978,7 @@ impl State {
                                 if !done {
                                     // Don't check override redirect windows, because we don't set keyboard focus to them explicitly.
                                     // These cases are handled by the XwaylandKeyboardGrab.
-                                    if let Some((target, _)) =
+                                    if let Some(target) =
                                         self.common.shell.element_under(pos, &output)
                                     {
                                         under = Some(target);
@@ -1003,12 +1013,7 @@ impl State {
                                     }
                                 }
                             }
-                            Common::set_focus(
-                                self,
-                                under.and_then(|target| target.try_into().ok()).as_ref(),
-                                &seat,
-                                Some(serial),
-                            );
+                            Common::set_focus(self, under.as_ref(), &seat, Some(serial));
                         }
                     } else {
                         if let OverviewMode::Started(Trigger::Pointer(action_button), _) =
@@ -2291,7 +2296,7 @@ impl State {
         if let Some(session_lock) = session_lock {
             return session_lock.surfaces.get(output).map(|surface| {
                 (
-                    PointerFocusTarget::LockSurface(surface.clone()),
+                    PointerFocusTarget::WlSurface(surface.wl_surface().clone()),
                     output_geo.loc,
                 )
             });
@@ -2301,24 +2306,33 @@ impl State {
             let layers = layer_map_for_output(output);
             if let Some(layer) = layers.layer_under(WlrLayer::Overlay, relative_pos.as_logical()) {
                 let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-                if layer
-                    .surface_under(
-                        relative_pos.as_logical() - layer_loc.to_f64(),
-                        WindowSurfaceType::ALL,
-                    )
-                    .is_some()
-                {
-                    return Some((layer.clone().into(), output_geo.loc + layer_loc.as_global()));
+                if let Some((wl_surface, surface_loc)) = layer.surface_under(
+                    relative_pos.as_logical() - layer_loc.to_f64(),
+                    WindowSurfaceType::ALL,
+                ) {
+                    return Some((
+                        wl_surface.into(),
+                        output_geo.loc + layer_loc.as_global() + surface_loc.as_global(),
+                    ));
                 }
             }
-            if let Some(or) = shell.override_redirect_windows.iter().find(|or| {
-                or.is_in_input_region(
-                    &(global_pos.as_logical() - X11Surface::geometry(*or).loc.to_f64()),
-                )
-            }) {
-                return Some((or.clone().into(), X11Surface::geometry(or).loc.as_global()));
+            if let Some((surface, geo)) = shell
+                .override_redirect_windows
+                .iter()
+                .find(|or| {
+                    or.is_in_input_region(
+                        &(global_pos.as_logical() - X11Surface::geometry(*or).loc.to_f64()),
+                    )
+                })
+                .and_then(|or| {
+                    or.wl_surface()
+                        .map(|surface| (surface, X11Surface::geometry(or).loc.as_global()))
+                })
+            {
+                return Some((surface.into(), geo));
             }
-            Some((window.clone().into(), output_geo.loc))
+            PointerFocusTarget::under_surface(window, relative_pos.as_logical())
+                .map(|(target, surface_loc)| (target, output_geo.loc + surface_loc.as_global()))
         } else {
             {
                 let layers = layer_map_for_output(output);
@@ -2327,28 +2341,33 @@ impl State {
                     .or_else(|| layers.layer_under(WlrLayer::Top, relative_pos.as_logical()))
                 {
                     let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-                    if layer
-                        .surface_under(
-                            relative_pos.as_logical() - layer_loc.to_f64(),
-                            WindowSurfaceType::ALL,
-                        )
-                        .is_some()
-                    {
+                    if let Some((wl_surface, surface_loc)) = layer.surface_under(
+                        relative_pos.as_logical() - layer_loc.to_f64(),
+                        WindowSurfaceType::ALL,
+                    ) {
                         return Some((
-                            layer.clone().into(),
-                            output_geo.loc + layer_loc.as_global(),
+                            wl_surface.into(),
+                            output_geo.loc + layer_loc.as_global() + surface_loc.as_global(),
                         ));
                     }
                 }
             }
-            if let Some(or) = shell.override_redirect_windows.iter().find(|or| {
-                or.is_in_input_region(
-                    &(global_pos.as_logical() - X11Surface::geometry(*or).loc.to_f64()),
-                )
-            }) {
-                return Some((or.clone().into(), X11Surface::geometry(or).loc.as_global()));
+            if let Some((surface, geo)) = shell
+                .override_redirect_windows
+                .iter()
+                .find(|or| {
+                    or.is_in_input_region(
+                        &(global_pos.as_logical() - X11Surface::geometry(*or).loc.to_f64()),
+                    )
+                })
+                .and_then(|or| {
+                    or.wl_surface()
+                        .map(|surface| (surface, X11Surface::geometry(or).loc.as_global()))
+                })
+            {
+                return Some((surface.into(), geo));
             }
-            if let Some((target, loc)) = shell.element_under(global_pos, output) {
+            if let Some((target, loc)) = shell.surface_under(global_pos, output) {
                 return Some((target, loc));
             }
             {
@@ -2358,16 +2377,13 @@ impl State {
                     .or_else(|| layers.layer_under(WlrLayer::Background, relative_pos.as_logical()))
                 {
                     let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-                    if layer
-                        .surface_under(
-                            relative_pos.as_logical() - layer_loc.to_f64(),
-                            WindowSurfaceType::ALL,
-                        )
-                        .is_some()
-                    {
+                    if let Some((wl_surface, surface_loc)) = layer.surface_under(
+                        relative_pos.as_logical() - layer_loc.to_f64(),
+                        WindowSurfaceType::ALL,
+                    ) {
                         return Some((
-                            layer.clone().into(),
-                            output_geo.loc + layer_loc.as_global(),
+                            wl_surface.into(),
+                            output_geo.loc + layer_loc.as_global() + surface_loc.as_global(),
                         ));
                     }
                 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -732,7 +732,7 @@ impl State {
                                 ptr.frame(self);
                                 return;
                             }
-                            if let PointerFocusTarget::WlSurface(surface) = surface {
+                            if let PointerFocusTarget::WlSurface { surface, .. } = surface {
                                 if under_from_surface_tree(
                                     surface,
                                     position.as_logical() - surface_loc.to_f64(),
@@ -2296,7 +2296,10 @@ impl State {
         if let Some(session_lock) = session_lock {
             return session_lock.surfaces.get(output).map(|surface| {
                 (
-                    PointerFocusTarget::WlSurface(surface.wl_surface().clone()),
+                    PointerFocusTarget::WlSurface {
+                        surface: surface.wl_surface().clone(),
+                        toplevel: None,
+                    },
                     output_geo.loc,
                 )
             });
@@ -2311,7 +2314,10 @@ impl State {
                     WindowSurfaceType::ALL,
                 ) {
                     return Some((
-                        wl_surface.into(),
+                        PointerFocusTarget::WlSurface {
+                            surface: wl_surface,
+                            toplevel: None,
+                        },
                         output_geo.loc + layer_loc.as_global() + surface_loc.as_global(),
                     ));
                 }
@@ -2329,7 +2335,13 @@ impl State {
                         .map(|surface| (surface, X11Surface::geometry(or).loc.as_global()))
                 })
             {
-                return Some((surface.into(), geo));
+                return Some((
+                    PointerFocusTarget::WlSurface {
+                        surface,
+                        toplevel: None,
+                    },
+                    geo,
+                ));
             }
             PointerFocusTarget::under_surface(window, relative_pos.as_logical())
                 .map(|(target, surface_loc)| (target, output_geo.loc + surface_loc.as_global()))
@@ -2346,7 +2358,10 @@ impl State {
                         WindowSurfaceType::ALL,
                     ) {
                         return Some((
-                            wl_surface.into(),
+                            PointerFocusTarget::WlSurface {
+                                surface: wl_surface,
+                                toplevel: None,
+                            },
                             output_geo.loc + layer_loc.as_global() + surface_loc.as_global(),
                         ));
                     }
@@ -2365,7 +2380,13 @@ impl State {
                         .map(|surface| (surface, X11Surface::geometry(or).loc.as_global()))
                 })
             {
-                return Some((surface.into(), geo));
+                return Some((
+                    PointerFocusTarget::WlSurface {
+                        surface,
+                        toplevel: None,
+                    },
+                    geo,
+                ));
             }
             if let Some((target, loc)) = shell.surface_under(global_pos, output) {
                 return Some((target, loc));
@@ -2382,7 +2403,10 @@ impl State {
                         WindowSurfaceType::ALL,
                     ) {
                         return Some((
-                            wl_surface.into(),
+                            PointerFocusTarget::WlSurface {
+                                surface: wl_surface,
+                                toplevel: None,
+                            },
                             output_geo.loc + layer_loc.as_global() + surface_loc.as_global(),
                         ));
                     }

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -18,12 +18,6 @@ use smithay::{
     },
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
-        pointer::{
-            AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent,
-            GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
-            GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent, MotionEvent,
-            PointerTarget, RelativeMotionEvent,
-        },
         Seat,
     },
     output::Output,
@@ -670,11 +664,22 @@ impl KeyboardTarget<State> for CosmicSurface {
         if self.0.is_x11() {
             keys = vec![];
         }
-        KeyboardTarget::enter(&self.0, seat, data, keys, serial)
+
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => {
+                KeyboardTarget::enter(toplevel.wl_surface(), seat, data, keys, serial)
+            }
+            WindowSurface::X11(x11) => KeyboardTarget::enter(x11, seat, data, keys, serial),
+        }
     }
 
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: smithay::utils::Serial) {
-        KeyboardTarget::leave(&self.0, seat, data, serial)
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => {
+                KeyboardTarget::leave(toplevel.wl_surface(), seat, data, serial)
+            }
+            WindowSurface::X11(x11) => KeyboardTarget::leave(x11, seat, data, serial),
+        }
     }
 
     fn key(
@@ -686,7 +691,14 @@ impl KeyboardTarget<State> for CosmicSurface {
         serial: smithay::utils::Serial,
         time: u32,
     ) {
-        KeyboardTarget::key(&self.0, seat, data, key, state, serial, time)
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => {
+                KeyboardTarget::key(toplevel.wl_surface(), seat, data, key, state, serial, time)
+            }
+            WindowSurface::X11(x11) => {
+                KeyboardTarget::key(x11, seat, data, key, state, serial, time)
+            }
+        }
     }
 
     fn modifiers(
@@ -696,110 +708,14 @@ impl KeyboardTarget<State> for CosmicSurface {
         modifiers: ModifiersState,
         serial: smithay::utils::Serial,
     ) {
-        KeyboardTarget::modifiers(&self.0, seat, data, modifiers, serial)
-    }
-}
-
-impl PointerTarget<State> for CosmicSurface {
-    fn enter(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {
-        PointerTarget::enter(&self.0, seat, data, event)
-    }
-
-    fn motion(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {
-        PointerTarget::motion(&self.0, seat, data, event)
-    }
-
-    fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {
-        PointerTarget::relative_motion(&self.0, seat, data, event)
-    }
-
-    fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {
-        PointerTarget::button(&self.0, seat, data, event)
-    }
-
-    fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {
-        PointerTarget::axis(&self.0, seat, data, frame)
-    }
-
-    fn frame(&self, seat: &Seat<State>, data: &mut State) {
-        PointerTarget::frame(&self.0, seat, data)
-    }
-
-    fn leave(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        serial: smithay::utils::Serial,
-        time: u32,
-    ) {
-        PointerTarget::leave(&self.0, seat, data, serial, time)
-    }
-
-    fn gesture_swipe_begin(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureSwipeBeginEvent,
-    ) {
-        PointerTarget::gesture_swipe_begin(&self.0, seat, data, event)
-    }
-
-    fn gesture_swipe_update(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureSwipeUpdateEvent,
-    ) {
-        PointerTarget::gesture_swipe_update(&self.0, seat, data, event)
-    }
-
-    fn gesture_swipe_end(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureSwipeEndEvent,
-    ) {
-        PointerTarget::gesture_swipe_end(&self.0, seat, data, event)
-    }
-
-    fn gesture_pinch_begin(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GesturePinchBeginEvent,
-    ) {
-        PointerTarget::gesture_pinch_begin(&self.0, seat, data, event)
-    }
-
-    fn gesture_pinch_update(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GesturePinchUpdateEvent,
-    ) {
-        PointerTarget::gesture_pinch_update(&self.0, seat, data, event)
-    }
-
-    fn gesture_pinch_end(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GesturePinchEndEvent,
-    ) {
-        PointerTarget::gesture_pinch_end(&self.0, seat, data, event)
-    }
-
-    fn gesture_hold_begin(
-        &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureHoldBeginEvent,
-    ) {
-        PointerTarget::gesture_hold_begin(&self.0, seat, data, event)
-    }
-
-    fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {
-        PointerTarget::gesture_hold_end(&self.0, seat, data, event)
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => {
+                KeyboardTarget::modifiers(toplevel.wl_surface(), seat, data, modifiers, serial)
+            }
+            WindowSurface::X11(x11) => {
+                KeyboardTarget::modifiers(x11, seat, data, modifiers, serial)
+            }
+        }
     }
 }
 

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -10,7 +10,6 @@ use crate::{
         iced::{IcedElement, Program},
         prelude::*,
     },
-    wayland::handlers::screencopy::SessionHolder,
 };
 use calloop::LoopHandle;
 use cosmic::{iced::Command, widget::mouse_area, Apply};
@@ -39,7 +38,7 @@ use smithay::{
     output::Output,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     render_elements,
-    utils::{Buffer as BufferCoords, IsAlive, Logical, Point, Rectangle, Serial, Size, Transform},
+    utils::{Buffer as BufferCoords, IsAlive, Logical, Point, Rectangle, Serial, Size},
     wayland::seat::WaylandFocus,
 };
 use std::{
@@ -50,7 +49,6 @@ use std::{
         atomic::{AtomicBool, AtomicU8, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
 };
 use wayland_backend::server::ObjectId;
 
@@ -221,7 +219,10 @@ impl CosmicWindow {
                 .surface_under(relative_pos, WindowSurfaceType::ALL)
                 .map(|(surface, surface_offset)| {
                     (
-                        PointerFocusTarget::WlSurface(surface),
+                        PointerFocusTarget::WlSurface {
+                            surface,
+                            toplevel: Some(p.window.clone().into()),
+                        },
                         offset + surface_offset,
                     )
                 })

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -1,6 +1,7 @@
 use crate::{
     backend::render::cursor::{CursorShape, CursorState},
     shell::{
+        focus::target::PointerFocusTarget,
         grabs::{ReleaseMode, ResizeEdge},
         Shell,
     },
@@ -24,7 +25,7 @@ use smithay::{
             ImportAll, ImportMem, Renderer,
         },
     },
-    desktop::space::SpaceElement,
+    desktop::{space::SpaceElement, WindowSurfaceType},
     input::{
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         pointer::{
@@ -97,7 +98,6 @@ impl fmt::Debug for CosmicWindowInternal {
 pub enum Focus {
     None,
     Header,
-    Window,
     ResizeTop,
     ResizeLeft,
     ResizeRight,
@@ -179,6 +179,54 @@ impl CosmicWindow {
 
     pub fn surface(&self) -> CosmicSurface {
         self.0.with_program(|p| p.window.clone())
+    }
+
+    pub fn focus_under(
+        &self,
+        mut relative_pos: Point<f64, Logical>,
+    ) -> Option<(PointerFocusTarget, Point<i32, Logical>)> {
+        self.0.with_program(|p| {
+            let mut offset = Point::from((0, 0));
+            let mut window_ui = None;
+            if p.has_ssd(false) {
+                let geo = p.window.geometry();
+
+                let point_i32 = relative_pos.to_i32_round::<i32>();
+                if (point_i32.x - geo.loc.x >= -RESIZE_BORDER && point_i32.x - geo.loc.x < 0)
+                    || (point_i32.y - geo.loc.y >= -RESIZE_BORDER && point_i32.y - geo.loc.y < 0)
+                    || (point_i32.x - geo.loc.x >= geo.size.w
+                        && point_i32.x - geo.loc.x < geo.size.w + RESIZE_BORDER)
+                    || (point_i32.y - geo.loc.y >= geo.size.h
+                        && point_i32.y - geo.loc.y < geo.size.h + SSD_HEIGHT + RESIZE_BORDER)
+                {
+                    window_ui = Some((
+                        PointerFocusTarget::WindowUI(self.clone()),
+                        Point::from((0, 0)),
+                    ));
+                }
+
+                if point_i32.y - geo.loc.y < SSD_HEIGHT {
+                    window_ui = Some((
+                        PointerFocusTarget::WindowUI(self.clone()),
+                        Point::from((0, 0)),
+                    ));
+                }
+
+                relative_pos.y -= SSD_HEIGHT as f64;
+                offset.y += SSD_HEIGHT;
+            }
+
+            p.window
+                .0
+                .surface_under(relative_pos, WindowSurfaceType::ALL)
+                .map(|(surface, surface_offset)| {
+                    (
+                        PointerFocusTarget::WlSurface(surface),
+                        offset + surface_offset,
+                    )
+                })
+                .or(window_ui)
+        })
     }
 
     pub fn contains_surface(&self, window: &CosmicSurface) -> bool {
@@ -452,30 +500,7 @@ impl SpaceElement for CosmicWindow {
         })
     }
     fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {
-        let mut point = *point;
-        self.0.with_program(|p| {
-            if p.has_ssd(false) {
-                let geo = p.window.geometry();
-
-                let point_i32 = point.to_i32_round::<i32>();
-                if (point_i32.x - geo.loc.x >= -RESIZE_BORDER && point_i32.x - geo.loc.x < 0)
-                    || (point_i32.y - geo.loc.y >= -RESIZE_BORDER && point_i32.y - geo.loc.y < 0)
-                    || (point_i32.x - geo.loc.x >= geo.size.w
-                        && point_i32.x - geo.loc.x < geo.size.w + RESIZE_BORDER)
-                    || (point_i32.y - geo.loc.y >= geo.size.h
-                        && point_i32.y - geo.loc.y < geo.size.h + SSD_HEIGHT + RESIZE_BORDER)
-                {
-                    return true;
-                }
-
-                if point_i32.y - geo.loc.y < SSD_HEIGHT {
-                    return true;
-                }
-
-                point.y -= SSD_HEIGHT as f64;
-            }
-            SpaceElement::is_in_input_region(&p.window, &point)
-        })
+        self.focus_under(*point).is_some()
     }
     fn set_activate(&self, activated: bool) {
         if self
@@ -575,7 +600,7 @@ impl KeyboardTarget<State> for CosmicWindow {
 impl PointerTarget<State> for CosmicWindow {
     fn enter(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {
         let mut event = event.clone();
-        if self.0.with_program(|p| {
+        self.0.with_program(|p| {
             if p.has_ssd(false) {
                 let geo = p.window.geometry();
                 let loc = event.location.to_i32_round::<i32>();
@@ -612,34 +637,7 @@ impl PointerTarget<State> for CosmicWindow {
                 } else if loc.y - geo.loc.y < SSD_HEIGHT {
                     (p.swap_focus(Focus::Header), CursorShape::Default)
                 } else {
-                    let focus = p.swap_focus(Focus::Window);
-                    assert_eq!(focus, Focus::None);
-
-                    let mut event = event.clone();
-                    event.location.y -= SSD_HEIGHT as f64;
-                    PointerTarget::enter(&p.window, seat, data, &event);
-
-                    for session in p.window.cursor_sessions() {
-                        session.set_cursor_pos(Some(
-                            event
-                                .location
-                                .to_buffer(
-                                    1.0,
-                                    Transform::Normal,
-                                    &p.window.geometry().size.to_f64(),
-                                )
-                                .to_i32_round(),
-                        ));
-                        if let Some((_, hotspot)) = seat.cursor_geometry(
-                            (0.0, 0.0),
-                            Duration::from_millis(event.time as u64).into(),
-                        ) {
-                            session.set_cursor_hotspot(hotspot);
-                        } else {
-                            session.set_cursor_hotspot((0, 0));
-                        }
-                    }
-                    return false;
+                    return;
                 };
 
                 assert_eq!(old_focus, Focus::None);
@@ -651,37 +649,16 @@ impl PointerTarget<State> for CosmicWindow {
                     .get::<RefCell<CursorImageStatus>>()
                     .unwrap();
                 *cursor_status.borrow_mut() = CursorImageStatus::default_named();
-                shape == CursorShape::Default
-            } else {
-                p.swap_focus(Focus::Window);
-                PointerTarget::enter(&p.window, seat, data, &event);
-                for session in p.window.cursor_sessions() {
-                    session.set_cursor_pos(Some(
-                        event
-                            .location
-                            .to_buffer(1.0, Transform::Normal, &p.window.geometry().size.to_f64())
-                            .to_i32_round(),
-                    ));
-                    if let Some((_, hotspot)) = seat.cursor_geometry(
-                        (0.0, 0.0),
-                        Duration::from_millis(event.time as u64).into(),
-                    ) {
-                        session.set_cursor_hotspot(hotspot);
-                    } else {
-                        session.set_cursor_hotspot((0, 0));
-                    }
-                }
-                false
             }
-        }) {
-            event.location -= self.0.with_program(|p| p.window.geometry().loc.to_f64());
-            PointerTarget::enter(&self.0, seat, data, &event)
-        }
+        });
+
+        event.location -= self.0.with_program(|p| p.window.geometry().loc.to_f64());
+        PointerTarget::enter(&self.0, seat, data, &event)
     }
 
     fn motion(&self, seat: &Seat<State>, data: &mut State, event: &MotionEvent) {
         let mut event = event.clone();
-        if let Some((previous, next)) = self.0.with_program(|p| {
+        self.0.with_program(|p| {
             if p.has_ssd(false) {
                 let geo = p.window.geometry();
                 let loc = event.location.to_i32_round::<i32>();
@@ -704,43 +681,10 @@ impl PointerTarget<State> for CosmicWindow {
                 } else if loc.y < SSD_HEIGHT {
                     (Focus::Header, CursorShape::Default)
                 } else {
-                    event.location.y -= SSD_HEIGHT as f64;
-
-                    let previous = p.swap_focus(Focus::Window);
-                    if previous != Focus::Window {
-                        PointerTarget::enter(&p.window, seat, data, &event);
-                    } else {
-                        PointerTarget::motion(&p.window, seat, data, &event);
-                    }
-
-                    for session in p.window.cursor_sessions() {
-                        session.set_cursor_pos(Some(
-                            event
-                                .location
-                                .to_buffer(
-                                    1.0,
-                                    Transform::Normal,
-                                    &p.window.geometry().size.to_f64(),
-                                )
-                                .to_i32_round(),
-                        ));
-                        if let Some((_, hotspot)) = seat.cursor_geometry(
-                            (0.0, 0.0),
-                            Duration::from_millis(event.time as u64).into(),
-                        ) {
-                            session.set_cursor_hotspot(hotspot);
-                        } else {
-                            session.set_cursor_hotspot((0, 0));
-                        }
-                    }
-
-                    return Some((previous, Focus::Window));
+                    return;
                 };
 
-                let previous = p.swap_focus(next);
-                if previous == Focus::Window {
-                    PointerTarget::leave(&p.window, seat, data, event.serial, event.time);
-                }
+                let _previous = p.swap_focus(next);
 
                 let cursor_state = seat.user_data().get::<CursorState>().unwrap();
                 cursor_state.set_shape(shape);
@@ -749,52 +693,19 @@ impl PointerTarget<State> for CosmicWindow {
                     .get::<RefCell<CursorImageStatus>>()
                     .unwrap();
                 *cursor_status.borrow_mut() = CursorImageStatus::default_named();
-
-                Some((previous, next))
-            } else {
-                p.swap_focus(Focus::Window);
-                PointerTarget::motion(&p.window, seat, data, &event);
-
-                for session in p.window.cursor_sessions() {
-                    session.set_cursor_pos(Some(
-                        event
-                            .location
-                            .to_buffer(1.0, Transform::Normal, &p.window.geometry().size.to_f64())
-                            .to_i32_round(),
-                    ));
-                    if let Some((_, hotspot)) = seat.cursor_geometry(
-                        (0.0, 0.0),
-                        Duration::from_millis(event.time as u64).into(),
-                    ) {
-                        session.set_cursor_hotspot(hotspot);
-                    } else {
-                        session.set_cursor_hotspot((0, 0));
-                    }
-                }
-
-                None
             }
-        }) {
-            event.location -= self.0.with_program(|p| p.window.geometry().loc.to_f64());
-            match (previous, next) {
-                (Focus::Header, Focus::Header) => {
-                    PointerTarget::motion(&self.0, seat, data, &event)
-                }
-                (_, Focus::Header) => PointerTarget::enter(&self.0, seat, data, &event),
-                (Focus::Header, _) => {
-                    PointerTarget::leave(&self.0, seat, data, event.serial, event.time)
-                }
-                _ => {}
-            };
-        }
+        });
+
+        event.location -= self.0.with_program(|p| p.window.geometry().loc.to_f64());
+        PointerTarget::motion(&self.0, seat, data, &event)
     }
 
-    fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::relative_motion(&p.window, seat, data, event)
-            }
-        })
+    fn relative_motion(
+        &self,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &RelativeMotionEvent,
+    ) {
     }
 
     fn button(&self, seat: &Seat<State>, data: &mut State, event: &ButtonEvent) {
@@ -805,9 +716,6 @@ impl PointerTarget<State> for CosmicWindow {
                 });
                 PointerTarget::button(&self.0, seat, data, event)
             }
-            Focus::Window => self
-                .0
-                .with_program(|p| PointerTarget::button(&p.window, seat, data, event)),
             Focus::None => {}
             x => {
                 let serial = event.serial;
@@ -830,7 +738,7 @@ impl PointerTarget<State> for CosmicWindow {
                             Focus::ResizeBottomRight => ResizeEdge::BOTTOM_RIGHT,
                             Focus::ResizeLeft => ResizeEdge::LEFT,
                             Focus::ResizeRight => ResizeEdge::RIGHT,
-                            Focus::Header | Focus::Window | Focus::None => unreachable!(),
+                            Focus::Header | Focus::None => unreachable!(),
                         },
                     )
                 });
@@ -841,9 +749,6 @@ impl PointerTarget<State> for CosmicWindow {
     fn axis(&self, seat: &Seat<State>, data: &mut State, frame: AxisFrame) {
         match self.0.with_program(|p| p.current_focus()) {
             Focus::Header => PointerTarget::axis(&self.0, seat, data, frame),
-            Focus::Window => self
-                .0
-                .with_program(|p| PointerTarget::axis(&p.window, seat, data, frame)),
             _ => {}
         }
     }
@@ -851,129 +756,81 @@ impl PointerTarget<State> for CosmicWindow {
     fn frame(&self, seat: &Seat<State>, data: &mut State) {
         match self.0.with_program(|p| p.current_focus()) {
             Focus::Header => PointerTarget::frame(&self.0, seat, data),
-            Focus::Window => self
-                .0
-                .with_program(|p| PointerTarget::frame(&p.window, seat, data)),
             _ => {}
         }
     }
 
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {
-        let previous = self.0.with_program(|p| {
-            for session in p.window.cursor_sessions() {
-                session.set_cursor_pos(None);
-            }
-
+        self.0.with_program(|p| {
             let cursor_state = seat.user_data().get::<CursorState>().unwrap();
             cursor_state.set_shape(CursorShape::Default);
-            p.swap_focus(Focus::None)
+            let _previous = p.swap_focus(Focus::None);
         });
-        match previous {
-            Focus::Header => PointerTarget::leave(&self.0, seat, data, serial, time),
-            Focus::Window => self
-                .0
-                .with_program(|p| PointerTarget::leave(&p.window, seat, data, serial, time)),
-            _ => {}
-        }
+        PointerTarget::leave(&self.0, seat, data, serial, time)
     }
 
     fn gesture_swipe_begin(
         &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureSwipeBeginEvent,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GestureSwipeBeginEvent,
     ) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_swipe_begin(&p.window, seat, data, event)
-            }
-        })
     }
 
     fn gesture_swipe_update(
         &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureSwipeUpdateEvent,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GestureSwipeUpdateEvent,
     ) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_swipe_update(&p.window, seat, data, event)
-            }
-        })
     }
 
     fn gesture_swipe_end(
         &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureSwipeEndEvent,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GestureSwipeEndEvent,
     ) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_swipe_end(&p.window, seat, data, event)
-            }
-        })
     }
 
     fn gesture_pinch_begin(
         &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GesturePinchBeginEvent,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GesturePinchBeginEvent,
     ) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_pinch_begin(&p.window, seat, data, event)
-            }
-        })
     }
 
     fn gesture_pinch_update(
         &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GesturePinchUpdateEvent,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GesturePinchUpdateEvent,
     ) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_pinch_update(&p.window, seat, data, event)
-            }
-        })
     }
 
     fn gesture_pinch_end(
         &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GesturePinchEndEvent,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GesturePinchEndEvent,
     ) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_pinch_end(&p.window, seat, data, event)
-            }
-        })
     }
 
     fn gesture_hold_begin(
         &self,
-        seat: &Seat<State>,
-        data: &mut State,
-        event: &GestureHoldBeginEvent,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GestureHoldBeginEvent,
     ) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_hold_begin(&p.window, seat, data, event)
-            }
-        })
     }
 
-    fn gesture_hold_end(&self, seat: &Seat<State>, data: &mut State, event: &GestureHoldEndEvent) {
-        self.0.with_program(|p| {
-            if !p.has_ssd(false) || p.current_focus() == Focus::Window {
-                PointerTarget::gesture_hold_end(&p.window, seat, data, event)
-            }
-        })
+    fn gesture_hold_end(
+        &self,
+        _seat: &Seat<State>,
+        _data: &mut State,
+        _event: &GestureHoldEndEvent,
+    ) {
     }
 }
 

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -266,21 +266,21 @@ impl Common {
                             .get::<PopupGrabData>()
                             .and_then(|x| x.take())
                         {
-                            if !popup_grab.has_ended() {
-                                if let Some(new) = popup_grab.current_grab() {
-                                    trace!("restore focus to previous popup grab");
-                                    if let Some(keyboard) = seat.get_keyboard() {
-                                        keyboard.set_focus(
-                                            state,
-                                            Some(new.clone()),
-                                            SERIAL_COUNTER.next_serial(),
-                                        );
-                                    }
-                                    ActiveFocus::set(&seat, Some(new));
-                                    seat.user_data()
+                                if !popup_grab.has_ended() {
+                                    if let Some(new) = popup_grab.current_grab() {
+                                        trace!("restore focus to previous popup grab");
+                                        if let Some(keyboard) = seat.get_keyboard() {
+                                            keyboard.set_focus(
+                                                state,
+                                                Some(new.clone()),
+                                                SERIAL_COUNTER.next_serial(),
+                                            );
+                                        }
+                                        ActiveFocus::set(&seat, Some(new));
+                                        seat.user_data()
                                         .get_or_insert::<PopupGrabData, _>(PopupGrabData::default)
-                                        .set(Some(popup_grab));
-                                    continue;
+                                            .set(Some(popup_grab));
+                                        continue;
                                 }
                             }
                         }

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -760,18 +760,24 @@ impl Drop for MoveGrab {
 
             if let Some((mapped, position)) = position {
                 let serial = SERIAL_COUNTER.next_serial();
-                pointer.motion(
-                    state,
-                    Some((
-                        PointerFocusTarget::from(mapped.clone()),
-                        position.as_logical() - window.geometry().loc,
-                    )),
-                    &MotionEvent {
-                        location: pointer.current_location(),
-                        serial,
-                        time: 0,
-                    },
-                );
+                let current_location = pointer.current_location();
+
+                if let Some((target, offset)) =
+                    mapped.focus_under(current_location - position.as_logical().to_f64())
+                {
+                    pointer.motion(
+                        state,
+                        Some((
+                            target,
+                            position.as_logical() - window.geometry().loc + offset,
+                        )),
+                        &MotionEvent {
+                            location: pointer.current_location(),
+                            serial,
+                            time: 0,
+                        },
+                    );
+                }
                 Common::set_focus(
                     state,
                     Some(&KeyboardFocusTarget::from(mapped)),

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -490,15 +490,22 @@ impl Workspace {
             .find(|e| e.windows().any(|(w, _)| &w == surface))
     }
 
-    pub fn element_under(
+    pub fn element_under(&mut self, location: Point<f64, Global>) -> Option<KeyboardFocusTarget> {
+        let location = location.to_local(&self.output);
+        self.floating_layer
+            .element_under(location)
+            .or_else(|| self.tiling_layer.element_under(location))
+    }
+
+    pub fn surface_under(
         &mut self,
         location: Point<f64, Global>,
         overview: OverviewMode,
     ) -> Option<(PointerFocusTarget, Point<i32, Global>)> {
         let location = location.to_local(&self.output);
         self.floating_layer
-            .element_under(location)
-            .or_else(|| self.tiling_layer.element_under(location, overview))
+            .surface_under(location)
+            .or_else(|| self.tiling_layer.surface_under(location, overview))
             .map(|(m, p)| (m, p.to_global(&self.output)))
     }
 

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -136,7 +136,7 @@ impl CompositorHandler for State {
                     }
                 }
             }
-        })
+        });
     }
 
     fn commit(&mut self, surface: &WlSurface) {

--- a/src/wayland/handlers/seat.rs
+++ b/src/wayland/handlers/seat.rs
@@ -19,6 +19,7 @@ use std::cell::RefCell;
 impl SeatHandler for State {
     type KeyboardFocus = KeyboardFocusTarget;
     type PointerFocus = PointerFocusTarget;
+    type TouchFocus = PointerFocusTarget;
 
     fn seat_state(&mut self) -> &mut SeatState<Self> {
         &mut self.common.seat_state

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -19,11 +19,10 @@ use smithay::{
         seat::WaylandFocus,
         shell::xdg::{
             PopupSurface, PositionerState, SurfaceCachedState, ToplevelSurface,
-            XdgPopupSurfaceRoleAttributes, XDG_POPUP_ROLE,
+            XdgPopupSurfaceData, XDG_POPUP_ROLE,
         },
     },
 };
-use std::sync::Mutex;
 use tracing::{trace, warn};
 
 impl Shell {
@@ -96,7 +95,7 @@ pub fn update_reactive_popups<'a>(
                 let positioner = with_states(&surface.wl_surface(), |states| {
                     let attributes = states
                         .data_map
-                        .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                        .get::<XdgPopupSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap();
@@ -378,7 +377,7 @@ pub fn get_popup_toplevel(popup: &PopupSurface) -> Option<WlSurface> {
         parent = with_states(&parent, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()
@@ -402,7 +401,7 @@ fn get_popup_toplevel_coords(popup: &PopupSurface) -> Point<i32, Logical> {
         offset += with_states(&parent, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()
@@ -413,7 +412,7 @@ fn get_popup_toplevel_coords(popup: &PopupSurface) -> Point<i32, Logical> {
         parent = with_states(&parent, |states| {
             states
                 .data_map
-                .get::<Mutex<XdgPopupSurfaceRoleAttributes>>()
+                .get::<XdgPopupSurfaceData>()
                 .unwrap()
                 .lock()
                 .unwrap()


### PR DESCRIPTION
Continuation of https://github.com/pop-os/cosmic-comp/pull/322 to eventually bump smithay again.

This takes about half of @ids1024 original approach, by leaving the `KeyboardFocusTarget` as is and adjusting the `PointerFocusTarget` to go all the way and split up `CosmicMapped` focus into iced-UI and surfaces.

Reasoning:
- The smithay changes actually don't require us to adjust the keyboard focus and I don't think consolidating into a single `WlSurface` variant is a good idea, as we are loosing context. The old PR spent quite a bit of code to reconstruct toplevel-surfaces. Let's simply not do that.
- The new pointer focus logic is meant to fix inconsistencies when wrapping multiple elements, regarding grabs, which suddently can't differentiate anymore between the individual elements (which in particular problematic for touch input). We have our fair share of weird workarounds and hacks in `CosmicWindow` and especially in `CosmicStack` to make the window unaware of the decorations and provide proper wl_poiinter events. All of this is brittle and in some parts even straight up buggy (for admittedly rare input combinations). Lets split the focus in the actual window surface(s) and the decorations to fix this.

Remaining TODOs:
- [x] Rebase
- [x] Currently this comments out the screencopy stuff inside the window-types, as there is no central location to get pointer events for a single window anymore. Lets fix this (somehow..)
- [x] Actually upgrade smithay
- [x] Incorporate https://github.com/pop-os/cosmic-comp/pull/341
