### PR TITLE
Disable Smithay `use_system_lib` to use Rust backend to wayland-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,8 +1968,6 @@ dependencies = [
  "drm-fourcc",
  "gbm-sys",
  "libc",
- "wayland-backend",
- "wayland-server",
 ]
 
 [[package]]
@@ -4595,13 +4593,11 @@ dependencies = [
  "thiserror",
  "tracing",
  "udev",
- "wayland-backend",
  "wayland-egl",
  "wayland-protocols",
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-server",
- "wayland-sys",
  "winit",
  "x11rb",
  "xkbcommon",
@@ -5678,9 +5674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
 dependencies = [
  "dlib",
- "libc",
  "log",
- "memoffset 0.9.0",
  "once_cell",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ features = [
   "backend_vulkan",
   "backend_x11",
   "desktop",
-  "use_system_lib",
   "renderer_glow",
   "renderer_multi",
   "renderer_pixman",

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -10,12 +10,13 @@ use crate::{
 use anyhow::{anyhow, Context, Result};
 use smithay::{
     backend::{
+        drm::NodeType,
         egl::EGLDevice,
         renderer::{
             damage::{OutputDamageTracker, RenderOutputResult},
             gles::GlesRenderbuffer,
             glow::GlowRenderer,
-            ImportDma, ImportEgl,
+            ImportDma,
         },
         winit::{self, WinitEvent, WinitGraphicsBackend, WinitVirtualDevice},
     },
@@ -251,51 +252,46 @@ fn init_egl_client_side(
     state: &mut State,
     renderer: &mut WinitGraphicsBackend<GlowRenderer>,
 ) -> Result<()> {
-    let bind_result = renderer.renderer().bind_wl_display(dh);
     let render_node = EGLDevice::device_for_display(renderer.renderer().egl_context().display())
         .and_then(|device| device.try_get_render_node());
 
     let dmabuf_formats = renderer.renderer().dmabuf_formats().collect::<Vec<_>>();
-    let dmabuf_default_feedback = match render_node {
-        Ok(Some(node)) => {
-            let dmabuf_default_feedback =
-                DmabufFeedbackBuilder::new(node.dev_id(), dmabuf_formats.clone())
-                    .build()
-                    .unwrap();
-            Some(dmabuf_default_feedback)
-        }
-        Ok(None) => {
-            warn!("Failed to query render node, dmabuf protocol will only advertise v3");
-            None
-        }
-        Err(err) => {
-            warn!(
-                ?err,
-                "Failed to egl device for display, dmabuf protocol will only advertise v3"
-            );
-            None
-        }
-    };
 
-    match dmabuf_default_feedback {
-        Some(feedback) => {
-            state
+    match render_node {
+        Ok(Some(node)) => {
+            let feedback = DmabufFeedbackBuilder::new(node.dev_id(), dmabuf_formats.clone())
+                .build()
+                .unwrap();
+
+            let dmabuf_global = state
                 .common
                 .dmabuf_state
                 .create_global_with_default_feedback::<State>(dh, &feedback);
 
+            let render_node = render_node.unwrap().unwrap();
+            let _drm_global_id = state.common.wl_drm_state.create_global::<State>(
+                dh,
+                render_node
+                    .dev_path_with_type(NodeType::Render)
+                    .or_else(|| render_node.dev_path())
+                    .ok_or(anyhow!(
+                        "Could not determine path for gpu node: {}",
+                        render_node
+                    ))?,
+                dmabuf_formats,
+                &dmabuf_global,
+            );
+
             info!("EGL hardware-acceleration enabled.");
         }
-        None if bind_result.is_ok() => {
-            state
-                .common
-                .dmabuf_state
-                .create_global::<State>(dh, dmabuf_formats);
-            info!("EGL hardware-acceleration enabled.");
+        Ok(None) => {
+            warn!("Failed to query render node. Unable to initialize bind display to EGL.")
         }
-        None => {
-            let err = bind_result.unwrap_err();
-            warn!(?err, "Unable to initialize bind display to EGL.")
+        Err(err) => {
+            warn!(
+                ?err,
+                "Failed to egl device for display. Unable to initialize bind display to EGL."
+            )
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -140,9 +140,8 @@ impl ClientData for ClientState {
     }
 }
 
-pub fn advertised_node_for_surface(w: &WlSurface, dh: &DisplayHandle) -> Option<DrmNode> {
+pub fn advertised_node_for_client(client: &Client) -> Option<DrmNode> {
     // Lets check the global drm-node the client got either through default-feedback or wl_drm
-    let client = dh.get_client(w.id()).ok()?;
     if let Some(normal_client) = client.get_data::<ClientState>() {
         return normal_client.advertised_drm_node.clone();
     }
@@ -151,6 +150,11 @@ pub fn advertised_node_for_surface(w: &WlSurface, dh: &DisplayHandle) -> Option<
         return xwayland_client.user_data().get::<DrmNode>().cloned();
     }
     None
+}
+
+pub fn advertised_node_for_surface(w: &WlSurface, dh: &DisplayHandle) -> Option<DrmNode> {
+    let client = dh.get_client(w.id()).ok()?;
+    advertised_node_for_client(&client)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
It seems this was needed for `renderer.bind_wl_display`. But only in the X11 and winit backends. Unless there's some less obvious reason to use the `use_system_lib` feature, it seems undesirable and avoidable.

This uses `WlDrmState` to provide `wl_drm` on those backends instead.

If I hide the dmabuf global, Mesa EGL clients seem to work fine using `wl_drm` here with both the winit and x11 backends.