### PR TITLE
Fix support for cursor planes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,6 +3767,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pixman"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a24da0bec14f4e43a495c1837a3c358b87532e7fe66bd75c348b89f0451b6"
+dependencies = [
+ "drm-fourcc",
+ "paste",
+ "pixman-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "pixman-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0483e89e81d7915defe83c51f23f6800594d64f6f4a21253ce87fd8444ada"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4531,6 +4549,7 @@ dependencies = [
  "libloading 0.8.1",
  "libseat",
  "once_cell",
+ "pixman",
  "pkg-config",
  "profiling",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ features = [
   "use_system_lib",
   "renderer_glow",
   "renderer_multi",
+  "renderer_pixman",
   "wayland_frontend",
   "xwayland",
 ]

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends:
     libfontconfig-dev,
     libgbm-dev,
     libinput-dev,
+    libpixman-1-dev,
     libseat-dev,
     libsystemd-dev,
     libudev-dev,

--- a/src/backend/render/element.rs
+++ b/src/backend/render/element.rs
@@ -5,7 +5,7 @@ use smithay::{
         element::{
             surface::WaylandSurfaceRenderElement,
             utils::{Relocate, RelocateRenderElement},
-            Element, Id, RenderElement, UnderlyingStorage,
+            Element, Id, Kind, RenderElement, UnderlyingStorage,
         },
         glow::{GlowFrame, GlowRenderer},
         utils::{CommitCounter, DamageSet},
@@ -149,6 +149,18 @@ where
             CosmicElement::AdditionalDamage(elem) => elem.alpha(),
             #[cfg(feature = "debug")]
             CosmicElement::Egui(elem) => elem.alpha(),
+        }
+    }
+
+    fn kind(&self) -> Kind {
+        match self {
+            CosmicElement::Workspace(elem) => elem.kind(),
+            CosmicElement::Cursor(elem) => elem.kind(),
+            CosmicElement::Dnd(elem) => elem.kind(),
+            CosmicElement::MoveGrab(elem) => elem.kind(),
+            CosmicElement::AdditionalDamage(elem) => elem.kind(),
+            #[cfg(feature = "debug")]
+            CosmicElement::Egui(elem) => elem.kind(),
         }
     }
 }


### PR DESCRIPTION
I've been wondering for a why cosmic-comp wasn't using cursor planes, despite seemingly having doing everything needed to support them.

It seems there was just a missing implementation of the `kind()` method.