### PR TITLE
moving: Show `snapping_indicator` only on current output

### DIFF
--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -147,7 +147,7 @@ impl MoveGrabState {
         };
 
         let snapping_indicator = match &self.snapping_zone {
-            Some(t) => {
+            Some(t) if &seat.active_output() == output => {
                 let base_color = theme.palette.neutral_9;
                 let overlay_geometry = t.overlay_geometry(non_exclusive_geometry);
                 vec![
@@ -177,7 +177,7 @@ impl MoveGrabState {
                     .into(),
                 ]
             }
-            None => vec![],
+            _ => vec![],
         };
 
         let (window_elements, popup_elements) = self


### PR DESCRIPTION
Without this check, a floating window that is dragged near an edge between monitors causes snapping indicators to show on both, since the window intersects both.