### PR TITLE
Don't enable thin LTO in `dev` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,9 +99,6 @@ default = ["systemd"]
 systemd = ["libsystemd"]
 profile-with-tracy = ["profiling/profile-with-tracy"]
 
-[profile.dev]
-lto = "thin"
-
 [profile.dev.package.tiny-skia]
 opt-level = 2
 


### PR DESCRIPTION
Using `lto = "thin"` seems to increase incremental build time when a file is `touch`ed from about 3 seconds to almost 30.

I'm not sure if this helped with anything, but there are probably better ways to improve `dev` performance than enabling LTO.