### PR TITLE
Set clipboard/primary focus in `refresh_focus`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4581,7 +4581,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=12bcefc#12bcefc2009c4648bb5e9ffde6e03a4cd4c02d90"
+source = "git+https://github.com/smithay//smithay?rev=96af9cb#96af9cb50f686e8c39a6638de3d4ef6b07a239ae"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,4 +118,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = {git = "https://github.com/smithay//smithay", rev = "12bcefc"}
+smithay = {git = "https://github.com/smithay//smithay", rev = "96af9cb"}

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -952,7 +952,7 @@ impl WaylandFocus for CosmicMapped {
     fn same_client_as(&self, object_id: &ObjectId) -> bool {
         match &self.element {
             CosmicMappedInternal::Window(w) => w.surface().same_client_as(object_id),
-            CosmicMappedInternal::Stack(s) => s.surfaces().any(|w| w.same_client_as(object_id)),
+            CosmicMappedInternal::Stack(s) => s.active().same_client_as(object_id),
             _ => false,
         }
     }

--- a/src/wayland/handlers/seat.rs
+++ b/src/wayland/handlers/seat.rs
@@ -8,11 +8,6 @@ use crate::{
 use smithay::{
     delegate_seat,
     input::{keyboard::LedState, pointer::CursorImageStatus, SeatHandler, SeatState},
-    reexports::wayland_server::Resource,
-    wayland::{
-        seat::WaylandFocus, selection::data_device::set_data_device_focus,
-        selection::primary_selection::set_primary_focus,
-    },
 };
 use std::cell::RefCell;
 
@@ -39,17 +34,9 @@ impl SeatHandler for State {
 
     fn focus_changed(
         &mut self,
-        seat: &smithay::input::Seat<Self>,
-        focused: Option<&Self::KeyboardFocus>,
+        _seat: &smithay::input::Seat<Self>,
+        _focused: Option<&Self::KeyboardFocus>,
     ) {
-        let dh = &self.common.display_handle;
-        if let Some(client) = focused
-            .and_then(|t| t.wl_surface())
-            .and_then(|s| dh.get_client(s.id()).ok())
-        {
-            set_data_device_focus(dh, seat, Some(client.clone()));
-            set_primary_focus(dh, seat, Some(client))
-        }
     }
 
     fn led_state_changed(&mut self, seat: &smithay::input::Seat<Self>, led_state: LedState) {


### PR DESCRIPTION
This should fix https://github.com/pop-os/cosmic-comp/issues/494, and make clipboard and primary focus consistently correct.

Changing the active element of a stack needs to change the clipboard focus, but it wasn't being changed since the `KeyboardFocusTarget` was unchanged. The `CosmicStack` methods that change the active stack element also have no obvious way to change the keyboard focus. So we can set this in `refresh_focus`, which should be correct.

If the new focus `WlSurface` is `None`, this clears the focus instead of leaving it as the previous code did. I believe that is desirable.

Requires https://github.com/Smithay/smithay/pull/1442 to avoid repeated `offer`s, instead of only when focus changed.

(Perhaps this could better be solved by having a `WlSurface` variant of `KeyboardFocusTarget`, like pointer focus, or some mechanism for a stack of focus, which could help other things. But it's also unclear exactly how that would work with the code for setting the active stack element, among other questions.)