### PR TITLE
Update Smithay with Nvidia `IN_FENCE_FD` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,7 +4556,7 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=8f132ec#8f132ecded5705e55fc1ce6cfa4b59850c6b038e"
+source = "git+https://github.com/smithay//smithay?rev=fb44b24#fb44b240ea4a3aa39a6b92f5bede23301ab9a26e"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,4 +118,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = {git = "https://github.com/smithay//smithay", rev = "8f132ec"}
+smithay = {git = "https://github.com/smithay//smithay", rev = "fb44b24"}


### PR DESCRIPTION
The only thing added to Smithay since the last update is https://github.com/Smithay/smithay/pull/1437.

Fixes https://github.com/pop-os/cosmic-comp/issues/497.