### PR TITLE
Use monotonic time instead of `0` for motion events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,7 +4703,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=e27fd27#e27fd27caba5238fac8a592f6dff32b430efb272"
+source = "git+https://github.com/smithay//smithay?rev=5dc0153#5dc015361c641cd76d4abbd60dd8896dd8cb8adc"
 dependencies = [
  "appendlist",
  "ash 0.38.0+1.3.281",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,4 +116,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "e27fd27" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "5dc0153" }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1470,7 +1470,7 @@ impl State {
                         &MotionEvent {
                             location: position.as_logical(),
                             serial: SERIAL_COUNTER.next_serial(),
-                            time: 0,
+                            time: self.common.clock.now().as_millis(),
                         },
                     );
 
@@ -1539,7 +1539,7 @@ impl State {
                         &MotionEvent {
                             location: position.as_logical(),
                             serial: SERIAL_COUNTER.next_serial(),
-                            time: 0,
+                            time: self.common.clock.now().as_millis(),
                         },
                     );
 

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -500,7 +500,7 @@ fn update_pointer_focus(state: &mut State, seat: &Seat<State>) {
                 &MotionEvent {
                     location: pointer.current_location(),
                     serial: SERIAL_COUNTER.next_serial(),
-                    time: 0,
+                    time: state.common.clock.now().as_millis(),
                 },
             );
         }

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -302,7 +302,7 @@ pub fn window_items(
                                     &MotionEvent {
                                         location: loc.as_logical().to_f64(),
                                         serial,
-                                        time: 0,
+                                        time: state.common.clock.now().as_millis(),
                                     },
                                 );
                                 pointer.frame(state);
@@ -332,7 +332,7 @@ pub fn window_items(
                                     &MotionEvent {
                                         location: loc.as_logical().to_f64(),
                                         serial,
-                                        time: 0,
+                                        time: state.common.clock.now().as_millis(),
                                     },
                                 );
                                 pointer.frame(state);
@@ -363,7 +363,7 @@ pub fn window_items(
                                     &MotionEvent {
                                         location: loc.as_logical().to_f64(),
                                         serial,
-                                        time: 0,
+                                        time: state.common.clock.now().as_millis(),
                                     },
                                 );
                                 pointer.frame(state);
@@ -394,7 +394,7 @@ pub fn window_items(
                                     &MotionEvent {
                                         location: loc.as_logical().to_f64(),
                                         serial,
-                                        time: 0,
+                                        time: state.common.clock.now().as_millis(),
                                     },
                                 );
                                 pointer.frame(state);

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -872,7 +872,7 @@ impl Drop for MoveGrab {
                             &MotionEvent {
                                 location: pointer.current_location(),
                                 serial,
-                                time: 0,
+                                time: state.common.clock.now().as_millis(),
                             },
                         );
                     }

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -73,7 +73,7 @@ impl ToplevelManagementHandler for State {
                                     &MotionEvent {
                                         location: new_pos.to_f64().as_logical(),
                                         serial,
-                                        time: 0,
+                                        time: self.common.clock.now().as_millis(),
                                     },
                                 );
                                 ptr.frame(self);


### PR DESCRIPTION
Update to https://github.com/Smithay/smithay/pull/1509, and adopt a similar change.