### PR TITLE
screencopy: Handle error from with_buffer_contents_mut 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=3731734#3731734d5a0409186a0475238ffe46e2835cee6d"
+source = "git+https://github.com/smithay//smithay?rev=4171247#41712470abede74dab8a039ce048c70d56115ce6"
 dependencies = [
  "appendlist",
  "ash 0.38.0+1.3.281",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,4 +119,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = {git = "https://github.com/smithay//smithay", rev = "3731734"}
+smithay = {git = "https://github.com/smithay//smithay", rev = "4171247"}

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -294,7 +294,11 @@ pub fn render_workspace_to_buffer(
             let size = buffer_dimensions(buffer).unwrap();
             let format =
                 with_buffer_contents(buffer, |_, _, data| shm_format_to_fourcc(data.format))
-                    .map_err(|_| DTError::OutputNoMode(OutputNoMode))? // eh, we have to do some error
+                    .map_err(|err| {
+                        DTError::Rendering(<R as Renderer>::Error::from_gles_error(
+                            GlesError::BufferAccessError(err),
+                        ))
+                    })?
                     .expect("We should be able to convert all hardcoded shm screencopy formats");
             let render_buffer =
                 Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, size)
@@ -574,7 +578,11 @@ pub fn render_window_to_buffer(
             let size = buffer_dimensions(buffer).unwrap();
             let format =
                 with_buffer_contents(buffer, |_, _, data| shm_format_to_fourcc(data.format))
-                    .map_err(|_| DTError::OutputNoMode(OutputNoMode))? // eh, we have to do some error
+                    .map_err(|err| {
+                        DTError::Rendering(<R as Renderer>::Error::from_gles_error(
+                            GlesError::BufferAccessError(err),
+                        ))
+                    })?
                     .expect("We should be able to convert all hardcoded shm screencopy formats");
             let render_buffer =
                 Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, size)
@@ -787,7 +795,11 @@ pub fn render_cursor_to_buffer(
             let size = buffer_dimensions(buffer).unwrap();
             let format =
                 with_buffer_contents(buffer, |_, _, data| shm_format_to_fourcc(data.format))
-                    .map_err(|_| DTError::OutputNoMode(OutputNoMode))? // eh, we have to do some error
+                    .map_err(|err| {
+                        DTError::Rendering(<R as Renderer>::Error::from_gles_error(
+                            GlesError::BufferAccessError(err),
+                        ))
+                    })?
                     .expect("We should be able to convert all hardcoded shm screencopy formats");
             let render_buffer =
                 Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, size)


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/48.

https://github.com/Smithay/smithay/pull/1475 fixes the segfault so this instead produces an error. Then we need to handle the error here.