### PR TITLE
fix: reduce size of top snap range

### DIFF
--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -258,7 +258,8 @@ pub enum SnappingZone {
 }
 
 const SNAP_RANGE: i32 = 32;
-const SNAP_RANGE_TOP: i32 = 24;
+const SNAP_RANGE_MAXIMIZE: i32 = 22;
+const SNAP_RANGE_TOP: i32 = 16;
 
 impl SnappingZone {
     pub fn contains(
@@ -269,8 +270,8 @@ impl SnappingZone {
         if !output_geometry.contains(point) {
             return false;
         }
-        let top_zone_32 = point.y < output_geometry.loc.y + SNAP_RANGE;
-        let top_zone_56 = point.y < output_geometry.loc.y + SNAP_RANGE + SNAP_RANGE_TOP;
+        let top_zone_32 = point.y < output_geometry.loc.y + SNAP_RANGE_MAXIMIZE;
+        let top_zone_56 = point.y < output_geometry.loc.y + SNAP_RANGE_MAXIMIZE + SNAP_RANGE_TOP;
         let left_zone = point.x < output_geometry.loc.x + SNAP_RANGE;
         let right_zone = point.x > output_geometry.loc.x + output_geometry.size.w - SNAP_RANGE;
         let bottom_zone = point.y > output_geometry.loc.y + output_geometry.size.h - SNAP_RANGE;


### PR DESCRIPTION
Reduces top snap range to 38, from 56, reducing top size to approximately 67.8% of the old size.

cc: @WatchMkr

fixes: https://github.com/pop-os/cosmic-comp/issues/408

I haven't tested this for usability yet, but it should be about 67.8% as usable /s

We could alternatively make the total size 32, like the other sides