### PR TITLE
Configurable empty workspace removal behaviour

### DIFF
--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -11,6 +11,19 @@ pub struct WorkspaceConfig {
     pub workspace_mode: WorkspaceMode,
     #[serde(default = "default_workspace_layout")]
     pub workspace_layout: WorkspaceLayout,
+    #[serde(default)]
+    pub remove_empty: RemoveEmpty,
+}
+
+/// Setting of which empty workspaces the compositor should automatically remove.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum RemoveEmpty {
+    /// Remove all empty workspaces, except the last one.
+    #[default]
+    All,
+
+    /// Remove only trailing empty workspaces, after the last one.
+    Trailing,
 }
 
 impl Default for WorkspaceConfig {
@@ -18,6 +31,7 @@ impl Default for WorkspaceConfig {
         Self {
             workspace_mode: WorkspaceMode::OutputBound,
             workspace_layout: WorkspaceLayout::Vertical,
+            remove_empty: RemoveEmpty::default(),
         }
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -7,44 +7,26 @@
         ]
       },
       "locked": {
-        "lastModified": 1699548976,
-        "narHash": "sha256-xnpxms0koM8mQpxIup9JnT0F7GrKdvv0QvtxvRuOYR4=",
+        "lastModified": 1722960479,
+        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "6849911446e18e520970cc6b7a691e64ee90d649",
+        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1687178632,
-        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
         "type": "github"
       },
       "original": {
@@ -55,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685591878,
-        "narHash": "sha256-Ib3apaLqIFkZb94q6Q214DXrz0FnJq5C7usywTv63og=",
+        "lastModified": 1723891200,
+        "narHash": "sha256-uljX21+D/DZgb9uEFFG2dkkQbPZN+ig4Z6+UCLWFVAk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d4d822bc0efa9de6eddc79cb0d82897a9baa750",
+        "rev": "a0d6390cb3e82062a35d0288979c45756e481f60",
         "type": "github"
       },
       "original": {
@@ -76,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688466019,
-        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -100,37 +82,21 @@
     },
     "rust": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1688438033,
-        "narHash": "sha256-wOmpZis06pVKTR+5meGwhrW10/buf98lnA26uQLaqek=",
+        "lastModified": 1723947704,
+        "narHash": "sha256-TcVf66N2NgGhxORFytzgqWcg0XJ+kk8uNLNsTRI5sYM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c3e43223dece545cfe06ddd92fd782adc73d56c3",
+        "rev": "456e78a55feade2c3bc6d7bc0bf5e710c9d86120",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -48,14 +48,12 @@
             ];
 
             buildInputs = with pkgs; [
-              wayland
-              systemd # For libudev
-              seatd # For libseat
               libxkbcommon
               libinput
-              mesa # For libgbm
-              fontconfig
-              stdenv.cc.cc.lib
+              mesa
+              pixman
+              seatd
+              udev
             ];
 
             runtimeDependencies = with pkgs; [

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -999,7 +999,7 @@ impl Workspaces {
         let set = self.sets.get(output).or(self.backup_set.as_ref()).unwrap();
         (
             set.previously_active
-                .map(|(idx, start)| (&set.workspaces[idx], start)),
+                .and_then(|(idx, start)| set.workspaces.get(idx).map(|w| (w, start))),
             &set.workspaces[set.active],
         )
     }


### PR DESCRIPTION
Related to #586 

Adds a configuration option that allows to choose the behavior of the compositor when an empty workspace gets deactivated.

`RemoveEmpty::All` - same as currently, the empty workspace gets removed and the ones after it get shifted
`RemoveEmpty::Trailing` - removes only "trailing" empty workspaces, the ones after which there are no non-empty workspaces anymore

Been running it for a week, works fine. There was an edge case that caused a crash [here](https://github.com/pop-os/cosmic-comp/compare/master...xDarksome:cosmic-comp:master_jammy?expand=1#diff-4f1e1533acb2e2645a75fc56f2249115a8c1029a541937726ef8e6449b3b0cecR1002), because now previously active workspace may become invalid (out of bounds). Let me now if there's a better way to fix it.


