### PR TITLE
Inhibit workspace animations when workspaces view is open

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -44,8 +44,8 @@ use crate::{
     utils::prelude::*,
     wayland::{
         handlers::{
-            toplevel_management::minimize_rectangle, xdg_activation::ActivationContext,
-            xdg_shell::popup::get_popup_toplevel,
+            screencopy::WORKSPACE_OVERVIEW_NAMESPACE, toplevel_management::minimize_rectangle,
+            xdg_activation::ActivationContext, xdg_shell::popup::get_popup_toplevel,
         },
         protocols::{
             toplevel_info::{
@@ -408,13 +408,23 @@ impl WorkspaceSet {
             return Err(InvalidWorkspaceIndex);
         }
 
+        // Animate if workspaces overview isn't open
+        let layer_map = layer_map_for_output(&self.output);
+        let animate = !layer_map
+            .layers()
+            .any(|l| l.namespace() == WORKSPACE_OVERVIEW_NAMESPACE);
+
         if self.active != idx {
             let old_active = self.active;
             state.remove_workspace_state(&self.workspaces[old_active].handle, WState::Active);
             state.remove_workspace_state(&self.workspaces[old_active].handle, WState::Urgent);
             state.remove_workspace_state(&self.workspaces[idx].handle, WState::Urgent);
             state.add_workspace_state(&self.workspaces[idx].handle, WState::Active);
-            self.previously_active = Some((old_active, workspace_delta));
+            self.previously_active = if animate {
+                Some((old_active, workspace_delta))
+            } else {
+                None
+            };
             self.active = idx;
             Ok(true)
         } else {


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-workspaces-epoch/issues/27.

We want this to apply to changes to workspace either through keybindings or the cosmic-workspaces UI, so it adding a check here seems reasonable. In principle it could be good to have some kind of privileged protocol for setting things like this.

We may also want a configuration option to disable animations at some point.