### PR TITLE
DPMS with `wlr-output-power-management-unstable-v1` protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "cosmic-config",
  "cosmic-protocols",
  "cosmic-settings-config",
+ "drm-ffi 0.8.0",
  "edid-rs",
  "egui",
  "egui_plot",
@@ -1271,6 +1272,16 @@ dependencies = [
 
 [[package]]
 name = "drm-ffi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53"
+dependencies = [
+ "drm-sys 0.7.0",
+ "rustix",
+]
+
+[[package]]
+name = "drm-ffi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e41459d99a9b529845f6d2c909eb9adf3b6d2f82635ae40be8de0601726e8b"
@@ -1290,6 +1301,16 @@ name = "drm-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.6.4",
+]
+
+[[package]]
+name = "drm-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986"
 dependencies = [
  "libc",
  "linux-raw-sys 0.6.4",
@@ -4635,7 +4656,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=df79eeb#df79eeba63a8e9c2d33b9be2418aee6a940135e7"
+source = "git+https://github.com/smithay//smithay?rev=05c49f7#05c49f7a193bc89fba12a6484dbac895d5c9f853"
 dependencies = [
  "appendlist",
  "ash 0.38.0+1.3.281",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ profiling = { version = "1.0" }
 rustix = { version = "0.38.32", features = ["process"] }
 smallvec = "1.13.2"
 rand = "0.8.5"
+drm-ffi = "0.8.0"
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"
@@ -117,4 +118,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "df79eeb" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "05c49f7" }

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -43,6 +43,7 @@ mod drm_helpers;
 pub mod render;
 mod socket;
 mod surface;
+pub(crate) use surface::Surface;
 
 use device::*;
 pub use surface::Timings;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -164,6 +164,8 @@ impl State {
     where
         <B as InputBackend>::Device: 'static,
     {
+        crate::wayland::handlers::output_power::set_all_surfaces_dpms_on(self);
+
         use smithay::backend::input::Event;
         match event {
             InputEvent::DeviceAdded { device } => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,7 @@ use crate::{
         drm::WlDrmState,
         image_source::ImageSourceState,
         output_configuration::OutputConfigurationState,
+        output_power::OutputPowerState,
         screencopy::ScreencopyState,
         toplevel_info::ToplevelInfoState,
         toplevel_management::{ManagementCapabilities, ToplevelManagementState},
@@ -198,6 +199,7 @@ pub struct Common {
     pub keyboard_shortcuts_inhibit_state: KeyboardShortcutsInhibitState,
     pub output_state: OutputManagerState,
     pub output_configuration_state: OutputConfigurationState<State>,
+    pub output_power_state: OutputPowerState,
     pub presentation_state: PresentationState,
     pub primary_selection_state: PrimarySelectionState,
     pub data_control_state: Option<DataControlState>,
@@ -487,6 +489,7 @@ impl State {
         let keyboard_shortcuts_inhibit_state = KeyboardShortcutsInhibitState::new::<Self>(dh);
         let output_state = OutputManagerState::new_with_xdg_output::<Self>(dh);
         let output_configuration_state = OutputConfigurationState::new(dh, client_is_privileged);
+        let output_power_state = OutputPowerState::new::<Self, _>(dh, client_is_privileged);
         let presentation_state = PresentationState::new::<Self>(dh, clock.id() as u32);
         let primary_selection_state = PrimarySelectionState::new::<Self>(dh);
         let image_source_state = ImageSourceState::new::<Self, _>(dh, client_is_privileged);
@@ -593,6 +596,7 @@ impl State {
                 keyboard_shortcuts_inhibit_state,
                 output_state,
                 output_configuration_state,
+                output_power_state,
                 presentation_state,
                 primary_selection_state,
                 data_control_state,

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -19,6 +19,7 @@ pub mod keyboard_shortcuts_inhibit;
 pub mod layer_shell;
 pub mod output;
 pub mod output_configuration;
+pub mod output_power;
 pub mod pointer_constraints;
 pub mod pointer_gestures;
 pub mod presentation;

--- a/src/wayland/handlers/output_power.rs
+++ b/src/wayland/handlers/output_power.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use smithay::output::Output;
+
+use crate::{
+    backend::kms::Surface,
+    state::{BackendData, State},
+    utils::prelude::OutputExt,
+    wayland::protocols::output_power::{
+        delegate_output_power, OutputPowerHandler, OutputPowerState,
+    },
+};
+
+pub fn set_all_surfaces_dpms_on(state: &mut State) {
+    let mut changed = false;
+    for surface in kms_surfaces(state) {
+        if !surface.get_dpms() {
+            surface.set_dpms(true);
+            changed = true;
+        }
+    }
+
+    if changed {
+        OutputPowerState::refresh(state);
+    }
+}
+
+fn kms_surfaces(state: &mut State) -> impl Iterator<Item = &mut Surface> {
+    if let BackendData::Kms(ref mut kms_state) = &mut state.backend {
+        Some(
+            kms_state
+                .drm_devices
+                .values_mut()
+                .flat_map(|device| device.surfaces.values_mut()),
+        )
+    } else {
+        None
+    }
+    .into_iter()
+    .flatten()
+}
+
+// Get KMS `Surface` for output, and for all outputs mirroring it
+fn kms_surfaces_for_output<'a>(
+    state: &'a mut State,
+    output: &'a Output,
+) -> impl Iterator<Item = &'a mut Surface> + 'a {
+    kms_surfaces(state).filter(move |surface| {
+        surface.output == *output || surface.output.mirroring().as_ref() == Some(&output)
+    })
+}
+
+// Get KMS `Surface` for output
+fn primary_kms_surface_for_output<'a>(
+    state: &'a mut State,
+    output: &Output,
+) -> Option<&'a mut Surface> {
+    kms_surfaces(state).find(|surface| surface.output == *output)
+}
+
+impl OutputPowerHandler for State {
+    fn output_power_state(&mut self) -> &mut OutputPowerState {
+        &mut self.common.output_power_state
+    }
+
+    fn get_dpms(&mut self, output: &Output) -> Option<bool> {
+        let surface = primary_kms_surface_for_output(self, output)?;
+        Some(surface.get_dpms())
+    }
+
+    fn set_dpms(&mut self, output: &Output, on: bool) {
+        for surface in kms_surfaces_for_output(self, output) {
+            surface.set_dpms(on);
+        }
+    }
+}
+
+delegate_output_power!(State);

--- a/src/wayland/protocols/mod.rs
+++ b/src/wayland/protocols/mod.rs
@@ -3,6 +3,7 @@
 pub mod drm;
 pub mod image_source;
 pub mod output_configuration;
+pub mod output_power;
 pub mod overlap_notify;
 pub mod screencopy;
 pub mod toplevel_info;

--- a/src/wayland/protocols/output_power.rs
+++ b/src/wayland/protocols/output_power.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use smithay::{
+    output::{Output, WeakOutput},
+    reexports::{
+        wayland_protocols_wlr::output_power_management::v1::server::{
+            zwlr_output_power_manager_v1::{self, ZwlrOutputPowerManagerV1},
+            zwlr_output_power_v1::{self, ZwlrOutputPowerV1},
+        },
+        wayland_server::{
+            backend::GlobalId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
+            Resource,
+        },
+    },
+};
+use std::{collections::HashMap, mem};
+use wayland_backend::{protocol::WEnum, server::ClientId};
+
+pub trait OutputPowerHandler {
+    fn output_power_state(&mut self) -> &mut OutputPowerState;
+    fn get_dpms(&mut self, output: &Output) -> Option<bool>;
+    fn set_dpms(&mut self, output: &Output, on: bool);
+}
+
+#[derive(Debug)]
+pub struct OutputPowerState {
+    global: GlobalId,
+    output_powers: HashMap<ZwlrOutputPowerV1, zwlr_output_power_v1::Mode>,
+}
+
+impl OutputPowerState {
+    pub fn new<D, F>(dh: &DisplayHandle, client_filter: F) -> OutputPowerState
+    where
+        D: GlobalDispatch<ZwlrOutputPowerManagerV1, OutputPowerManagerGlobalData> + 'static,
+        F: for<'a> Fn(&'a Client) -> bool + Clone + Send + Sync + 'static,
+    {
+        let global = dh.create_global::<D, ZwlrOutputPowerManagerV1, _>(
+            1,
+            OutputPowerManagerGlobalData {
+                filter: Box::new(client_filter.clone()),
+            },
+        );
+
+        OutputPowerState {
+            global,
+            output_powers: HashMap::new(),
+        }
+    }
+
+    pub fn global_id(&self) -> GlobalId {
+        self.global.clone()
+    }
+
+    /// Send `mode` events for any output powers where dpms state has changed.
+    ///
+    /// This is handled automatically for changes made through the protocol.
+    pub fn refresh<D: OutputPowerHandler>(state: &mut D) {
+        let mut output_powers = mem::take(&mut state.output_power_state().output_powers);
+        for (output_power, old_mode) in output_powers.iter_mut() {
+            let data = output_power.data::<OutputPowerData>().unwrap();
+            if let Some(output) = data.output.as_ref().and_then(|o| o.upgrade()) {
+                if let Some(on) = state.get_dpms(&output) {
+                    let mode = output_power_mode(on);
+                    if mode != *old_mode {
+                        output_power.mode(mode);
+                        *old_mode = mode;
+                    }
+                }
+            }
+        }
+        state.output_power_state().output_powers = output_powers;
+    }
+}
+
+pub struct OutputPowerManagerGlobalData {
+    filter: Box<dyn for<'a> Fn(&'a Client) -> bool + Send + Sync>,
+}
+
+pub struct OutputPowerData {
+    output: Option<WeakOutput>,
+}
+
+impl<D> GlobalDispatch<ZwlrOutputPowerManagerV1, OutputPowerManagerGlobalData, D>
+    for OutputPowerState
+where
+    D: GlobalDispatch<ZwlrOutputPowerManagerV1, OutputPowerManagerGlobalData>
+        + Dispatch<ZwlrOutputPowerManagerV1, ()>
+        + 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _dh: &DisplayHandle,
+        _client: &Client,
+        resource: New<ZwlrOutputPowerManagerV1>,
+        _global_data: &OutputPowerManagerGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, global_data: &OutputPowerManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<ZwlrOutputPowerManagerV1, (), D> for OutputPowerState
+where
+    D: GlobalDispatch<ZwlrOutputPowerManagerV1, OutputPowerManagerGlobalData>
+        + Dispatch<ZwlrOutputPowerManagerV1, ()>
+        + Dispatch<ZwlrOutputPowerV1, OutputPowerData>
+        + OutputPowerHandler
+        + 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        _obj: &ZwlrOutputPowerManagerV1,
+        request: zwlr_output_power_manager_v1::Request,
+        _data: &(),
+        _dh: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            zwlr_output_power_manager_v1::Request::GetOutputPower { id, output } => {
+                let output = Output::from_resource(&output);
+                let output_power = data_init.init(
+                    id,
+                    OutputPowerData {
+                        output: output.as_ref().map(|o| o.downgrade()),
+                    },
+                );
+                if let Some(on) = output.as_ref().and_then(|o| state.get_dpms(o)) {
+                    let mode = output_power_mode(on);
+                    output_power.mode(mode);
+                    state
+                        .output_power_state()
+                        .output_powers
+                        .insert(output_power, mode);
+                } else {
+                    output_power.failed();
+                }
+            }
+            zwlr_output_power_manager_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<ZwlrOutputPowerV1, OutputPowerData, D> for OutputPowerState
+where
+    D: Dispatch<ZwlrOutputPowerV1, OutputPowerData> + OutputPowerHandler + 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        obj: &ZwlrOutputPowerV1,
+        request: zwlr_output_power_v1::Request,
+        data: &OutputPowerData,
+        _dh: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            zwlr_output_power_v1::Request::SetMode { mode } => {
+                if let Some(output) = data.output.as_ref().and_then(|o| o.upgrade()) {
+                    let on = match mode {
+                        WEnum::Value(zwlr_output_power_v1::Mode::On) => true,
+                        WEnum::Value(zwlr_output_power_v1::Mode::Off) => false,
+                        _ => {
+                            return;
+                        }
+                    };
+                    state.set_dpms(&output, on);
+                    if let Some(on) = state.get_dpms(&output) {
+                        let mode = output_power_mode(on);
+                        for (output_power, old_mode) in
+                            state.output_power_state().output_powers.iter_mut()
+                        {
+                            let data = output_power.data::<OutputPowerData>().unwrap();
+                            if let Some(o) = data.output.as_ref() {
+                                if o == &output && mode != *old_mode {
+                                    output_power.mode(mode);
+                                    *old_mode = mode;
+                                }
+                            }
+                        }
+                    } else {
+                        obj.failed();
+                        state.output_power_state().output_powers.remove(obj);
+                    }
+                } else {
+                    obj.failed();
+                    state.output_power_state().output_powers.remove(obj);
+                }
+            }
+            zwlr_output_power_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+
+    fn destroyed(
+        state: &mut D,
+        _client: ClientId,
+        obj: &ZwlrOutputPowerV1,
+        _data: &OutputPowerData,
+    ) {
+        state.output_power_state().output_powers.remove(obj);
+    }
+}
+
+fn output_power_mode(on: bool) -> zwlr_output_power_v1::Mode {
+    if on {
+        zwlr_output_power_v1::Mode::On
+    } else {
+        zwlr_output_power_v1::Mode::Off
+    }
+}
+
+macro_rules! delegate_output_power {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_manager_v1::ZwlrOutputPowerManagerV1: $crate::wayland::protocols::output_power::OutputPowerManagerGlobalData
+        ] => $crate::wayland::protocols::output_power::OutputPowerState);
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_manager_v1::ZwlrOutputPowerManagerV1: ()
+        ] => $crate::wayland::protocols::output_power::OutputPowerState);
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_v1::ZwlrOutputPowerV1: $crate::wayland::protocols::output_power::OutputPowerData
+        ] => $crate::wayland::protocols::output_power::OutputPowerState);
+    };
+}
+pub(crate) use delegate_output_power;


### PR DESCRIPTION
This works to set DPMS on or off. It still needs to track the DPMS state and send events to clients when the mode changes. And otherwise be cleaned up a bit.

Components like `cosmic-greeter` may make use of this.

This can be tested with the below code (which also works on Sway):

```rust
use std::{env, process};
use wayland_client::{
    delegate_noop,
    globals::{registry_queue_init, GlobalListContents},
    protocol::{wl_output, wl_registry},
    Connection, Dispatch, Proxy, QueueHandle,
};
use wayland_protocols_wlr::output_power_management::v1::client::{
    zwlr_output_power_manager_v1, zwlr_output_power_v1,
};

struct State;

fn main() {
    let mode = match env::args().skip(1).next().as_ref().map(|x| x.as_str()) {
        Some("on") => zwlr_output_power_v1::Mode::On,
        Some("off") => zwlr_output_power_v1::Mode::Off,
        _ => {
            eprintln!("Usage: dpms on|off");
            process::exit(1);
        }
    };

    let connection = Connection::connect_to_env().unwrap();
    let (globals, mut event_queue) = registry_queue_init::<State>(&connection).unwrap();
    let qh = event_queue.handle();

    let outputs = globals.contents().with_list(|list| {
        list.iter()
            .filter(|global| global.interface == wl_output::WlOutput::interface().name)
            .map(|global| globals.registry().bind(global.name, global.version, &qh, ()))
            .collect::<Vec<wl_output::WlOutput>>()
    });

    let output_power_manager = globals
        .bind::<zwlr_output_power_manager_v1::ZwlrOutputPowerManagerV1, _, _>(&qh, 1..=1, ())
        .unwrap();

    for output in &outputs {
        let output_power = output_power_manager.get_output_power(output, &qh, ());
        output_power.set_mode(mode);
    }
    event_queue.roundtrip(&mut State).unwrap();
}

impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
    fn event(
        _: &mut Self,
        _: &wl_registry::WlRegistry,
        _: wl_registry::Event,
        _: &GlobalListContents,
        _: &Connection,
        _: &QueueHandle<Self>,
    ) {
    }
}

delegate_noop!(State: ignore wl_output::WlOutput);
delegate_noop!(State: zwlr_output_power_manager_v1::ZwlrOutputPowerManagerV1);
delegate_noop!(State: ignore zwlr_output_power_v1::ZwlrOutputPowerV1);

```