### PR TITLE
Configurable mouse focus

### DIFF
--- a/cosmic-comp-config/src/input.rs
+++ b/cosmic-comp-config/src/input.rs
@@ -5,6 +5,8 @@
 pub use input::{AccelProfile, ClickMethod, ScrollMethod, TapButtonMap};
 use serde::{Deserialize, Serialize};
 
+// Note: For the following values, None is used to represent the system default
+// Configuration for input devices
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct InputConfig {
     pub state: DeviceState,

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -23,6 +23,12 @@ pub struct CosmicCompConfig {
     pub autotile_behavior: TileBehavior,
     /// Active hint enabled
     pub active_hint: bool,
+    /// Enables changing keyboard focus to windows when the cursor passes into them
+    pub focus_follows_cursor: bool,
+    /// Enables warping the cursor to the focused window when focus changes due to keyboard input
+    pub cursor_follows_focus: bool,
+    /// The delay in milliseconds before focus follows mouse (if enabled)
+    pub focus_follows_cursor_delay: u64,
     /// Let X11 applications scale themselves
     pub descale_xwayland: bool,
 }
@@ -50,6 +56,9 @@ impl Default for CosmicCompConfig {
             autotile: Default::default(),
             autotile_behavior: Default::default(),
             active_hint: true,
+            focus_follows_cursor: false,
+            cursor_follows_focus: false,
+            focus_follows_cursor_delay: 250,
             descale_xwayland: false,
         }
     }

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -660,7 +660,7 @@ where
         .lock()
         .unwrap()
         .is_some();
-    let active_output = last_active_seat.active_output();
+    let focused_output = last_active_seat.focused_or_active_output();
     let output_size = output.geometry().size;
     let output_scale = output.current_scale().fractional_scale();
 
@@ -670,7 +670,7 @@ where
         .iter()
         .find(|w| w.handle == current.0)
         .ok_or(OutputNoMode)?;
-    let is_active_space = workspace.outputs().any(|o| o == &active_output);
+    let is_active_space = workspace.outputs().any(|o| o == &focused_output);
 
     let has_fullscreen = workspace
         .fullscreen
@@ -775,7 +775,7 @@ where
                 .space_for_handle(&previous)
                 .ok_or(OutputNoMode)?;
             let has_fullscreen = workspace.fullscreen.is_some();
-            let is_active_space = workspace.outputs().any(|o| o == &active_output);
+            let is_active_space = workspace.outputs().any(|o| o == &focused_output);
 
             let percentage = match start {
                 WorkspaceDelta::Shortcut(st) => ease(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -658,6 +658,24 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                     state.common.update_xwayland_scale();
                 }
             }
+            "focus_follows_cursor" => {
+                let new = get_config::<bool>(&config, "focus_follows_cursor");
+                if new != state.common.config.cosmic_conf.focus_follows_cursor {
+                    state.common.config.cosmic_conf.focus_follows_cursor = new;
+                }
+            }
+            "cursor_follows_focus" => {
+                let new = get_config::<bool>(&config, "cursor_follows_focus");
+                if new != state.common.config.cosmic_conf.cursor_follows_focus {
+                    state.common.config.cosmic_conf.cursor_follows_focus = new;
+                }
+            }
+            "focus_follows_cursor_delay" => {
+                let new = get_config::<u64>(&config, "focus_follows_cursor_delay");
+                if new != state.common.config.cosmic_conf.focus_follows_cursor_delay {
+                    state.common.config.cosmic_conf.focus_follows_cursor_delay = new;
+                }
+            }
             _ => {}
         }
     }

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -177,7 +177,7 @@ impl CosmicWindowInternal {
     pub fn current_focus(&self) -> Option<Focus> {
         unsafe { Focus::from_u8(self.pointer_entered.load(Ordering::SeqCst)) }
     }
-
+    /// returns if the window has any current or pending server-side decorations
     pub fn has_ssd(&self, pending: bool) -> bool {
         !self.window.is_decorated(pending)
     }

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -20,7 +20,7 @@ fn toggle_stacking(state: &mut State, mapped: &CosmicMapped) {
     let seat = shell.seats.last_active().clone();
     if let Some(new_focus) = shell.toggle_stacking(&seat, mapped) {
         std::mem::drop(shell);
-        Shell::set_focus(state, Some(&new_focus), &seat, None);
+        Shell::set_focus(state, Some(&new_focus), &seat, None, false);
     }
 }
 
@@ -52,7 +52,7 @@ fn move_prev_workspace(state: &mut State, mapped: &CosmicMapped) {
         );
         if let Some((target, _)) = res {
             std::mem::drop(shell);
-            Shell::set_focus(state, Some(&target), &seat, None);
+            Shell::set_focus(state, Some(&target), &seat, None, true);
         }
     }
 }
@@ -85,7 +85,7 @@ fn move_next_workspace(state: &mut State, mapped: &CosmicMapped) {
         );
         if let Some((target, _point)) = res {
             std::mem::drop(shell);
-            Shell::set_focus(state, Some(&target), &seat, None)
+            Shell::set_focus(state, Some(&target), &seat, None, true)
         }
     }
 }

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -161,6 +161,7 @@ impl Item {
     }
 }
 
+/// Menu that comes up when right-clicking an application header bar
 pub struct ContextMenu {
     items: Vec<Item>,
     selected: AtomicBool,

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -882,6 +882,7 @@ impl Drop for MoveGrab {
                     Some(&KeyboardFocusTarget::from(mapped)),
                     &seat,
                     Some(serial),
+                    false,
                 )
             }
         });

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -728,7 +728,7 @@ impl FloatingLayout {
         self.space.element_geometry(elem).map(RectExt::as_local)
     }
 
-    pub fn element_under(&mut self, location: Point<f64, Local>) -> Option<KeyboardFocusTarget> {
+    pub fn element_under(&self, location: Point<f64, Local>) -> Option<KeyboardFocusTarget> {
         self.space
             .element_under(location.as_logical())
             .map(|(mapped, _)| mapped.clone().into())

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -3088,10 +3088,7 @@ impl TilingLayout {
         None
     }
 
-    pub fn element_under(
-        &mut self,
-        location_f64: Point<f64, Local>,
-    ) -> Option<KeyboardFocusTarget> {
+    pub fn element_under(&self, location_f64: Point<f64, Local>) -> Option<KeyboardFocusTarget> {
         let location = location_f64.to_i32_round();
 
         for (mapped, geo) in self.mapped() {

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -177,6 +177,7 @@ impl IsAlive for FullscreenSurface {
     }
 }
 
+/// LIFO stack of focus targets
 #[derive(Debug, Default)]
 pub struct FocusStacks(HashMap<Seat<State>, IndexSet<CosmicMapped>>);
 
@@ -444,7 +445,7 @@ impl Workspace {
             .find(|e| e.windows().any(|(w, _)| &w == surface))
     }
 
-    pub fn element_under(&mut self, location: Point<f64, Global>) -> Option<KeyboardFocusTarget> {
+    pub fn element_under(&self, location: Point<f64, Global>) -> Option<KeyboardFocusTarget> {
         let location = location.to_local(&self.output);
         self.floating_layer
             .element_under(location)
@@ -784,6 +785,8 @@ impl Workspace {
         }
     }
 
+    /// Returns the content of the current display if it is alive and
+    /// not in the process of rendering an animation
     pub fn get_fullscreen(&self) -> Option<&CosmicSurface> {
         self.fullscreen
             .as_ref()

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,7 +8,7 @@ use crate::{
         x11::X11State,
     },
     config::{Config, OutputConfig, OutputState},
-    input::gestures::GestureState,
+    input::{gestures::GestureState, PointerFocusState},
     shell::{grabs::SeatMoveGrabState, CosmicSurface, SeatExt, Shell},
     utils::prelude::OutputExt,
     wayland::protocols::{
@@ -226,6 +226,7 @@ pub struct Common {
     pub xwayland_scale: Option<i32>,
     pub xwayland_state: Option<XWaylandState>,
     pub xwayland_shell_state: XWaylandShellState,
+    pub pointer_focus_state: Option<PointerFocusState>,
 }
 
 #[derive(Debug)]
@@ -621,6 +622,7 @@ impl State {
                 xwayland_scale: None,
                 xwayland_state: None,
                 xwayland_shell_state,
+                pointer_focus_state: None,
             },
             backend: BackendData::Unset,
             ready: Once::new(),

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -272,7 +272,7 @@ impl State {
                     if let Some(target) = res {
                         let seat = shell.seats.last_active().clone();
                         std::mem::drop(shell);
-                        Shell::set_focus(self, Some(&target), &seat, None);
+                        Shell::set_focus(self, Some(&target), &seat, None, true);
                         return true;
                     }
                 }
@@ -290,7 +290,7 @@ impl State {
                 if let Some(target) = shell.map_layer(&layer_surface) {
                     let seat = shell.seats.last_active().clone();
                     std::mem::drop(shell);
-                    Shell::set_focus(self, Some(&target), &seat, None);
+                    Shell::set_focus(self, Some(&target), &seat, None, false);
                 }
                 layer_surface.layer_surface().send_configure();
                 return true;

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -87,7 +87,7 @@ impl ToplevelManagementHandler for State {
                 }
 
                 mapped.focus_window(window);
-                Shell::set_focus(self, Some(&mapped.clone().into()), &seat, None);
+                Shell::set_focus(self, Some(&mapped.clone().into()), &seat, None, true);
                 return;
             }
         }
@@ -133,7 +133,7 @@ impl ToplevelManagementHandler for State {
             );
             if let Some((target, _)) = res {
                 std::mem::drop(shell);
-                Shell::set_focus(self, Some(&target), &seat, None);
+                Shell::set_focus(self, Some(&target), &seat, None, true);
             }
             return;
         }

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -156,7 +156,7 @@ impl XdgActivationHandler for State {
                             let target = element.into();
 
                             std::mem::drop(shell);
-                            Shell::set_focus(self, Some(&target), &seat, None);
+                            Shell::set_focus(self, Some(&target), &seat, None, false);
                         } else if let Some(w) = shell.space_for(&element).map(|w| w.handle.clone())
                         {
                             shell.append_focus_stack(&element, &seat);

--- a/src/wayland/handlers/xdg_foreign.rs
+++ b/src/wayland/handlers/xdg_foreign.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use smithay::{delegate_xdg_foreign, wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState}};
 use crate::state::State;
+use smithay::{
+    delegate_xdg_foreign,
+    wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState},
+};
 
 impl XdgForeignHandler for State {
     fn xdg_foreign_state(&mut self) -> &mut XdgForeignState {

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -97,7 +97,13 @@ impl XdgShellHandler for State {
                         grab.ungrab(PopupUngrabStrategy::All);
                         return;
                     }
-                    Shell::set_focus(self, grab.current_grab().as_ref(), &seat, Some(serial));
+                    Shell::set_focus(
+                        self,
+                        grab.current_grab().as_ref(),
+                        &seat,
+                        Some(serial),
+                        false,
+                    );
                     keyboard.set_grab(self, PopupKeyboardGrab::new(&grab), serial);
                 }
 
@@ -226,11 +232,13 @@ impl XdgShellHandler for State {
     fn fullscreen_request(&mut self, surface: ToplevelSurface, output: Option<WlOutput>) {
         let mut shell = self.common.shell.write().unwrap();
         let seat = shell.seats.last_active().clone();
-        let active_output = seat.active_output();
+        let Some(focused_output) = seat.focused_output() else {
+            return;
+        };
         let output = output
             .as_ref()
             .and_then(Output::from_resource)
-            .unwrap_or_else(|| active_output.clone());
+            .unwrap_or_else(|| focused_output.clone());
 
         if let Some(mapped) = shell.element_for_surface(surface.wl_surface()).cloned() {
             let from = minimize_rectangle(&output, &mapped.active_window());

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -390,7 +390,7 @@ impl XwmHandler for State {
             if let Some(target) = res {
                 let seat = shell.seats.last_active().clone();
                 std::mem::drop(shell);
-                Shell::set_focus(self, Some(&target), &seat, None);
+                Shell::set_focus(self, Some(&target), &seat, None, false);
             }
         }
     }


### PR DESCRIPTION
- resolves #564 

Still learning the codebase, and right now this is just some boilerplate. As mentioned in 564 there would be 3 mouse focus policies:
- focus requires click (current and default)
- focus changes when mouse moves to a new output
- focus follows mouse (sloppily or lazily)

The first requires 0 changes and the code for click to focus still needs to execute when following one of the other policies (if there is a delay before window focusing, clicking a window should still focus it.). So the only place code needs to be added is in the two `todo!()`s currently in `src/input/mod.rs`. I think  I can probably extract the contents of [this conditional](https://github.com/pop-os/cosmic-comp/blob/713ac470aa992712b105116e44c338986d591782/src/input/mod.rs#L755) into a function, with some minor changes to reuse the existing code for moving keyboard focus to a window or region. 