### PR TITLE
Maximise window when Up and not tilled 

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.72"
+channel = "stable"

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1038,7 +1038,8 @@ impl FloatingLayout {
                     (Direction::Up, Some(TiledCorners::Bottom))
                     | (Direction::Down, Some(TiledCorners::Top))
                     | (Direction::Left, Some(TiledCorners::Right))
-                    | (Direction::Right, Some(TiledCorners::Left)) => {
+                    | (Direction::Right, Some(TiledCorners::Left))
+                    | (Direction::Up, None) if !element.is_maximized(true) => {
                         std::mem::drop(tiled_state);
 
                         let mut maximized_state = element.maximized_state.lock().unwrap();


### PR DESCRIPTION
Same of #563, but simpler 

> This PR change the behaviour when moving a window Upward that is not tilled. It will maximize it.