### PR TITLE
Fix `Workspace::minimize` for tiled fullscreen applications

### DIFF
--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -585,7 +585,7 @@ impl Workspace {
             None
         };
 
-        if self.is_tiled(elem) {
+        if self.tiling_layer.mapped().any(|(m, _)| m == elem) {
             let was_maximized = self.floating_layer.unmap(&elem);
             let tiling_state = self.tiling_layer.unmap_minimize(elem, to);
             Some(MinimizedWindow {


### PR DESCRIPTION
Using `is_tiled()` here doesn't work for fullscreen windows, since `is_tiled()` returns `false` for them.

This (plus the previous changes for supporting minimize) seems to fix the behavior of `SDL_MINIMIZE_ON_FOCUS_LOSS` in XWayland applications (https://github.com/pop-os/cosmic-comp/issues/231). Wine had a similar issue, though I haven't tested it yet.

It doesn't seem ideal visually that the fullscreen window becomes tiled then minimized itself, but that's less of a problem.

May need to check if this is an issue with any other uses of `is_tiled()` or `is_floating()`.