### PR TITLE
Add `linux-drm-syncobj-v1` protocol

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -35,7 +35,11 @@ use smithay::{
         wayland_server::{Client, DisplayHandle},
     },
     utils::{Clock, DevPath, Monotonic, Size},
-    wayland::{dmabuf::DmabufGlobal, relative_pointer::RelativePointerManagerState},
+    wayland::{
+        dmabuf::DmabufGlobal,
+        drm_syncobj::{supports_syncobj_eventfd, DrmSyncobjState},
+        relative_pointer::RelativePointerManagerState,
+    },
 };
 use surface::GbmDrmOutput;
 use tracing::{error, info, trace, warn};
@@ -70,6 +74,8 @@ pub struct KmsState {
 
     session: LibSeatSession,
     libinput: Libinput,
+
+    pub syncobj_state: Option<DrmSyncobjState>,
 }
 
 pub fn init_backend(
@@ -136,6 +142,8 @@ pub fn init_backend(
 
         session,
         libinput: libinput_context,
+
+        syncobj_state: None,
     });
 
     // start x11
@@ -145,6 +153,23 @@ pub fn init_backend(
     for (dev, path) in udev_dispatcher.as_source_ref().device_list() {
         if let Err(err) = state.device_added(dev, path.into(), dh) {
             warn!("Failed to add device {}: {:?}", path.display(), err);
+        }
+    }
+
+    let kms = match &mut state.backend {
+        BackendData::Kms(kms) => kms,
+        _ => unreachable!(),
+    };
+    if let Some(primary_node) = kms
+        .primary_node
+        .and_then(|node| node.node_with_type(NodeType::Primary).and_then(|x| x.ok()))
+    {
+        if let Some(device) = kms.drm_devices.get(&primary_node) {
+            let import_device = device.drm.device().device_fd().clone();
+            if supports_syncobj_eventfd(&import_device) {
+                let syncobj_state = DrmSyncobjState::new::<State>(&dh, import_device);
+                kms.syncobj_state = Some(syncobj_state);
+            }
         }
     }
 

--- a/src/wayland/handlers/drm_syncobj.rs
+++ b/src/wayland/handlers/drm_syncobj.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::state::{BackendData, State};
+use smithay::{
+    delegate_drm_syncobj,
+    wayland::drm_syncobj::{DrmSyncobjHandler, DrmSyncobjState},
+};
+
+impl DrmSyncobjHandler for State {
+    fn drm_syncobj_state(&mut self) -> &mut DrmSyncobjState {
+        let kms = match &mut self.backend {
+            BackendData::Kms(kms) => kms,
+            _ => unreachable!(),
+        };
+        kms.syncobj_state.as_mut().unwrap()
+    }
+}
+
+delegate_drm_syncobj!(State);

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod decoration;
 pub mod dmabuf;
 pub mod drm;
 pub mod drm_lease;
+pub mod drm_syncobj;
 pub mod foreign_toplevel_list;
 pub mod fractional_scale;
 pub mod idle_inhibit;


### PR DESCRIPTION
Based on https://github.com/Smithay/smithay/pull/1356.

I think the blocker logic should be correct for handling acquire points (if I properly understand the transaction system in Smithay). Though I don't see rendering issues with Mesa git when the blocker is removed... maybe it needs to be tested with something heavier than vkcube. (Or is there something still forcing implicit sync?).

The logic I added in Smithay for signaling releases may be a little less correct. Though maybe not more incorrect that how buffer releases are currently handled? (If I understand DRM correctly, with direct scanout we should make sure not to release until we've committed a new buffer and are sure the display controller won't want to read the buffer.)

We'll be able to test more when the next Nvidia driver is released. This at least gives us a way to test the explicit sync support they're adding.

Presumably we should test if `drmSyncobjEventfd` is supported... maybe just creating a syncobj and calling that to see if it works? I'm also still a little unsure how this ends up working with multiple GPUs... particularly if one is Nvidia.