### PR TITLE
Fixes for handling of SSDs in window geometry

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -415,9 +415,9 @@ impl CosmicSurface {
         }
         .map(|size| {
             if self.is_decorated(false) {
-                size + (0, SSD_HEIGHT).into()
-            } else {
                 size
+            } else {
+                size + (0, SSD_HEIGHT).into()
             }
         })
     }
@@ -434,9 +434,9 @@ impl CosmicSurface {
         }
         .map(|size| {
             if self.is_decorated(false) {
-                size + (0, SSD_HEIGHT).into()
-            } else {
                 size
+            } else {
+                size + (0, SSD_HEIGHT).into()
             }
         })
     }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -2,7 +2,10 @@ use std::{ffi::OsString, os::unix::io::OwnedFd, process::Stdio};
 
 use crate::{
     backend::render::cursor::{load_cursor_theme, Cursor, CursorShape},
-    shell::{focus::target::KeyboardFocusTarget, grabs::ReleaseMode, CosmicSurface, Shell},
+    shell::{
+        element::surface::SSD_HEIGHT, focus::target::KeyboardFocusTarget, grabs::ReleaseMode,
+        CosmicSurface, Shell,
+    },
     state::State,
     utils::prelude::*,
     wayland::handlers::{
@@ -379,12 +382,13 @@ impl XwmHandler for State {
                     .is_some();
 
             if is_floating {
+                let ssd_height = if window.is_decorated() { 0 } else { SSD_HEIGHT };
                 mapped.set_geometry(
                     Rectangle::from_loc_and_size(
                         current_geo.loc,
                         (
                             w.map(|w| w as i32).unwrap_or(current_geo.size.w),
-                            h.map(|h| h as i32).unwrap_or(current_geo.size.h),
+                            h.map(|h| h as i32).unwrap_or(current_geo.size.h) + ssd_height,
                         ),
                     )
                     .as_global(),


### PR DESCRIPTION
This seems to fix the issue described in https://github.com/pop-os/cosmic-comp/issues/502 with XWayland dialogs not being allocated enough height.

This may also fix https://github.com/pop-os/cosmic-comp/issues/468, or that could be a similar issue. That will need more testing. If comic-comp gets the `geometry` of a window then calls `set_geometry`, if everything isn't perfectly symmetric that may lead to the sizing shrinking or growing like that.