### PR TITLE
Render only layer shell surfaces when `cosmic-workspaces` is open, and add a `SplitRenderElements`

### DIFF
--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -7,11 +7,9 @@ use crate::{
     },
     shell::Shell,
     state::SurfaceDmabufFeedback,
-    utils::prelude::*,
+    utils::{prelude::*, quirks::workspace_overview_is_open},
     wayland::{
-        handlers::screencopy::{
-            submit_buffer, FrameHolder, SessionData, WORKSPACE_OVERVIEW_NAMESPACE,
-        },
+        handlers::screencopy::{submit_buffer, FrameHolder, SessionData},
         protocols::screencopy::{
             FailureReason, Frame as ScreencopyFrame, Session as ScreencopySession,
         },
@@ -48,7 +46,7 @@ use smithay::{
             Bind, ImportDma, Offscreen, Renderer, Texture,
         },
     },
-    desktop::{layer_map_for_output, utils::OutputPresentationFeedback},
+    desktop::utils::OutputPresentationFeedback,
     output::{Output, OutputNoMode},
     reexports::{
         calloop::{
@@ -871,10 +869,7 @@ impl SurfaceThreadState {
 
             std::mem::drop(shell);
 
-            let element_filter = if layer_map_for_output(output)
-                .layers()
-                .any(|s| s.namespace() == WORKSPACE_OVERVIEW_NAMESPACE)
-            {
+            let element_filter = if workspace_overview_is_open(output) {
                 ElementFilter::LayerShellOnly
             } else {
                 ElementFilter::All

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -58,7 +58,7 @@ use smithay::{
     desktop::{layer_map_for_output, PopupManager},
     input::Seat,
     output::{Output, OutputNoMode},
-    utils::{IsAlive, Logical, Monotonic, Point, Rectangle, Scale, Time, Transform},
+    utils::{IsAlive, Logical, Monotonic, Physical, Point, Rectangle, Scale, Time, Transform},
     wayland::{
         dmabuf::get_dmabuf,
         shell::wlr_layer::Layer,
@@ -464,6 +464,60 @@ where
 #[cfg(not(feature = "debug"))]
 pub type EguiState = ();
 
+#[derive(Clone, Debug)]
+pub struct SplitRenderElements<E> {
+    pub w_elements: Vec<E>,
+    pub p_elements: Vec<E>,
+}
+
+impl<E> Default for SplitRenderElements<E> {
+    fn default() -> Self {
+        Self {
+            w_elements: Vec::new(),
+            p_elements: Vec::new(),
+        }
+    }
+}
+
+impl<E> SplitRenderElements<E> {
+    pub fn extend(&mut self, other: Self) {
+        self.w_elements.extend(other.w_elements);
+        self.p_elements.extend(other.p_elements);
+    }
+
+    pub fn extend_map<E2, F: FnMut(E2) -> E>(&mut self, other: SplitRenderElements<E2>, mut f: F) {
+        self.w_elements
+            .extend(other.w_elements.into_iter().map(&mut f));
+        self.p_elements
+            .extend(other.p_elements.into_iter().map(&mut f));
+    }
+
+    pub fn join(mut self) -> Vec<E> {
+        self.p_elements.extend(self.w_elements);
+        self.p_elements
+    }
+}
+
+impl<R> SplitRenderElements<CosmicElement<R>>
+where
+    R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
+    CosmicMappedRenderElement<R>: RenderElement<R>,
+{
+    fn extend_from_workspace_elements<E: Into<WorkspaceRenderElement<R>>>(
+        &mut self,
+        other: SplitRenderElements<E>,
+        offset: Point<i32, Physical>,
+    ) {
+        self.extend_map(other, |element| {
+            CosmicElement::Workspace(RelocateRenderElement::from_element(
+                element.into(),
+                offset,
+                Relocate::Relative,
+            ))
+        })
+    }
+}
+
 #[profiling::function]
 pub fn workspace_elements<R>(
     _gpu: Option<&DrmNode>,
@@ -484,6 +538,8 @@ where
     CosmicMappedRenderElement<R>: RenderElement<R>,
     WorkspaceRenderElement<R>: RenderElement<R>,
 {
+    let mut elements = SplitRenderElements::default();
+
     let theme = shell.read().unwrap().theme().clone();
     let seats = shell
         .read()
@@ -493,7 +549,7 @@ where
         .cloned()
         .collect::<Vec<_>>();
 
-    let mut elements = cursor_elements(
+    elements.p_elements.extend(cursor_elements(
         renderer,
         seats.iter(),
         &theme,
@@ -501,7 +557,7 @@ where
         output,
         cursor_mode,
         exclude_workspace_overview,
-    );
+    ));
 
     #[cfg(feature = "debug")]
     {
@@ -525,7 +581,7 @@ where
             )
             .map_err(FromGlesError::from_gles_error)
             .map_err(RenderError::Rendering)?;
-            elements.push(fps_overlay.into());
+            elements.p_elements.push(fps_overlay.into());
         }
     }
 
@@ -533,12 +589,12 @@ where
 
     // If session locked, only show session lock surfaces
     if let Some(session_lock) = &shell.session_lock {
-        elements.extend(
+        elements.p_elements.extend(
             session_lock_elements(renderer, output, session_lock)
                 .into_iter()
                 .map(|x| WorkspaceRenderElement::from(x).into()),
         );
-        return Ok(elements);
+        return Ok(elements.join());
     }
 
     let theme = theme.cosmic();
@@ -586,20 +642,22 @@ where
         .as_ref()
         .filter(|f| !f.is_animating())
         .is_some();
-    let (overlay_elements, overlay_popups) =
+    let overlay_elements =
         split_layer_elements(renderer, output, Layer::Overlay, exclude_workspace_overview);
 
     // overlay is above everything
-    elements.extend(overlay_popups.into_iter().map(Into::into));
-    elements.extend(overlay_elements.into_iter().map(Into::into));
+    elements
+        .p_elements
+        .extend(overlay_elements.p_elements.into_iter().map(Into::into));
+    elements
+        .p_elements
+        .extend(overlay_elements.w_elements.into_iter().map(Into::into));
 
-    let mut window_elements = if !has_fullscreen {
-        let (top_elements, top_popups) =
-            split_layer_elements(renderer, output, Layer::Top, exclude_workspace_overview);
-        elements.extend(top_popups.into_iter().map(Into::into));
-        top_elements.into_iter().map(Into::into).collect()
-    } else {
-        Vec::new()
+    if !has_fullscreen {
+        elements.extend_from_workspace_elements(
+            split_layer_elements(renderer, output, Layer::Top, exclude_workspace_overview),
+            (0, 0).into(),
+        );
     };
 
     let active_hint = if shell.active_hint {
@@ -611,7 +669,7 @@ where
     // overlay redirect windows
     // they need to be over sticky windows, because they could be popups of sticky windows,
     // and we can't differenciate that.
-    elements.extend(
+    elements.p_elements.extend(
         shell
             .override_redirect_windows
             .iter()
@@ -632,13 +690,7 @@ where
                     1.0,
                 )
             })
-            .map(|p_element| {
-                CosmicElement::Workspace(RelocateRenderElement::from_element(
-                    p_element,
-                    (0, 0),
-                    Relocate::Relative,
-                ))
-            }),
+            .map(|p_element| p_element.into()),
     );
 
     // sticky windows
@@ -664,29 +716,17 @@ where
             .then_some(last_active_seat)
             .map(|seat| workspace.focus_stack.get(seat));
 
-        let (w_elements, p_elements) = set.sticky_layer.render(
-            renderer,
-            current_focus.as_ref().and_then(|stack| stack.last()),
-            resize_indicator.clone(),
-            active_hint,
-            alpha,
-            theme,
+        elements.extend_from_workspace_elements(
+            set.sticky_layer.render(
+                renderer,
+                current_focus.as_ref().and_then(|stack| stack.last()),
+                resize_indicator.clone(),
+                active_hint,
+                alpha,
+                theme,
+            ),
+            (0, 0).into(),
         );
-
-        elements.extend(p_elements.into_iter().map(|p_element| {
-            CosmicElement::Workspace(RelocateRenderElement::from_element(
-                WorkspaceRenderElement::Window(p_element),
-                (0, 0),
-                Relocate::Relative,
-            ))
-        }));
-        window_elements.extend(w_elements.into_iter().map(|w_element| {
-            CosmicElement::Workspace(RelocateRenderElement::from_element(
-                WorkspaceRenderElement::Window(w_element),
-                (0, 0),
-                Relocate::Relative,
-            ))
-        }));
     }
 
     let offset = match previous.as_ref() {
@@ -728,48 +768,25 @@ where
                 }
             });
 
-            let (w_elements, p_elements) = workspace
-                .render::<R>(
-                    renderer,
-                    (!move_active && is_active_space).then_some(last_active_seat),
-                    overview.clone(),
-                    resize_indicator.clone(),
-                    active_hint,
-                    theme,
-                )
-                .map_err(|_| OutputNoMode)?;
-            elements.extend(p_elements.into_iter().map(|p_element| {
-                CosmicElement::Workspace(RelocateRenderElement::from_element(
-                    p_element,
-                    offset.to_physical_precise_round(output_scale),
-                    Relocate::Relative,
-                ))
-            }));
-            window_elements.extend(w_elements.into_iter().map(|w_element| {
-                CosmicElement::Workspace(RelocateRenderElement::from_element(
-                    w_element,
-                    offset.to_physical_precise_round(output_scale),
-                    Relocate::Relative,
-                ))
-            }));
+            elements.extend_from_workspace_elements(
+                workspace
+                    .render::<R>(
+                        renderer,
+                        (!move_active && is_active_space).then_some(last_active_seat),
+                        overview.clone(),
+                        resize_indicator.clone(),
+                        active_hint,
+                        theme,
+                    )
+                    .map_err(|_| OutputNoMode)?,
+                offset.to_physical_precise_round(output_scale),
+            );
 
             if !has_fullscreen {
-                let (w_elements, p_elements) =
-                    background_layer_elements(renderer, output, exclude_workspace_overview);
-                elements.extend(p_elements.into_iter().map(|p_element| {
-                    CosmicElement::Workspace(RelocateRenderElement::from_element(
-                        p_element,
-                        offset.to_physical_precise_round(output_scale),
-                        Relocate::Relative,
-                    ))
-                }));
-                window_elements.extend(w_elements.into_iter().map(|w_element| {
-                    CosmicElement::Workspace(RelocateRenderElement::from_element(
-                        w_element,
-                        offset.to_physical_precise_round(output_scale),
-                        Relocate::Relative,
-                    ))
-                }));
+                elements.extend_from_workspace_elements(
+                    background_layer_elements(renderer, output, exclude_workspace_overview),
+                    offset.to_physical_precise_round(output_scale),
+                );
             }
 
             Point::<i32, Logical>::from(match (layout, *previous_idx < current.1) {
@@ -782,55 +799,28 @@ where
         None => (0, 0).into(),
     };
 
-    let (w_elements, p_elements) = workspace
-        .render::<R>(
-            renderer,
-            (!move_active && is_active_space).then_some(&last_active_seat),
-            overview,
-            resize_indicator,
-            active_hint,
-            theme,
-        )
-        .map_err(|_| OutputNoMode)?;
-    elements.extend(p_elements.into_iter().map(|p_element| {
-        CosmicElement::Workspace(RelocateRenderElement::from_element(
-            p_element,
-            offset.to_physical_precise_round(output_scale),
-            Relocate::Relative,
-        ))
-    }));
-    window_elements.extend(w_elements.into_iter().map(|w_element| {
-        CosmicElement::Workspace(RelocateRenderElement::from_element(
-            w_element,
-            offset.to_physical_precise_round(output_scale),
-            Relocate::Relative,
-        ))
-    }));
+    elements.extend_from_workspace_elements(
+        workspace
+            .render::<R>(
+                renderer,
+                (!move_active && is_active_space).then_some(&last_active_seat),
+                overview,
+                resize_indicator,
+                active_hint,
+                theme,
+            )
+            .map_err(|_| OutputNoMode)?,
+        offset.to_physical_precise_round(output_scale),
+    );
 
     if !has_fullscreen {
-        let (w_elements, p_elements) =
-            background_layer_elements(renderer, output, exclude_workspace_overview);
-
-        elements.extend(p_elements.into_iter().map(|p_element| {
-            CosmicElement::Workspace(RelocateRenderElement::from_element(
-                p_element,
-                offset.to_physical_precise_round(output_scale),
-                Relocate::Relative,
-            ))
-        }));
-
-        window_elements.extend(w_elements.into_iter().map(|w_element| {
-            CosmicElement::Workspace(RelocateRenderElement::from_element(
-                w_element,
-                offset.to_physical_precise_round(output_scale),
-                Relocate::Relative,
-            ))
-        }));
+        elements.extend_from_workspace_elements(
+            background_layer_elements(renderer, output, exclude_workspace_overview),
+            offset.to_physical_precise_round(output_scale),
+        );
     }
 
-    elements.extend(window_elements);
-
-    Ok(elements)
+    Ok(elements.join())
 }
 
 pub fn split_layer_elements<R>(
@@ -838,10 +828,7 @@ pub fn split_layer_elements<R>(
     output: &Output,
     layer: Layer,
     exclude_workspace_overview: bool,
-) -> (
-    Vec<WorkspaceRenderElement<R>>,
-    Vec<WorkspaceRenderElement<R>>,
-)
+) -> SplitRenderElements<WorkspaceRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
     <R as Renderer>::TextureId: Clone + 'static,
@@ -852,8 +839,7 @@ where
     let layer_map = layer_map_for_output(output);
     let output_scale = output.current_scale().fractional_scale();
 
-    let mut popup_elements = Vec::new();
-    let mut layer_elements = Vec::new();
+    let mut elements = SplitRenderElements::default();
 
     layer_map
         .layers_on(layer)
@@ -869,35 +855,39 @@ where
             let surface = surface.wl_surface();
             let scale = Scale::from(output_scale);
 
-            popup_elements.extend(PopupManager::popups_for_surface(surface).flat_map(
-                |(popup, popup_offset)| {
-                    let offset = (popup_offset - popup.geometry().loc)
-                        .to_f64()
-                        .to_physical(scale)
-                        .to_i32_round();
+            elements
+                .p_elements
+                .extend(PopupManager::popups_for_surface(surface).flat_map(
+                    |(popup, popup_offset)| {
+                        let offset = (popup_offset - popup.geometry().loc)
+                            .to_f64()
+                            .to_physical(scale)
+                            .to_i32_round();
 
-                    render_elements_from_surface_tree(
-                        renderer,
-                        popup.wl_surface(),
-                        location + offset,
-                        scale,
-                        1.0,
-                        Kind::Unspecified,
-                    )
-                },
-            ));
+                        render_elements_from_surface_tree(
+                            renderer,
+                            popup.wl_surface(),
+                            location + offset,
+                            scale,
+                            1.0,
+                            Kind::Unspecified,
+                        )
+                    },
+                ));
 
-            layer_elements.extend(render_elements_from_surface_tree(
-                renderer,
-                surface,
-                location,
-                scale,
-                1.0,
-                Kind::Unspecified,
-            ));
+            elements
+                .w_elements
+                .extend(render_elements_from_surface_tree(
+                    renderer,
+                    surface,
+                    location,
+                    scale,
+                    1.0,
+                    Kind::Unspecified,
+                ));
         });
 
-    (layer_elements, popup_elements)
+    elements
 }
 
 // bottom and background layer surfaces
@@ -905,10 +895,7 @@ pub fn background_layer_elements<R>(
     renderer: &mut R,
     output: &Output,
     exclude_workspace_overview: bool,
-) -> (
-    Vec<WorkspaceRenderElement<R>>,
-    Vec<WorkspaceRenderElement<R>>,
-)
+) -> SplitRenderElements<WorkspaceRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
     <R as Renderer>::TextureId: Clone + 'static,
@@ -916,17 +903,15 @@ where
     CosmicMappedRenderElement<R>: RenderElement<R>,
     WorkspaceRenderElement<R>: RenderElement<R>,
 {
-    let (mut layer_elements, mut popup_elements) =
+    let mut elements =
         split_layer_elements(renderer, output, Layer::Bottom, exclude_workspace_overview);
-    let more = split_layer_elements(
+    elements.extend(split_layer_elements(
         renderer,
         output,
         Layer::Background,
         exclude_workspace_overview,
-    );
-    layer_elements.extend(more.0);
-    popup_elements.extend(more.1);
-    (layer_elements, popup_elements)
+    ));
+    elements
 }
 
 fn session_lock_elements<R>(

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -20,7 +20,10 @@ use crate::{
         CosmicMappedRenderElement, OverviewMode, SeatExt, SessionLock, Trigger, WorkspaceDelta,
         WorkspaceRenderElement,
     },
-    utils::{prelude::*, quirks::WORKSPACE_OVERVIEW_NAMESPACE},
+    utils::{
+        prelude::*,
+        quirks::{workspace_overview_is_open, WORKSPACE_OVERVIEW_NAMESPACE},
+    },
     wayland::{
         handlers::{
             data_device::get_dnd_icon,
@@ -988,6 +991,12 @@ where
     let workspace = (workspace.handle, idx);
     std::mem::drop(shell_ref);
 
+    let element_filter = if workspace_overview_is_open(output) {
+        ElementFilter::LayerShellOnly
+    } else {
+        ElementFilter::All
+    };
+
     let result = render_workspace(
         gpu,
         renderer,
@@ -1001,7 +1010,7 @@ where
         previous_workspace,
         workspace,
         cursor_mode,
-        ElementFilter::All,
+        element_filter,
     );
 
     match result {

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -20,11 +20,11 @@ use crate::{
         CosmicMappedRenderElement, OverviewMode, SeatExt, SessionLock, Trigger, WorkspaceDelta,
         WorkspaceRenderElement,
     },
-    utils::prelude::*,
+    utils::{prelude::*, quirks::WORKSPACE_OVERVIEW_NAMESPACE},
     wayland::{
         handlers::{
             data_device::get_dnd_icon,
-            screencopy::{render_session, FrameHolder, SessionData, WORKSPACE_OVERVIEW_NAMESPACE},
+            screencopy::{render_session, FrameHolder, SessionData},
         },
         protocols::workspace::WorkspaceHandle,
     },

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         FocusResult, InvalidWorkspaceIndex, MoveResult, OverviewMode, ResizeMode, SeatExt, Trigger,
         WorkspaceDelta,
     },
-    utils::prelude::*,
+    utils::{prelude::*, quirks::workspace_overview_is_open},
     wayland::{
         handlers::{screencopy::SessionHolder, xdg_activation::ActivationContext},
         protocols::{
@@ -1000,7 +1000,7 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    if event.fingers() >= 3 {
+                    if event.fingers() >= 3 && !workspace_overview_is_open(&seat.active_output()) {
                         self.common.gesture_state = Some(GestureState::new(event.fingers()));
                     } else {
                         let serial = SERIAL_COUNTER.next_serial();

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -4,7 +4,7 @@ use crate::{
     backend::render::{
         cursor::{CursorShape, CursorState},
         element::AsGlowRenderer,
-        BackdropShader, IndicatorShader, Key, Usage,
+        BackdropShader, IndicatorShader, Key, SplitRenderElements, Usage,
     },
     shell::{
         element::{
@@ -182,7 +182,10 @@ impl MoveGrabState {
             _ => vec![],
         };
 
-        let (window_elements, popup_elements) = self
+        let SplitRenderElements {
+            w_elements,
+            p_elements,
+        } = self
             .window
             .split_render_elements::<R, CosmicMappedRenderElement<R>>(
                 renderer,
@@ -202,9 +205,9 @@ impl MoveGrabState {
                     1.0,
                 )
             })
-            .chain(popup_elements)
+            .chain(p_elements)
             .chain(focus_element)
-            .chain(window_elements.into_iter().map(|elem| match elem {
+            .chain(w_elements.into_iter().map(|elem| match elem {
                 CosmicMappedRenderElement::Stack(stack) => {
                     CosmicMappedRenderElement::GrabbedStack(
                         RescaleRenderElement::from_element(

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     backend::render::{
-        element::AsGlowRenderer, BackdropShader, IndicatorShader, Key, Usage, ACTIVE_GROUP_COLOR,
-        GROUP_COLOR,
+        element::AsGlowRenderer, BackdropShader, IndicatorShader, Key, SplitRenderElements, Usage,
+        ACTIVE_GROUP_COLOR, GROUP_COLOR,
     },
     shell::{
         element::{
@@ -3846,13 +3846,7 @@ impl TilingLayout {
         resize_indicator: Option<(ResizeMode, ResizeIndicator)>,
         indicator_thickness: u8,
         theme: &cosmic::theme::CosmicTheme,
-    ) -> Result<
-        (
-            Vec<CosmicMappedRenderElement<R>>,
-            Vec<CosmicMappedRenderElement<R>>,
-        ),
-        OutputNotMapped,
-    >
+    ) -> Result<SplitRenderElements<CosmicMappedRenderElement<R>>, OutputNotMapped>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
         <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -3885,8 +3879,7 @@ impl TilingLayout {
         };
         let draw_groups = overview.0.alpha();
 
-        let mut window_elements = Vec::new();
-        let mut popup_elements = Vec::new();
+        let mut elements = SplitRenderElements::default();
 
         let is_overview = !matches!(overview.0, OverviewMode::None);
         let is_mouse_tiling = (matches!(overview.0, OverviewMode::Started(Trigger::Pointer(_), _)))
@@ -3921,7 +3914,7 @@ impl TilingLayout {
             .unzip();
 
             // all old windows we want to fade out
-            let (w_elements, p_elements) = render_old_tree(
+            elements.extend(render_old_tree(
                 reference_tree,
                 target_tree,
                 renderer,
@@ -3931,9 +3924,7 @@ impl TilingLayout {
                 indicator_thickness,
                 swap_desc.is_some(),
                 theme,
-            );
-            window_elements.extend(w_elements);
-            popup_elements.extend(p_elements);
+            ));
 
             geometries
         } else {
@@ -3961,7 +3952,7 @@ impl TilingLayout {
         .unzip();
 
         // all alive windows
-        let (w_elements, p_elements) = render_new_tree(
+        elements.extend(render_new_tree(
             target_tree,
             reference_tree,
             renderer,
@@ -3989,16 +3980,14 @@ impl TilingLayout {
             &self.swapping_stack_surface_id,
             &self.placeholder_id,
             theme,
-        );
-        window_elements.extend(w_elements);
-        popup_elements.extend(p_elements);
+        ));
 
         // tiling hints
         if let Some(group_elements) = group_elements {
-            window_elements.extend(group_elements);
+            elements.w_elements.extend(group_elements);
         }
 
-        Ok((window_elements, popup_elements))
+        Ok(elements)
     }
 
     fn gaps(&self) -> (i32, i32) {
@@ -4694,10 +4683,7 @@ fn render_old_tree<R>(
     indicator_thickness: u8,
     is_swap_mode: bool,
     theme: &cosmic::theme::CosmicTheme,
-) -> (
-    Vec<CosmicMappedRenderElement<R>>,
-    Vec<CosmicMappedRenderElement<R>>,
-)
+) -> SplitRenderElements<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
     <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -4706,8 +4692,7 @@ where
     CosmicStackRenderElement<R>: RenderElement<R>,
 {
     let window_hint = crate::theme::active_window_hint(theme);
-    let mut window_elements = Vec::new();
-    let mut popup_elements = Vec::new();
+    let mut elements = SplitRenderElements::default();
 
     if let Some(root) = reference_tree.root_node_id() {
         let geometries = geometries.unwrap_or_default();
@@ -4777,62 +4762,68 @@ where
                 };
 
                 let elem_geometry = mapped.geometry().to_physical_precise_round(output_scale);
-                let (w_elements, p_elements) = mapped
-                    .split_render_elements::<R, CosmicMappedRenderElement<R>>(
-                        renderer,
-                        geo.loc.as_logical().to_physical_precise_round(output_scale)
-                            - elem_geometry.loc,
-                        Scale::from(output_scale),
-                        alpha,
-                    );
+                let SplitRenderElements {
+                    w_elements,
+                    p_elements,
+                } = mapped.split_render_elements::<R, CosmicMappedRenderElement<R>>(
+                    renderer,
+                    geo.loc.as_logical().to_physical_precise_round(output_scale)
+                        - elem_geometry.loc,
+                    Scale::from(output_scale),
+                    alpha,
+                );
 
-                window_elements.extend(w_elements.into_iter().flat_map(|element| {
-                    match element {
-                        CosmicMappedRenderElement::Stack(elem) => constrain_render_elements(
-                            std::iter::once(elem),
-                            geo.loc.as_logical().to_physical_precise_round(output_scale)
-                                - elem_geometry.loc,
-                            geo.as_logical().to_physical_precise_round(output_scale),
-                            elem_geometry,
-                            ConstrainScaleBehavior::Stretch,
-                            ConstrainAlign::CENTER,
-                            output_scale,
-                        )
-                        .next()
-                        .map(CosmicMappedRenderElement::TiledStack),
-                        CosmicMappedRenderElement::Window(elem) => constrain_render_elements(
-                            std::iter::once(elem),
-                            geo.loc.as_logical().to_physical_precise_round(output_scale)
-                                - elem_geometry.loc,
-                            geo.as_logical().to_physical_precise_round(output_scale),
-                            elem_geometry,
-                            ConstrainScaleBehavior::Stretch,
-                            ConstrainAlign::CENTER,
-                            output_scale,
-                        )
-                        .next()
-                        .map(CosmicMappedRenderElement::TiledWindow),
-                        x => Some(x),
-                    }
-                }));
+                elements
+                    .w_elements
+                    .extend(w_elements.into_iter().flat_map(|element| {
+                        match element {
+                            CosmicMappedRenderElement::Stack(elem) => constrain_render_elements(
+                                std::iter::once(elem),
+                                geo.loc.as_logical().to_physical_precise_round(output_scale)
+                                    - elem_geometry.loc,
+                                geo.as_logical().to_physical_precise_round(output_scale),
+                                elem_geometry,
+                                ConstrainScaleBehavior::Stretch,
+                                ConstrainAlign::CENTER,
+                                output_scale,
+                            )
+                            .next()
+                            .map(CosmicMappedRenderElement::TiledStack),
+                            CosmicMappedRenderElement::Window(elem) => constrain_render_elements(
+                                std::iter::once(elem),
+                                geo.loc.as_logical().to_physical_precise_round(output_scale)
+                                    - elem_geometry.loc,
+                                geo.as_logical().to_physical_precise_round(output_scale),
+                                elem_geometry,
+                                ConstrainScaleBehavior::Stretch,
+                                ConstrainAlign::CENTER,
+                                output_scale,
+                            )
+                            .next()
+                            .map(CosmicMappedRenderElement::TiledWindow),
+                            x => Some(x),
+                        }
+                    }));
                 if minimize_geo.is_some() && indicator_thickness > 0 {
-                    window_elements.push(CosmicMappedRenderElement::FocusIndicator(
-                        IndicatorShader::focus_element(
-                            renderer,
-                            Key::Window(Usage::FocusIndicator, mapped.clone().key()),
-                            geo,
-                            indicator_thickness,
-                            output_scale,
-                            alpha,
-                            [window_hint.red, window_hint.green, window_hint.blue],
-                        ),
-                    ));
+                    elements
+                        .w_elements
+                        .push(CosmicMappedRenderElement::FocusIndicator(
+                            IndicatorShader::focus_element(
+                                renderer,
+                                Key::Window(Usage::FocusIndicator, mapped.clone().key()),
+                                geo,
+                                indicator_thickness,
+                                output_scale,
+                                alpha,
+                                [window_hint.red, window_hint.green, window_hint.blue],
+                            ),
+                        ));
                 }
-                popup_elements.extend(p_elements);
+                elements.p_elements.extend(p_elements);
             });
     }
 
-    (window_elements, popup_elements)
+    elements
 }
 
 fn render_new_tree<R>(
@@ -4854,10 +4845,7 @@ fn render_new_tree<R>(
     swapping_stack_surface_id: &Id,
     placeholder_id: &Id,
     theme: &cosmic::theme::CosmicTheme,
-) -> (
-    Vec<CosmicMappedRenderElement<R>>,
-    Vec<CosmicMappedRenderElement<R>>,
-)
+) -> SplitRenderElements<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
     <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -5246,15 +5234,17 @@ where
 
             if let Data::Mapped { mapped, .. } = data {
                 let elem_geometry = mapped.geometry().to_physical_precise_round(output_scale);
-                let (mut w_elements, p_elements) = mapped
-                    .split_render_elements::<R, CosmicMappedRenderElement<R>>(
-                        renderer,
-                        //original_location,
-                        geo.loc.as_logical().to_physical_precise_round(output_scale)
-                            - elem_geometry.loc,
-                        Scale::from(output_scale),
-                        alpha,
-                    );
+                let SplitRenderElements {
+                    mut w_elements,
+                    p_elements,
+                } = mapped.split_render_elements::<R, CosmicMappedRenderElement<R>>(
+                    renderer,
+                    //original_location,
+                    geo.loc.as_logical().to_physical_precise_round(output_scale)
+                        - elem_geometry.loc,
+                    Scale::from(output_scale),
+                    alpha,
+                );
                 if swap_desc
                     .as_ref()
                     .filter(|swap_desc| swap_desc.node == node_id)
@@ -5373,7 +5363,10 @@ where
         .chain(group_backdrop.into_iter().map(Into::into))
         .collect();
 
-    (window_elements, popup_elements)
+    SplitRenderElements {
+        w_elements: window_elements,
+        p_elements: popup_elements,
+    }
 }
 
 fn scale_to_center<C>(

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -52,11 +52,11 @@ use smithay::{
 use crate::{
     backend::render::animations::spring::{Spring, SpringParams},
     config::Config,
-    utils::prelude::*,
+    utils::{prelude::*, quirks::WORKSPACE_OVERVIEW_NAMESPACE},
     wayland::{
         handlers::{
-            screencopy::WORKSPACE_OVERVIEW_NAMESPACE, toplevel_management::minimize_rectangle,
-            xdg_activation::ActivationContext, xdg_shell::popup::get_popup_toplevel,
+            toplevel_management::minimize_rectangle, xdg_activation::ActivationContext,
+            xdg_shell::popup::get_popup_toplevel,
         },
         protocols::{
             toplevel_info::{

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::render::{
         element::{AsGlowFrame, AsGlowRenderer},
-        BackdropShader, GlMultiError, GlMultiFrame, GlMultiRenderer,
+        BackdropShader, GlMultiError, GlMultiFrame, GlMultiRenderer, SplitRenderElements,
     },
     shell::{
         layout::{floating::FloatingLayout, tiling::TilingLayout},
@@ -1005,13 +1005,7 @@ impl Workspace {
         resize_indicator: Option<(ResizeMode, ResizeIndicator)>,
         indicator_thickness: u8,
         theme: &CosmicTheme,
-    ) -> Result<
-        (
-            Vec<WorkspaceRenderElement<R>>,
-            Vec<WorkspaceRenderElement<R>>,
-        ),
-        OutputNotMapped,
-    >
+    ) -> Result<SplitRenderElements<WorkspaceRenderElement<R>>, OutputNotMapped>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
         <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -1020,8 +1014,7 @@ impl Workspace {
         CosmicStackRenderElement<R>: RenderElement<R>,
         WorkspaceRenderElement<R>: RenderElement<R>,
     {
-        let mut window_elements = Vec::new();
-        let mut popup_elements = Vec::new();
+        let mut elements = SplitRenderElements::default();
 
         let output_scale = self.output.current_scale().fractional_scale();
         let zone = {
@@ -1104,7 +1097,10 @@ impl Workspace {
                 y: target_geo.size.h as f64 / bbox.size.h as f64,
             };
 
-            let (w_elements, p_elements) = fullscreen
+            let SplitRenderElements {
+                w_elements,
+                p_elements,
+            } = fullscreen
                 .surface
                 .split_render_elements::<R, CosmicWindowRenderElement<R>>(
                     renderer,
@@ -1112,13 +1108,15 @@ impl Workspace {
                     output_scale.into(),
                     alpha,
                 );
-            window_elements.extend(
+            elements.w_elements.extend(
                 w_elements
                     .into_iter()
                     .map(|elem| RescaleRenderElement::from_element(elem, render_loc, scale))
                     .map(Into::into),
             );
-            popup_elements.extend(p_elements.into_iter().map(Into::into));
+            elements
+                .p_elements
+                .extend(p_elements.into_iter().map(Into::into))
         }
 
         if self
@@ -1149,16 +1147,17 @@ impl Workspace {
                 OverviewMode::None => 1.0,
             };
 
-            let (w_elements, p_elements) = self.floating_layer.render::<R>(
-                renderer,
-                focused.as_ref(),
-                resize_indicator.clone(),
-                indicator_thickness,
-                alpha,
-                theme,
+            elements.extend_map(
+                self.floating_layer.render::<R>(
+                    renderer,
+                    focused.as_ref(),
+                    resize_indicator.clone(),
+                    indicator_thickness,
+                    alpha,
+                    theme,
+                ),
+                WorkspaceRenderElement::from,
             );
-            popup_elements.extend(p_elements.into_iter().map(WorkspaceRenderElement::from));
-            window_elements.extend(w_elements.into_iter().map(WorkspaceRenderElement::from));
 
             let alpha = match &overview.0 {
                 OverviewMode::Started(_, start) => Some(
@@ -1173,20 +1172,21 @@ impl Workspace {
             };
 
             //tiling surfaces
-            let (w_elements, p_elements) = self.tiling_layer.render::<R>(
-                renderer,
-                draw_focus_indicator,
-                zone,
-                overview,
-                resize_indicator,
-                indicator_thickness,
-                theme,
-            )?;
-            popup_elements.extend(p_elements.into_iter().map(WorkspaceRenderElement::from));
-            window_elements.extend(w_elements.into_iter().map(WorkspaceRenderElement::from));
+            elements.extend_map(
+                self.tiling_layer.render::<R>(
+                    renderer,
+                    draw_focus_indicator,
+                    zone,
+                    overview,
+                    resize_indicator,
+                    indicator_thickness,
+                    theme,
+                )?,
+                WorkspaceRenderElement::from,
+            );
 
             if let Some(alpha) = alpha {
-                window_elements.push(
+                elements.w_elements.push(
                     Into::<CosmicMappedRenderElement<R>>::into(BackdropShader::element(
                         renderer,
                         self.backdrop_id.clone(),
@@ -1203,7 +1203,7 @@ impl Workspace {
             }
         }
 
-        Ok((window_elements, popup_elements))
+        Ok(elements)
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,7 @@ pub(crate) use self::ids::id_gen;
 pub mod geometry;
 pub mod iced;
 pub mod prelude;
+pub mod quirks;
 pub mod rlimit;
 pub mod screenshot;
 pub mod tween;

--- a/src/utils/quirks.rs
+++ b/src/utils/quirks.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use smithay::{desktop::layer_map_for_output, output::Output};
+
+/// Layer shell namespace used by `cosmic-workspaces`
+// TODO: Avoid special case, or add protocol to expose required behavior
+pub const WORKSPACE_OVERVIEW_NAMESPACE: &str = "cosmic-workspace-overview";
+
+/// Check if a workspace overview shell surface is open on the output
+pub fn workspace_overview_is_open(output: &Output) -> bool {
+    layer_map_for_output(output)
+        .layers()
+        .any(|s| s.namespace() == WORKSPACE_OVERVIEW_NAMESPACE)
+}

--- a/src/wayland/handlers/screencopy/mod.rs
+++ b/src/wayland/handlers/screencopy/mod.rs
@@ -39,8 +39,6 @@ pub use self::render::*;
 use self::user_data::*;
 pub use self::user_data::{FrameHolder, ScreencopySessions, SessionData, SessionHolder};
 
-pub const WORKSPACE_OVERVIEW_NAMESPACE: &str = "cosmic-workspace-overview";
-
 impl ScreencopyHandler for State {
     fn screencopy_state(&mut self) -> &mut ScreencopyState {
         &mut self.common.screencopy_state

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -36,7 +36,7 @@ use crate::{
     backend::render::{
         cursor,
         element::{AsGlowRenderer, CosmicElement, DamageElement, FromGlesError},
-        render_workspace, CursorMode, CLEAR_COLOR,
+        render_workspace, CursorMode, ElementFilter, CLEAR_COLOR,
     },
     shell::{CosmicMappedRenderElement, CosmicSurface, WorkspaceRenderElement},
     state::{BackendData, Common, State},
@@ -287,7 +287,7 @@ pub fn render_workspace_to_buffer(
                 None,
                 handle,
                 cursor_mode,
-                true,
+                ElementFilter::ExcludeWorkspaceOverview,
             )
             .map(|res| res.0)
         } else {
@@ -316,7 +316,7 @@ pub fn render_workspace_to_buffer(
                 None,
                 handle,
                 cursor_mode,
-                true,
+                ElementFilter::ExcludeWorkspaceOverview,
             )
             .map(|res| res.0)
         }


### PR DESCRIPTION
This helps with issues like https://github.com/pop-os/cosmic-workspaces-epoch/issues/59.

I'm not entirely happy with the growing complexity of `workspace_elements`. I was thinking of a couple ways to split it up, noticed the most redundant part was the repeated code extending `p_elements` and `w_elements`. And the cleanest way to de-duplicate that out is with a dedicated `SplitRenderElements` type, which could be good in general. I have a commit adding that.

This also adds the commit from https://github.com/pop-os/cosmic-comp/pull/459, which makes more of a difference now. (If we wanted an animation between workspaces with this, we'd need to make sure `cosmic-comp` and `cosmic-comp` animate in sync.)

This seems to generally work with cosmic-workspaces modified to leave the background transparent. But I still need to do a bit more testing with it. (And I guess make this change on apply to the X11/winit backends.)