### PR TITLE
Fix xwm games

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=4171247#41712470abede74dab8a039ce048c70d56115ce6"
+source = "git+https://github.com/smithay//smithay?rev=e2b233f#e2b233ff588747310c8c4aa6bbb6d56c877351a8"
 dependencies = [
  "appendlist",
  "ash 0.38.0+1.3.281",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,4 +119,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = {git = "https://github.com/smithay//smithay", rev = "4171247"}
+smithay = {git = "https://github.com/smithay//smithay", rev = "e2b233f"}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -597,7 +597,7 @@ impl State {
                                     (0, 0),
                                     WindowSurfaceType::ALL,
                                 )
-                                .is_some()
+                                .is_none()
                                 {
                                     ptr.frame(self);
                                     return;

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -378,8 +378,11 @@ impl CosmicSurface {
             .get_or_insert_threadsafe(Minimized::default)
             .0
             .store(minimized, Ordering::SeqCst);
-        if let WindowSurface::X11(surface) = self.0.underlying_surface() {
-            let _ = surface.set_mapped(!minimized);
+        if !minimized {
+            if let WindowSurface::X11(surface) = self.0.underlying_surface() {
+                let _ = surface.set_mapped(false);
+                let _ = surface.set_mapped(true);
+            }
         }
     }
 

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -197,6 +197,10 @@ impl Shell {
                 window.set_activated(focused_windows.contains(&window));
                 window.configure();
             }
+            for m in set.minimized_windows.iter() {
+                m.window.set_activated(false);
+                m.window.configure();
+            }
 
             let workspace = self.workspaces.active_mut(&output);
             for focused in focused_windows.iter() {
@@ -205,6 +209,10 @@ impl Shell {
             for window in workspace.mapped() {
                 window.set_activated(focused_windows.contains(&window));
                 window.configure();
+            }
+            for m in workspace.minimized_windows.iter() {
+                m.window.set_activated(false);
+                m.window.configure();
             }
         }
     }

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -685,6 +685,24 @@ impl KeyboardTarget<State> for KeyboardFocusTarget {
             }
         }
     }
+    fn replace(
+        &self,
+        replaced: <State as smithay::input::SeatHandler>::KeyboardFocus,
+        seat: &Seat<State>,
+        data: &mut State,
+        keys: Vec<KeysymHandle<'_>>,
+        modifiers: ModifiersState,
+        serial: Serial,
+    ) {
+        if !replaced
+            .wl_surface()
+            .is_some_and(|s| Some(s) == self.wl_surface())
+        {
+            KeyboardTarget::leave(&replaced, seat, data, serial);
+            KeyboardTarget::enter(self, seat, data, keys, serial);
+            KeyboardTarget::modifiers(self, seat, data, modifiers, serial);
+        }
+    }
 }
 
 impl WaylandFocus for KeyboardFocusTarget {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2816,6 +2816,9 @@ impl Shell {
         if window.is_maximized(true) {
             self.unmaximize_request(window);
         } else {
+            if window.is_fullscreen(true) {
+                return;
+            }
             self.maximize_request(window, seat);
         }
     }

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -788,7 +788,7 @@ impl Workspace {
         self.fullscreen
             .as_ref()
             .filter(|f| f.alive())
-            .filter(|f| f.ended_at.is_none() && f.start_at.is_none())
+            .filter(|f| f.ended_at.is_none())
             .map(|f| &f.surface)
     }
 
@@ -800,11 +800,9 @@ impl Workspace {
         amount: i32,
     ) -> bool {
         if let Some(toplevel) = focused.toplevel() {
-            if self
-                .fullscreen
-                .as_ref()
-                .is_some_and(|f| f.surface.wl_surface().as_deref() == Some(&toplevel))
-            {
+            if self.fullscreen.as_ref().is_some_and(|f| {
+                f.ended_at.is_none() && f.surface.wl_surface().as_deref() == Some(&toplevel)
+            }) {
                 return false;
             }
         }
@@ -934,7 +932,7 @@ impl Workspace {
     pub fn is_fullscreen(&self, mapped: &CosmicMapped) -> bool {
         self.fullscreen
             .as_ref()
-            .is_some_and(|f| f.surface == mapped.active_window())
+            .is_some_and(|f| f.ended_at.is_none() && f.surface == mapped.active_window())
             || self
                 .minimized_windows
                 .iter()

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -204,7 +204,15 @@ impl Common {
                                 )
                                 .flat_map(|(_, workspace)| {
                                     workspace.get_fullscreen().cloned().into_iter().chain(
-                                        workspace.mapped().flat_map(|mapped| {
+                                        workspace
+                                            .mapped()
+                                            .chain(
+                                                workspace
+                                                    .minimized_windows
+                                                    .iter()
+                                                    .map(|m| &m.window),
+                                            )
+                                            .flat_map(|mapped| {
                                             let active = mapped.active_window();
                                             std::iter::once(active.clone()).chain(
                                                 mapped


### PR DESCRIPTION
This seems to fix the majority of minimize-bugs happening with a lot of games. (Where maximizing the window immediately minimizes it again.)

The culprit was the `wl_keyboard::leave` event, causing the app to register a focus loss, when we switched between `KeyboardTarget::Element` and `KeyboardTarget::Fullscreen`. (Confusingly most games seem to unfullscreen themselves before minimizing and restore fullscreen state after unminimizing... causing this weird transition in our code.)

This skips the set of events (thanks to https://github.com/Smithay/smithay/pull/1479), when the new target represents the same surface, which should be fine?!

Dunno, this probably needs some more testing to see, if it doesn't break other apps, but first tests seem promising.

Ref:
- https://github.com/pop-os/cosmic-comp/issues/601
- https://github.com/pop-os/cosmic-comp/issues/475
- https://github.com/pop-os/cosmic-comp/issues/383
- https://github.com/pop-os/cosmic-comp/issues/231