### PR TITLE
Fix button events being sent when super is held

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -888,6 +888,7 @@ impl State {
                                                                         &state.common.config,
                                                                         &state.common.event_loop_handle,
                                                                         &state.common.xdg_activation_state,
+                                                                        false
                                                                     );
                                                                     drop(shell);
                                                                     dispatch_grab(res, seat_clone, serial, state);
@@ -910,7 +911,8 @@ impl State {
                                                                         &surface,
                                                                         &seat_clone,
                                                                         serial,
-                                                                        edge
+                                                                        edge,
+                                                                        false
                                                                     );
                                                                     drop(shell);
                                                                     dispatch_grab(res, seat_clone, serial, state);

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -622,6 +622,7 @@ impl CosmicStack {
                             &state.common.config,
                             &state.common.event_loop_handle,
                             &state.common.xdg_activation_state,
+                            false,
                         );
                         if let Some((grab, focus)) = res {
                             if grab.is_touch_grab() {
@@ -710,6 +711,7 @@ impl Program for CosmicStackInternal {
                                 &state.common.config,
                                 &state.common.event_loop_handle,
                                 &state.common.xdg_activation_state,
+                                false,
                             );
                             if let Some((grab, focus)) = res {
                                 if grab.is_touch_grab() {
@@ -1290,6 +1292,7 @@ impl PointerTarget<State> for CosmicStack {
                             Focus::ResizeRight => ResizeEdge::RIGHT,
                             Focus::Header => unreachable!(),
                         },
+                        false,
                     );
                     if let Some((grab, focus)) = res {
                         if grab.is_touch_grab() {
@@ -1356,6 +1359,7 @@ impl PointerTarget<State> for CosmicStack {
                             &state.common.config,
                             &state.common.event_loop_handle,
                             &state.common.xdg_activation_state,
+                            false,
                         );
                         if let Some((grab, focus)) = res {
                             if grab.is_touch_grab() {

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -406,6 +406,7 @@ impl Program for CosmicWindowInternal {
                                 &state.common.config,
                                 &state.common.event_loop_handle,
                                 &state.common.xdg_activation_state,
+                                false,
                             );
                             if let Some((grab, focus)) = res {
                                 if grab.is_touch_grab() {
@@ -718,6 +719,7 @@ impl PointerTarget<State> for CosmicWindow {
                             Focus::ResizeRight => ResizeEdge::RIGHT,
                             Focus::Header => unreachable!(),
                         },
+                        false,
                     );
 
                     if let Some((grab, focus)) = res {

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -257,6 +257,7 @@ pub fn window_items(
                         &state.common.config,
                         &state.common.event_loop_handle,
                         &state.common.xdg_activation_state,
+                        false,
                     );
 
                     std::mem::drop(shell);

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2430,15 +2430,11 @@ impl Shell {
         config: &Config,
         evlh: &LoopHandle<'static, State>,
         xdg_activation_state: &XdgActivationState,
+        client_initiated: bool,
     ) -> Option<(MoveGrab, Focus)> {
         let serial = serial.into();
 
-        let mut start_data = check_grab_preconditions(
-            &seat,
-            surface,
-            serial,
-            release == ReleaseMode::NoMouseButtons && !move_out_of_stack,
-        )?;
+        let mut start_data = check_grab_preconditions(&seat, surface, serial, client_initiated)?;
         let mut old_mapped = self.element_for_surface(surface).cloned()?;
         if old_mapped.is_minimized() {
             return None;
@@ -3072,9 +3068,10 @@ impl Shell {
         seat: &Seat<State>,
         serial: impl Into<Option<Serial>>,
         edges: ResizeEdge,
+        client_initiated: bool,
     ) -> Option<(ResizeGrab, Focus)> {
         let serial = serial.into();
-        let start_data = check_grab_preconditions(&seat, surface, serial, true)?;
+        let start_data = check_grab_preconditions(&seat, surface, serial, client_initiated)?;
         let mapped = self.element_for_surface(surface).cloned()?;
         if mapped.is_fullscreen(true) || mapped.is_maximized(true) {
             return None;

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -5,7 +5,7 @@ use std::{any::Any, cell::RefCell, collections::HashMap, sync::Mutex, time::Dura
 use crate::{
     backend::render::cursor::{CursorShape, CursorState},
     config::{xkb_config_to_wl, Config},
-    input::{ModifiersShortcutQueue, SupressedKeys},
+    input::{ModifiersShortcutQueue, SupressedButtons, SupressedKeys},
     state::State,
 };
 use smithay::{
@@ -169,6 +169,7 @@ pub fn create_seat(
     userdata.insert_if_missing_threadsafe(SeatId::default);
     userdata.insert_if_missing(Devices::default);
     userdata.insert_if_missing(SupressedKeys::default);
+    userdata.insert_if_missing(SupressedButtons::default);
     userdata.insert_if_missing(ModifiersShortcutQueue::default);
     userdata.insert_if_missing_threadsafe(SeatMoveGrabState::default);
     userdata.insert_if_missing_threadsafe(SeatMenuGrabState::default);
@@ -215,6 +216,7 @@ pub trait SeatExt {
     fn set_active_output(&self, output: &Output);
     fn devices(&self) -> &Devices;
     fn supressed_keys(&self) -> &SupressedKeys;
+    fn supressed_buttons(&self) -> &SupressedButtons;
     fn modifiers_shortcut_queue(&self) -> &ModifiersShortcutQueue;
 
     fn cursor_geometry(
@@ -252,6 +254,10 @@ impl SeatExt for Seat<State> {
 
     fn supressed_keys(&self) -> &SupressedKeys {
         self.user_data().get::<SupressedKeys>().unwrap()
+    }
+
+    fn supressed_buttons(&self) -> &SupressedButtons {
+        self.user_data().get::<SupressedButtons>().unwrap()
     }
 
     fn modifiers_shortcut_queue(&self) -> &ModifiersShortcutQueue {

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -161,6 +161,7 @@ impl XdgShellHandler for State {
             &self.common.config,
             &self.common.event_loop_handle,
             &self.common.xdg_activation_state,
+            true,
         ) {
             std::mem::drop(shell);
             if grab.is_touch_grab() {
@@ -183,7 +184,7 @@ impl XdgShellHandler for State {
         let seat = Seat::from_resource(&seat).unwrap();
         let mut shell = self.common.shell.write().unwrap();
         if let Some((grab, focus)) =
-            shell.resize_request(surface.wl_surface(), &seat, serial, edges.into())
+            shell.resize_request(surface.wl_surface(), &seat, serial, edges.into(), true)
         {
             std::mem::drop(shell);
             if grab.is_touch_grab() {

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -481,7 +481,7 @@ impl XwmHandler for State {
             let mut shell = self.common.shell.write().unwrap();
             let seat = shell.seats.last_active().clone();
             if let Some((grab, focus)) =
-                shell.resize_request(&wl_surface, &seat, None, resize_edge.into())
+                shell.resize_request(&wl_surface, &seat, None, resize_edge.into(), true)
             {
                 std::mem::drop(shell);
                 if grab.is_touch_grab() {
@@ -513,6 +513,7 @@ impl XwmHandler for State {
                 &self.common.config,
                 &self.common.event_loop_handle,
                 &self.common.xdg_activation_state,
+                true,
             ) {
                 std::mem::drop(shell);
                 if grab.is_touch_grab() {


### PR DESCRIPTION
Fixes #686

Previously when doing Super+{Left,Right} Click the compositor would still send the button event to the client, for left click this didn't cause issues most of the time but for right click this caused many issues because it would usually open a context menu which would cause the resize to stop immediately.

This PR fixes the issue by not sending any button events if the logo key is held.