### PR TITLE
Add smart window gaps feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "atomicwrites",
  "calloop 0.14.0",
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "futures",
  "iced_core",
@@ -2353,7 +2353,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2457,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2790,7 +2790,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
+source = "git+https://github.com/JCapucho/libcosmic.git?branch=smart-window-gaps#43985bf9eb08d80cdbfe2ec849bc203c98c20875"
 dependencies = [
  "apply",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,9 @@ lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
 smithay = { git = "https://github.com/smithay//smithay", rev = "c484442" }
+
+[patch."https://github.com/pop-os/libcosmic.git"]
+libcosmic = {git="https://github.com/JCapucho/libcosmic.git", branch="smart-window-gaps"}
+cosmic-config = {git="https://github.com/JCapucho/libcosmic.git", branch="smart-window-gaps"}
+iced = {git="https://github.com/JCapucho/libcosmic.git", branch="smart-window-gaps"}
+iced_tiny_skia = {git="https://github.com/JCapucho/libcosmic.git", branch="smart-window-gaps"}

--- a/src/shell/layout/tiling/grabs/resize.rs
+++ b/src/shell/layout/tiling/grabs/resize.rs
@@ -224,6 +224,7 @@ impl ResizeForkGrab {
             let mut shell = data.common.shell.write().unwrap();
             let tiling_layer = &mut shell.active_space_mut(&output).tiling_layer;
             let gaps = tiling_layer.gaps();
+            let is_smart_gaps = tiling_layer.is_smart_gaps();
 
             let tree = &mut tiling_layer.queue.trees.back_mut().unwrap().0;
             match &mut self.old_tree {
@@ -317,7 +318,7 @@ impl ResizeForkGrab {
                 }
 
                 self.last_loc = location.as_global();
-                let blocker = TilingLayout::update_positions(&output, tree, gaps);
+                let blocker = TilingLayout::update_positions(&output, tree, gaps, is_smart_gaps);
                 tiling_layer.pending_blockers.extend(blocker);
             } else {
                 return true;

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -376,7 +376,7 @@ impl TilingLayout {
             }
         }
 
-        let blocker = TilingLayout::update_positions(output, &mut tree, gaps);
+        let blocker = TilingLayout::update_positions(output, &mut tree, gaps, self.is_smart_gaps());
         self.queue.push_tree(tree, None, blocker);
         self.output = output.clone();
     }
@@ -419,7 +419,8 @@ impl TilingLayout {
             direction,
             minimize_rect,
         );
-        let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+        let blocker =
+            TilingLayout::update_positions(&self.output, &mut tree, gaps, self.is_smart_gaps());
         self.queue.push_tree(tree, duration, blocker);
     }
 
@@ -484,7 +485,12 @@ impl TilingLayout {
                     tree.make_nth_sibling(&new_id, idx).unwrap();
                     *window.tiling_node_id.lock().unwrap() = Some(new_id);
 
-                    let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                    let blocker = TilingLayout::update_positions(
+                        &self.output,
+                        &mut tree,
+                        gaps,
+                        self.is_smart_gaps(),
+                    );
                     self.queue
                         .push_tree(tree, MINIMIZE_ANIMATION_DURATION, blocker);
                     return;
@@ -523,7 +529,12 @@ impl TilingLayout {
 
                 *window.tiling_node_id.lock().unwrap() = Some(new_id);
 
-                let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                let blocker = TilingLayout::update_positions(
+                    &self.output,
+                    &mut tree,
+                    gaps,
+                    self.is_smart_gaps(),
+                );
                 self.queue
                     .push_tree(tree, MINIMIZE_ANIMATION_DURATION, blocker);
                 return;
@@ -628,7 +639,8 @@ impl TilingLayout {
             old.output_leave(&self.output);
             new.output_enter(&self.output, new.bbox());
 
-            let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+            let blocker =
+                TilingLayout::update_positions(&self.output, &mut tree, gaps, self.is_smart_gaps());
             self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
         }
     }
@@ -786,12 +798,20 @@ impl TilingLayout {
                 let other_gaps = other.gaps();
 
                 TilingLayout::unmap_internal(&mut this_tree, &desc.node);
-                let blocker =
-                    TilingLayout::update_positions(&this.output, &mut this_tree, this_gaps);
+                let blocker = TilingLayout::update_positions(
+                    &this.output,
+                    &mut this_tree,
+                    this_gaps,
+                    this.is_smart_gaps(),
+                );
                 this.queue.push_tree(this_tree, ANIMATION_DURATION, blocker);
 
-                let blocker =
-                    TilingLayout::update_positions(&other.output, &mut other_tree, other_gaps);
+                let blocker = TilingLayout::update_positions(
+                    &other.output,
+                    &mut other_tree,
+                    other_gaps,
+                    other.is_smart_gaps(),
+                );
                 other
                     .queue
                     .push_tree(other_tree, ANIMATION_DURATION, blocker);
@@ -1227,18 +1247,26 @@ impl TilingLayout {
         }
 
         let this_gaps = this.gaps();
-        let blocker = TilingLayout::update_positions(&this.output, &mut this_tree, this_gaps);
+        let this_is_smart_gaps = this.is_smart_gaps();
+        let blocker = TilingLayout::update_positions(
+            &this.output,
+            &mut this_tree,
+            this_gaps,
+            this_is_smart_gaps,
+        );
         this.queue.push_tree(this_tree, ANIMATION_DURATION, blocker);
 
         let has_other_tree = other_tree.is_some();
         if let Some(mut other_tree) = other_tree {
-            let (other_queue, gaps) = if let Some(other) = other.as_mut() {
+            let (other_queue, gaps, is_smart_gaps) = if let Some(other) = other.as_mut() {
                 let other_gaps = other.gaps();
-                (&mut other.queue, other_gaps)
+                let other_is_smart_gaps = other.is_smart_gaps();
+                (&mut other.queue, other_gaps, other_is_smart_gaps)
             } else {
-                (&mut this.queue, this_gaps)
+                (&mut this.queue, this_gaps, this_is_smart_gaps)
             };
-            let blocker = TilingLayout::update_positions(&other_output, &mut other_tree, gaps);
+            let blocker =
+                TilingLayout::update_positions(&other_output, &mut other_tree, gaps, is_smart_gaps);
             other_queue.push_tree(other_tree, ANIMATION_DURATION, blocker);
         }
 
@@ -1394,7 +1422,12 @@ impl TilingLayout {
                 } else {
                     ANIMATION_DURATION
                 };
-                let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                let blocker = TilingLayout::update_positions(
+                    &self.output,
+                    &mut tree,
+                    gaps,
+                    self.is_smart_gaps(),
+                );
                 self.queue.push_tree(tree, duration, blocker);
 
                 return true;
@@ -1513,7 +1546,12 @@ impl TilingLayout {
                     .unwrap();
                     *mapped.tiling_node_id.lock().unwrap() = Some(new_id);
 
-                    let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                    let blocker = TilingLayout::update_positions(
+                        &self.output,
+                        &mut tree,
+                        gaps,
+                        self.is_smart_gaps(),
+                    );
                     self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
                     return MoveResult::ShiftFocus(mapped.into());
                 }
@@ -1589,7 +1627,12 @@ impl TilingLayout {
                     .data_mut()
                     .remove_window(og_idx);
 
-                let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                let blocker = TilingLayout::update_positions(
+                    &self.output,
+                    &mut tree,
+                    gaps,
+                    self.is_smart_gaps(),
+                );
                 self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
                 return MoveResult::Done;
             }
@@ -1615,7 +1658,12 @@ impl TilingLayout {
                     .data_mut()
                     .remove_window(og_idx);
 
-                let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                let blocker = TilingLayout::update_positions(
+                    &self.output,
+                    &mut tree,
+                    gaps,
+                    self.is_smart_gaps(),
+                );
                 self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
                 return MoveResult::Done;
             }
@@ -1771,7 +1819,12 @@ impl TilingLayout {
                     MoveResult::Done
                 };
 
-                let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                let blocker = TilingLayout::update_positions(
+                    &self.output,
+                    &mut tree,
+                    gaps,
+                    self.is_smart_gaps(),
+                );
                 self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
                 return result;
             }
@@ -2101,7 +2154,12 @@ impl TilingLayout {
 
                     *orientation = new_orientation;
 
-                    let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                    let blocker = TilingLayout::update_positions(
+                        &self.output,
+                        &mut tree,
+                        gaps,
+                        self.is_smart_gaps(),
+                    );
                     self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
                 }
             }
@@ -2219,7 +2277,8 @@ impl TilingLayout {
             }
         };
 
-        let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+        let blocker =
+            TilingLayout::update_positions(&self.output, &mut tree, gaps, self.is_smart_gaps());
         self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
 
         Some(result)
@@ -2295,7 +2354,12 @@ impl TilingLayout {
                         minimize_rect: None,
                     };
 
-                    let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+                    let blocker = TilingLayout::update_positions(
+                        &self.output,
+                        &mut tree,
+                        gaps,
+                        self.is_smart_gaps(),
+                    );
                     self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
 
                     return Some(KeyboardFocusTarget::Element(mapped));
@@ -2310,7 +2374,8 @@ impl TilingLayout {
         let gaps = self.gaps();
 
         let mut tree = self.queue.trees.back().unwrap().0.copy_clone();
-        let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+        let blocker =
+            TilingLayout::update_positions(&self.output, &mut tree, gaps, self.is_smart_gaps());
         self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
     }
 
@@ -2580,7 +2645,8 @@ impl TilingLayout {
                 }
                 _ => unreachable!(),
             }
-            let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+            let blocker =
+                TilingLayout::update_positions(&self.output, &mut tree, gaps, self.is_smart_gaps());
             self.queue.push_tree(tree, None, blocker);
 
             return true;
@@ -2620,7 +2686,8 @@ impl TilingLayout {
                 }
             }
 
-            let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+            let blocker =
+                TilingLayout::update_positions(&self.output, &mut tree, gaps, self.is_smart_gaps());
             self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
         }
     }
@@ -2774,7 +2841,8 @@ impl TilingLayout {
             }
         }
 
-        let blocker = TilingLayout::update_positions(&self.output, &mut tree, gaps);
+        let blocker =
+            TilingLayout::update_positions(&self.output, &mut tree, gaps, self.is_smart_gaps());
         self.queue.push_tree(tree, ANIMATION_DURATION, blocker);
 
         let location = self.element_geometry(&mapped).unwrap().loc;
@@ -2948,6 +3016,7 @@ impl TilingLayout {
         output: &Output,
         tree: &mut Tree<Data>,
         gaps: (i32, i32),
+        is_smart_gaps: bool,
     ) -> Option<TilingBlocker> {
         if let Some(root_id) = tree.root_node_id() {
             let mut configures = Vec::new();
@@ -2956,10 +3025,15 @@ impl TilingLayout {
             let mut geo = layer_map_for_output(&output)
                 .non_exclusive_zone()
                 .as_local();
-            geo.loc.x += outer;
-            geo.loc.y += outer;
-            geo.size.w -= outer * 2;
-            geo.size.h -= outer * 2;
+
+            let root = tree.get(&root_id).unwrap();
+            if !is_smart_gaps || root.data().is_group() {
+                geo.loc.x += outer;
+                geo.loc.y += outer;
+                geo.size.w -= outer * 2;
+                geo.size.h -= outer * 2;
+            }
+
             let mut stack = vec![geo];
 
             for node_id in tree
@@ -3004,33 +3078,21 @@ impl TilingLayout {
                     let node = tree.get(&node_id).unwrap();
                     let data = node.data();
                     if data.is_mapped(None) {
+                        let calculate_gap = |dir| {
+                            if TilingLayout::has_adjacent_node(tree, &node_id, dir) {
+                                inner / 2
+                            } else if is_smart_gaps {
+                                0
+                            } else {
+                                inner
+                            }
+                        };
+
                         let gap = (
+                            (calculate_gap(Direction::Left), calculate_gap(Direction::Up)),
                             (
-                                if TilingLayout::has_adjacent_node(tree, &node_id, Direction::Left)
-                                {
-                                    inner / 2
-                                } else {
-                                    inner
-                                },
-                                if TilingLayout::has_adjacent_node(tree, &node_id, Direction::Up) {
-                                    inner / 2
-                                } else {
-                                    inner
-                                },
-                            ),
-                            (
-                                if TilingLayout::has_adjacent_node(tree, &node_id, Direction::Right)
-                                {
-                                    inner / 2
-                                } else {
-                                    inner
-                                },
-                                if TilingLayout::has_adjacent_node(tree, &node_id, Direction::Down)
-                                {
-                                    inner / 2
-                                } else {
-                                    inner
-                                },
+                                calculate_gap(Direction::Right),
+                                calculate_gap(Direction::Down),
                             ),
                         );
                         geo.loc += gap.0.into();
@@ -3122,6 +3184,7 @@ impl TilingLayout {
         overview: OverviewMode,
     ) -> Option<(PointerFocusTarget, Point<f64, Local>)> {
         let gaps = self.gaps();
+        let is_smart_gaps = self.is_smart_gaps();
         let last_overview_hover = &mut self.last_overview_hover;
         let placeholder_id = &self.placeholder_id;
         let tree = &self.queue.trees.back().unwrap().0;
@@ -3697,6 +3760,7 @@ impl TilingLayout {
                                         &self.output,
                                         &mut tree,
                                         gaps,
+                                        is_smart_gaps,
                                     );
                                     self.queue.push_tree(tree, duration, blocker);
                                 }
@@ -3796,7 +3860,8 @@ impl TilingLayout {
         };
         TilingLayout::merge_trees(src, &mut dst, orientation);
 
-        let blocker = TilingLayout::update_positions(&self.output, &mut dst, gaps);
+        let blocker =
+            TilingLayout::update_positions(&self.output, &mut dst, gaps, self.is_smart_gaps());
         self.queue.push_tree(dst, ANIMATION_DURATION, blocker);
     }
 
@@ -3996,6 +4061,10 @@ impl TilingLayout {
     fn gaps(&self) -> (i32, i32) {
         let g = self.theme.cosmic().gaps;
         (g.0 as i32, g.1 as i32)
+    }
+
+    fn is_smart_gaps(&self) -> bool {
+        self.theme.cosmic().is_smart_gaps
     }
 }
 


### PR DESCRIPTION
This PR implements the smart gaps feature like what is present in i3 and sway https://i3wm.org/docs/userguide.html#gaps

Smart window gaps only add the external and internal gaps when it aids in visually separating the top levels (when using the tiling mode).

This is done by only adding the outer gap when more than one toplevel exists in the output and only adding the inner gap when an adjacent toplevel exists in the given direction.

I don't know if this is a wanted feature but it's absence was really bugging me (I previously used sway), so I implemented it and have been using it so I thought I might as well contribute it upstream :)


## Screenshots

One window (no gaps)
![One window](https://github.com/user-attachments/assets/5b83176f-1b67-46bd-8068-4bc4de54b1ff)

Two windows (outer and inner gaps)
![Two windows](https://github.com/user-attachments/assets/9ab9231f-55e9-4f16-a4cb-12421ca051b5)


## Notes

Requires a change in `libcosmic`, if the feature is wanted I will open the PR (Didn't want to spam two repositories for this feature), the changes are here https://github.com/JCapucho/libcosmic/tree/smart-window-gaps

I also think the inner gap calculations are wrong, currently they are:
```rust
if TilingLayout::has_adjacent_node(tree, &node_id, dir) {
    inner / 2
} else if is_smart_gaps {
    0
} else {
    inner
}
```

I have kept the previous version where if smart gaps isn't enabled and there are no adjacent windows a `inner` gap is added, but this seems wrong because it leads to windows having both an outer and inner gap when they are at the edge of the output. This should instead be:
```rust
if TilingLayout::has_adjacent_node(tree, &node_id, dir) {
    inner / 2
} else {
    0
}
```

I think this hasn't been a problem because by default the outer gap is 0 and there's no way to change it in the settings app, but if it's changed in the file directly it leads to a double border.

## Further work

I have also a similar change to only add the active window hint when there's more than one window in the output, but that one still has some problems.