### PR TITLE
Move tiling exceptions to configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#362c77f9faaeb7f1b9e4aa79a7d5588001f04874"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon#1ed68808e85ce681da882446ec572d44c68a6866"
 dependencies = [
  "cosmic-config",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ endif
 TARGET_BIN="$(DESTDIR)$(bindir)/$(BINARY)"
 
 KEYBINDINGS_CONF="$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicSettings.Shortcuts/v1/defaults"
+TILING_EXCEPTIONS_CONF="$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicComp/v1/tiling_exceptions"
 
 all: extract-vendor
 	cargo build $(ARGS)
@@ -49,6 +50,7 @@ endif
 install:
 	install -Dm0755 "$(CARGO_TARGET_DIR)/$(TARGET)/$(BINARY)" "$(TARGET_BIN)"
 	install -Dm0644 "data/keybindings.ron" "$(KEYBINDINGS_CONF)"
+	install -Dm0644 "data/tiling-exceptions.ron" "$(TILING_EXCEPTIONS_CONF)"
 
 install-bare-session: install
 	install -Dm0644 "data/cosmic.desktop" "$(DESTDIR)$(sharedir)/wayland-sessions/cosmic.desktop"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 TARGET_BIN="$(DESTDIR)$(bindir)/$(BINARY)"
 
 KEYBINDINGS_CONF="$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicSettings.Shortcuts/v1/defaults"
-TILING_EXCEPTIONS_CONF="$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicComp/v1/tiling_exceptions"
+TILING_EXCEPTIONS_CONF="$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicSettings.WindowRules/v1/tiling_exception_defaults"
 
 all: extract-vendor
 	cargo build $(ARGS)

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -15,7 +15,6 @@ pub struct CosmicCompConfig {
     pub input_touchpad: input::InputConfig,
     pub input_devices: HashMap<String, input::InputConfig>,
     pub xkb_config: XkbConfig,
-    pub tiling_exceptions: Vec<ApplicationExceptions>,
     /// Autotiling enabled
     pub autotile: bool,
     /// Determines the behavior of the autotile variable
@@ -24,12 +23,6 @@ pub struct CosmicCompConfig {
     pub autotile_behavior: TileBehavior,
     /// Active hint enabled
     pub active_hint: bool,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct ApplicationExceptions {
-    pub appid: String,
-    pub titles: Vec<String>,
 }
 
 impl Default for CosmicCompConfig {
@@ -52,7 +45,6 @@ impl Default for CosmicCompConfig {
             },
             input_devices: Default::default(),
             xkb_config: Default::default(),
-            tiling_exceptions: Default::default(),
             autotile: Default::default(),
             autotile_behavior: Default::default(),
             active_hint: true,

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -15,6 +15,7 @@ pub struct CosmicCompConfig {
     pub input_touchpad: input::InputConfig,
     pub input_devices: HashMap<String, input::InputConfig>,
     pub xkb_config: XkbConfig,
+    pub tiling_exceptions: Vec<ApplicationExceptions>,
     /// Autotiling enabled
     pub autotile: bool,
     /// Determines the behavior of the autotile variable
@@ -23,6 +24,12 @@ pub struct CosmicCompConfig {
     pub autotile_behavior: TileBehavior,
     /// Active hint enabled
     pub active_hint: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct ApplicationExceptions {
+    pub appid: String,
+    pub titles: Vec<String>,
 }
 
 impl Default for CosmicCompConfig {
@@ -45,6 +52,7 @@ impl Default for CosmicCompConfig {
             },
             input_devices: Default::default(),
             xkb_config: Default::default(),
+            tiling_exceptions: Default::default(),
             autotile: Default::default(),
             autotile_behavior: Default::default(),
             active_hint: true,

--- a/data/tiling-exceptions.ron
+++ b/data/tiling-exceptions.ron
@@ -1,0 +1,49 @@
+[
+	// Any appid title only matching
+	(
+		appid: ".*", 
+		titles: [
+			"Discord Updater",
+		]
+	),
+	// Empty appid title only matches
+	(
+		appid: "", 
+		titles: [
+			"Steam",
+			"wl-clipboard",
+		]
+	),
+
+
+	// Appid matches
+	(appid: "Authy Desktop", titles: [".*"]),
+	(appid: "Com.github.amezin.ddterm", titles: [".*"]),
+	(appid: "Com.github.donadigo.eddy", titles: [".*"]),
+	(appid: "Enpass", titles: ["Enpass Assistant"]),
+	(appid: "Gjs", titles: ["Settings"]),
+	(appid: "Gnome-initial-setup", titles: [".*"]),
+	(appid: "Gnome-terminal", titles: ["Preferences - General"]),
+	(appid: "Guake", titles: [".*"]),
+	(appid: "Io.elementary.sideload", titles: [".*"]),
+	(appid: "KotatogramDesktop", titles: ["Media viewer"]),
+	(appid: "Mozilla VPN", titles: [".*"]),
+	(appid: "update-manager", titles: ["Software Updater"]),
+	(appid: "Solaar", titles: [".*"]),
+	(appid: "Steam", titles: ["^.*?(Guard|Login).*"]),
+	(appid: "TelegramDesktop", titles: ["Media viewer"]),
+	(appid: "Zotero", titles: ["Quick Format Citation"]),
+	(appid: "gjs", titles: [".*"]),
+	(appid: "gnome-screenshot", titles: [".*"]),
+	(appid: "ibus-.*", titles: [".*"]),
+	(appid: "jetbrains-toolbox", titles: [".*"]),
+	(appid: "jetbrains-webstorm", titles: ["Customize WebStorm", "License Activation", "Welcome to WebStorm"]),
+	(appid: "krunner", titles: [".*"]),
+	(appid: "pritunl", titles: [".*"]),
+	(appid: "re.sonny.Junction", titles: [".*"]),
+	(appid: "system76-driver", titles: [".*"]),
+	(appid: "tilda", titles: [".*"]),
+	(appid: "zoom", titles: [".*"]),
+	(appid: "^.*?action=join.*$", titles: [".*"]),
+
+]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,7 @@ use cosmic_comp_config::{
 pub struct Config {
     pub dynamic_conf: DynamicConfig,
     pub cosmic_helper: cosmic_config::Config,
+    /// cosmic-config comp configuration for `com.system76.CosmicComp`
     pub cosmic_conf: CosmicCompConfig,
     /// cosmic-config context for `com.system76.CosmicSettings.Shortcuts`
     pub settings_context: cosmic_config::Config,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,8 @@ use crate::{
     },
 };
 use cosmic_config::{ConfigGet, CosmicConfigEntry};
-use cosmic_settings_config::{shortcuts, Shortcuts};
+use cosmic_settings_config::{shortcuts, Shortcuts, window_rules};
+use cosmic_settings_config::window_rules::ApplicationException;
 use serde::{Deserialize, Serialize};
 use smithay::wayland::xdg_activation::XdgActivationState;
 pub use smithay::{
@@ -53,6 +54,8 @@ pub struct Config {
     pub settings_context: cosmic_config::Config,
     /// Key bindings from `com.system76.CosmicSettings.Shortcuts`
     pub shortcuts: Shortcuts,
+    // Tiling exceptions from `com.system76.CosmicSettings.WindowRules`
+    pub tiling_exceptions: Vec<ApplicationException>,
     /// System actions from `com.system76.CosmicSettings.Shortcuts`
     pub system_actions: BTreeMap<shortcuts::action::System, String>,
 }
@@ -205,6 +208,9 @@ impl Config {
         let system_actions = shortcuts::system_actions(&config);
         let mut shortcuts = shortcuts::shortcuts(&settings_context);
 
+        let tiling_context = window_rules::context().expect("Failed to load window rules config");
+        let tiling_exceptions = window_rules::tiling_exceptions(&tiling_context);
+
         // Add any missing default shortcuts recommended by the compositor.
         key_bindings::add_default_bindings(&mut shortcuts, workspace.workspace_layout);
 
@@ -251,6 +257,7 @@ impl Config {
             settings_context,
             shortcuts,
             system_actions,
+            tiling_exceptions,
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -264,7 +264,7 @@ impl Config {
                                     .shell
                                     .write()
                                     .unwrap()
-                                    .update_tiling_exceptions(&state.common.config.tiling_exceptions);
+                                    .update_tiling_exceptions(state.common.config.tiling_exceptions.iter());
                             }
                             _ => (),
                         }

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -61,7 +61,10 @@ pub struct TilingExceptions {
 }
 
 impl TilingExceptions {
-    pub fn new(exceptions_config: &Vec<ApplicationException>) -> Self {
+    pub fn new<'a, I>(exceptions_config: I) -> Self
+    where
+      I: Iterator<Item=&'a ApplicationException>
+    {
         let mut app_ids = Vec::new();
         let mut titles = Vec::new();
 

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use cosmic_settings_config::shortcuts::action::Orientation;
+use cosmic_settings_config::{shortcuts::action::Orientation, window_rules::ApplicationException};
 use regex::{Regex, RegexSet};
 use smithay::{
     desktop::WindowSurface,
@@ -8,8 +8,6 @@ use smithay::{
     xwayland::xwm::WmWindowType,
 };
 use tracing::warn;
-
-use crate::config::Config;
 
 use super::CosmicSurface;
 
@@ -63,11 +61,11 @@ pub struct TilingExceptions {
 }
 
 impl TilingExceptions {
-    pub fn new(config: &Config) -> Self {
+    pub fn new(exceptions_config: &Vec<ApplicationException>) -> Self {
         let mut app_ids = Vec::new();
         let mut titles = Vec::new();
 
-        for exception in &config.tiling_exceptions {
+        for exception in exceptions_config {
             if let Err(e) = Regex::new(&exception.appid) {
                 warn!("Invalid regex for appid: {}, {}", exception.appid, e);
                 continue;

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -55,14 +55,14 @@ pub fn is_dialog(window: &CosmicSurface) -> bool {
     false
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TilingExceptions {
     app_ids: RegexSet,
     titles: RegexSet,
 }
 
 impl TilingExceptions {
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &Config) -> Result<Self, regex::Error> {
         let mut app_ids = Vec::new();
         let mut titles = Vec::new();
 
@@ -73,10 +73,10 @@ impl TilingExceptions {
             }
         }
 
-        Self {
-            app_ids: RegexSet::new(app_ids).unwrap(),
-            titles: RegexSet::new(titles).unwrap(),
-        }
+        Ok(Self {
+            app_ids: RegexSet::new(app_ids)?,
+            titles: RegexSet::new(titles)?,
+        })
     }
 }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -7,6 +7,7 @@ use std::{
     sync::atomic::Ordering,
     time::{Duration, Instant},
 };
+use tracing::error;
 use wayland_backend::server::ClientId;
 
 use cosmic_comp_config::{
@@ -1220,6 +1221,11 @@ impl Shell {
     pub fn new(config: &Config) -> Self {
         let theme = cosmic::theme::system_preference();
 
+        let tiling_exceptions = layout::TilingExceptions::new(config).unwrap_or_else(|e| {
+            error!(?e, "Could not load tiling exceptions, using default");
+            layout::TilingExceptions::default()
+        });
+
         Shell {
             workspaces: Workspaces::new(config, theme.clone()),
             seats: Seats::new(),
@@ -1237,7 +1243,7 @@ impl Shell {
             resize_mode: ResizeMode::None,
             resize_state: None,
             resize_indicator: None,
-            tiling_exceptions: layout::TilingExceptions::new(config),
+            tiling_exceptions,
 
             #[cfg(feature = "debug")]
             debug_active: false,

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,6 +1,7 @@
 use calloop::LoopHandle;
 use grabs::SeatMoveGrabState;
 use indexmap::IndexMap;
+use layout::TilingExceptions;
 use std::{
     collections::HashMap,
     sync::atomic::Ordering,
@@ -250,6 +251,7 @@ pub struct Shell {
         Output,
     )>,
     resize_indicator: Option<ResizeIndicator>,
+    tiling_exceptions: TilingExceptions,
 
     #[cfg(feature = "debug")]
     pub debug_active: bool,
@@ -1235,6 +1237,7 @@ impl Shell {
             resize_mode: ResizeMode::None,
             resize_state: None,
             resize_indicator: None,
+            tiling_exceptions: layout::TilingExceptions::new(config),
 
             #[cfg(feature = "debug")]
             debug_active: false,
@@ -1934,7 +1937,7 @@ impl Shell {
             && (workspace_output != seat.active_output() || active_handle != workspace.handle);
         let workspace_handle = workspace.handle;
         let is_dialog = layout::is_dialog(&window);
-        let floating_exception = layout::has_floating_exception(&window);
+        let floating_exception = layout::has_floating_exception(&self.tiling_exceptions, &window);
 
         let maybe_focused = workspace.focus_stack.get(&seat).iter().next().cloned();
         if let Some(focused) = maybe_focused {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -7,7 +7,6 @@ use std::{
     sync::atomic::Ordering,
     time::{Duration, Instant},
 };
-use tracing::error;
 use wayland_backend::server::ClientId;
 
 use cosmic_comp_config::{
@@ -1221,10 +1220,7 @@ impl Shell {
     pub fn new(config: &Config) -> Self {
         let theme = cosmic::theme::system_preference();
 
-        let tiling_exceptions = layout::TilingExceptions::new(config).unwrap_or_else(|e| {
-            error!(?e, "Could not load tiling exceptions, using default");
-            layout::TilingExceptions::default()
-        });
+        let tiling_exceptions = layout::TilingExceptions::new(config);
 
         Shell {
             workspaces: Workspaces::new(config, theme.clone()),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -16,7 +16,7 @@ use cosmic_comp_config::{
 use cosmic_protocols::workspace::v1::server::zcosmic_workspace_handle_v1::{
     State as WState, TilingState,
 };
-use cosmic_settings_config::shortcuts;
+use cosmic_settings_config::{shortcuts, window_rules::ApplicationException};
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection, ResizeDirection};
 use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
@@ -1220,7 +1220,7 @@ impl Shell {
     pub fn new(config: &Config) -> Self {
         let theme = cosmic::theme::system_preference();
 
-        let tiling_exceptions = layout::TilingExceptions::new(config);
+        let tiling_exceptions = layout::TilingExceptions::new(&config.tiling_exceptions);
 
         Shell {
             workspaces: Workspaces::new(config, theme.clone()),
@@ -3368,6 +3368,10 @@ impl Shell {
 
     pub fn theme(&self) -> &cosmic::Theme {
         &self.theme
+    }
+
+    pub fn update_tiling_exceptions(&mut self, exceptions: &Vec<ApplicationException>) {
+        self.tiling_exceptions = layout::TilingExceptions::new(exceptions);
     }
 
     pub fn take_presentation_feedback(

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1220,7 +1220,7 @@ impl Shell {
     pub fn new(config: &Config) -> Self {
         let theme = cosmic::theme::system_preference();
 
-        let tiling_exceptions = layout::TilingExceptions::new(&config.tiling_exceptions);
+        let tiling_exceptions = layout::TilingExceptions::new(config.tiling_exceptions.iter());
 
         Shell {
             workspaces: Workspaces::new(config, theme.clone()),
@@ -3370,7 +3370,10 @@ impl Shell {
         &self.theme
     }
 
-    pub fn update_tiling_exceptions(&mut self, exceptions: &Vec<ApplicationException>) {
+    pub fn update_tiling_exceptions<'a, I>(&mut self, exceptions: I)
+    where
+      I: Iterator<Item=&'a ApplicationException>
+    {
         self.tiling_exceptions = layout::TilingExceptions::new(exceptions);
     }
 


### PR DESCRIPTION
This moves out the hard coded tiling exceptions into a new separate config file under CosmicComp