### PR TITLE
toplevel-management: Set active output if changed, and move cursor

### DIFF
--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -3,10 +3,10 @@
 use cosmic_protocols::workspace::v1::server::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1;
 use smithay::{
     desktop::{layer_map_for_output, WindowSurfaceType},
-    input::Seat,
+    input::{pointer::MotionEvent, Seat},
     output::Output,
     reexports::wayland_server::DisplayHandle,
-    utils::{Point, Rectangle, Size},
+    utils::{Point, Rectangle, Size, SERIAL_COUNTER},
 };
 
 use crate::{
@@ -53,15 +53,40 @@ impl ToplevelManagementHandler for State {
                     .unwrap()
                     .clone();
 
-                let _ = shell.activate(
+                let res = shell.activate(
                     &output,
                     idx as usize,
                     WorkspaceDelta::new_shortcut(),
                     &mut self.common.workspace_state.update(),
-                ); // TODO: Move pointer?
-                mapped.focus_window(window);
-
+                );
                 std::mem::drop(shell);
+
+                if seat.active_output() != *output {
+                    match res {
+                        Ok(Some(new_pos)) => {
+                            seat.set_active_output(&output);
+                            if let Some(ptr) = seat.get_pointer() {
+                                let serial = SERIAL_COUNTER.next_serial();
+                                ptr.motion(
+                                    self,
+                                    None,
+                                    &MotionEvent {
+                                        location: new_pos.to_f64().as_logical(),
+                                        serial,
+                                        time: 0,
+                                    },
+                                );
+                                ptr.frame(self);
+                            }
+                        }
+                        Ok(None) => {
+                            seat.set_active_output(&output);
+                        }
+                        _ => {}
+                    }
+                }
+
+                mapped.focus_window(window);
                 Shell::set_focus(self, Some(&mapped.clone().into()), &seat, None);
                 return;
             }


### PR DESCRIPTION
Previously, alt-tab wouldn't actually focus a window if it was on another output, since the active output/workspace was unchanged.

We need to move the cursor if we activate a window on another output.