### PR TITLE
output: Store position as u32 and offset bad configs

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -642,7 +642,7 @@ impl KmsState {
             }
 
             // add new ones
-            let mut w = shell.read().unwrap().global_space().size.w;
+            let mut w = shell.read().unwrap().global_space().size.w as u32;
             if !test_only {
                 for (conn, crtc) in new_pairings {
                     let (output, _) = device.connector_added(
@@ -655,7 +655,7 @@ impl KmsState {
                         startup_done.clone(),
                     )?;
                     if output.mirroring().is_none() {
-                        w += output.config().mode_size().w;
+                        w += output.config().mode_size().w as u32;
                     }
                     all_outputs.push(output);
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -136,7 +136,7 @@ pub struct OutputConfig {
     pub scale: f64,
     #[serde(with = "TransformDef")]
     pub transform: Transform,
-    pub position: (i32, i32),
+    pub position: (u32, u32),
     #[serde(default = "default_enabled")]
     pub enabled: OutputState,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -57,7 +57,7 @@ use smithay::{
             Client, DisplayHandle, Resource,
         },
     },
-    utils::{Clock, IsAlive, Monotonic},
+    utils::{Clock, IsAlive, Monotonic, Point},
     wayland::{
         alpha_modifier::AlphaModifierState,
         compositor::{CompositorClientState, CompositorState, SurfaceData},
@@ -306,8 +306,11 @@ impl BackendData {
                 Some(final_config.transform.into()).filter(|x| *x != output.current_transform());
             let scale = Some(final_config.scale)
                 .filter(|x| *x != output.current_scale().fractional_scale());
-            let location =
-                Some(final_config.position.into()).filter(|x| *x != output.current_location());
+            let location = Some(Point::from((
+                final_config.position.0 as i32,
+                final_config.position.1 as i32,
+            )))
+            .filter(|x| *x != output.current_location());
             output.change_current_state(mode, transform, scale.map(Scale::Fractional), location);
 
             output.set_adaptive_sync(final_config.vrr);


### PR DESCRIPTION
Should at least partially fix https://github.com/pop-os/cosmic-comp/issues/397.

Fixes the exact symptoms observed in:
- https://github.com/pop-os/cosmic-epoch/issues/394
- https://github.com/pop-os/cosmic-epoch/issues/391

Will reset output configuration for already bad settings (where parsing now with u32 will fail), but should simply correct any new bad configs, by offsetting everything.