### PR TITLE
Add `unset` method to grab traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,7 +4506,7 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=ba0121a#ba0121aaed065c30ee4c42834126cce481cb0e57"
+source = "git+https://github.com/smithay//smithay?rev=033df94#033df9407104df60751438131687bac25d20e506"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,4 +118,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = {git = "https://github.com/smithay//smithay", rev = "ba0121a"}
+smithay = {git = "https://github.com/smithay//smithay", rev = "033df94"}

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -634,6 +634,8 @@ impl PointerGrab<State> for MenuGrab {
     fn start_data(&self) -> &PointerGrabStartData<State> {
         &self.start_data
     }
+
+    fn unset(&mut self, _data: &mut State) {}
 }
 
 impl MenuGrab {

--- a/src/shell/grabs/mod.rs
+++ b/src/shell/grabs/mod.rs
@@ -313,6 +313,13 @@ impl PointerGrab<State> for ResizeGrab {
             ResizeGrab::Tiling(grab) => PointerGrab::start_data(grab),
         }
     }
+
+    fn unset(&mut self, data: &mut State) {
+        match self {
+            ResizeGrab::Floating(grab) => PointerGrab::unset(grab, data),
+            ResizeGrab::Tiling(grab) => PointerGrab::unset(grab, data),
+        }
+    }
 }
 
 impl TouchGrab<State> for ResizeGrab {
@@ -375,6 +382,13 @@ impl TouchGrab<State> for ResizeGrab {
         match self {
             ResizeGrab::Floating(grab) => TouchGrab::start_data(grab),
             ResizeGrab::Tiling(grab) => TouchGrab::start_data(grab),
+        }
+    }
+
+    fn unset(&mut self, data: &mut State) {
+        match self {
+            ResizeGrab::Floating(grab) => TouchGrab::unset(grab, data),
+            ResizeGrab::Tiling(grab) => TouchGrab::unset(grab, data),
         }
     }
 }

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -575,6 +575,8 @@ impl PointerGrab<State> for MoveGrab {
             _ => unreachable!(),
         }
     }
+
+    fn unset(&mut self, _data: &mut State) {}
 }
 
 impl TouchGrab<State> for MoveGrab {
@@ -632,6 +634,8 @@ impl TouchGrab<State> for MoveGrab {
             _ => unreachable!(),
         }
     }
+
+    fn unset(&mut self, _data: &mut State) {}
 }
 
 impl MoveGrab {

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -162,13 +162,11 @@ impl PointerGrab<State> for ResizeSurfaceGrab {
         match self.release {
             ReleaseMode::NoMouseButtons => {
                 if handle.current_pressed().is_empty() {
-                    self.ungrab();
                     handle.unset_grab(data, event.serial, event.time, true);
                 }
             }
             ReleaseMode::Click => {
                 if event.state == ButtonState::Pressed {
-                    self.ungrab();
                     handle.unset_grab(data, event.serial, event.time, true);
                 }
             }
@@ -266,6 +264,10 @@ impl PointerGrab<State> for ResizeSurfaceGrab {
             _ => unreachable!(),
         }
     }
+
+    fn unset(&mut self, _data: &mut State) {
+        self.ungrab();
+    }
 }
 
 impl TouchGrab<State> for ResizeSurfaceGrab {
@@ -288,7 +290,6 @@ impl TouchGrab<State> for ResizeSurfaceGrab {
         seq: Serial,
     ) {
         if event.slot == <Self as TouchGrab<State>>::start_data(self).slot {
-            self.ungrab();
             handle.unset_grab(data);
         }
 
@@ -317,7 +318,6 @@ impl TouchGrab<State> for ResizeSurfaceGrab {
     }
 
     fn cancel(&mut self, data: &mut State, handle: &mut TouchInnerHandle<'_, State>, _seq: Serial) {
-        self.ungrab();
         handle.unset_grab(data);
     }
 
@@ -326,6 +326,10 @@ impl TouchGrab<State> for ResizeSurfaceGrab {
             GrabStartData::Touch(start_data) => start_data,
             _ => unreachable!(),
         }
+    }
+
+    fn unset(&mut self, _data: &mut State) {
+        self.ungrab();
     }
 }
 

--- a/src/shell/layout/tiling/grabs/resize.rs
+++ b/src/shell/layout/tiling/grabs/resize.rs
@@ -462,6 +462,8 @@ impl PointerGrab<State> for ResizeForkGrab {
             _ => unreachable!(),
         }
     }
+
+    fn unset(&mut self, _data: &mut State) {}
 }
 
 impl TouchGrab<State> for ResizeForkGrab {
@@ -521,4 +523,6 @@ impl TouchGrab<State> for ResizeForkGrab {
             _ => unreachable!(),
         }
     }
+
+    fn unset(&mut self, _data: &mut State) {}
 }

--- a/src/shell/layout/tiling/grabs/swap.rs
+++ b/src/shell/layout/tiling/grabs/swap.rs
@@ -99,4 +99,6 @@ impl KeyboardGrab<State> for SwapWindowGrab {
     fn start_data(&self) -> &KeyboardGrabStartData<State> {
         &KeyboardGrabStartData { focus: None }
     }
+
+    fn unset(&mut self, _state: &mut State) {}
 }


### PR DESCRIPTION
Requires https://github.com/Smithay/smithay/pull/1386. Based on https://github.com/pop-os/cosmic-comp/pull/404, since that adds/changes grabs.

Fixes https://github.com/pop-os/cosmic-comp/issues/403.