### PR TITLE
Change how `COSMIC_ENABLE_WAYLAND_SECURITY`/`privileged` is handled

### DIFF
--- a/src/backend/kms/socket.rs
+++ b/src/backend/kms/socket.rs
@@ -96,7 +96,10 @@ impl State {
             .insert_source(listener, move |client_stream, _, state: &mut State| {
                 if let Err(err) = state.common.display_handle.insert_client(
                     client_stream,
-                    Arc::new(state.new_client_state_with_node(render_node)),
+                    Arc::new(ClientState {
+                        advertised_drm_node: Some(render_node),
+                        ..state.new_client_state()
+                    }),
                 ) {
                     warn!(
                         socket_name = socket_name_clone,

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use tracing::{error, warn};
 
-use crate::state::State;
+use crate::state::{ClientState, State};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "message")]
@@ -146,7 +146,11 @@ pub fn setup_socket(handle: LoopHandle<State>, state: &State) -> Result<()> {
                                                         continue;
                                                     }
                                                     let stream = unsafe { UnixStream::from_raw_fd(fd) };
-                                                    if let Err(err) = state.common.display_handle.insert_client(stream, Arc::new(state.new_privileged_client_state())) {
+                                                    let client_state = Arc::new(ClientState {
+                                                        privileged: true,
+                                                        ..state.new_client_state()
+                                                    });
+                                                    if let Err(err) = state.common.display_handle.insert_client(stream, client_state) {
                                                         warn!(?err, "Failed to add privileged client to display");
                                                     }
                                                 }


### PR DESCRIPTION
Manually starting `cosmic-panel` was not working properly in release builds, because without `cfg!(debug_assertions)`, the `privileged` flag wasn't sent on the panel, so it couldn't be propagated to the applets, which also fail the `client_has_no_security_context()` check.

I don't see a way to have both the `cfg!(debug_assertions)` check and `COSMIC_ENABLE_WAYLAND_SECURITY`. Now only the latter is used, and it determines the value of `privileged` for clients started normally. In the future, we could make the default value of
`COSMIC_ENABLE_WAYLAND_SECURITY` depend on `cfg!(debug_assertions)` if desired. But it shouldn't be necessary to have `debug_assertions` to test clients, since that should work with normal release builds.

This also corrects the inconsistency that the `cfg!(debug_assertions)` check wasn't applied to the render-node-specific Wayland sockets.