### PR TITLE
screencopy: Use buffer age of `0` for render to temporary buffer

### DIFF
--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -219,7 +219,7 @@ pub fn render_workspace_to_buffer(
         buffer: &WlBuffer,
         renderer: &mut R,
         dt: &'d mut OutputDamageTracker,
-        age: usize,
+        mut age: usize,
         additional_damage: Vec<Rectangle<i32, BufferCoords>>,
         draw_cursor: bool,
         common: &mut Common,
@@ -303,6 +303,7 @@ pub fn render_workspace_to_buffer(
             let render_buffer =
                 Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, size)
                     .map_err(DTError::Rendering)?;
+            age = 0;
             render_workspace::<_, _, GlesRenderbuffer>(
                 None,
                 renderer,
@@ -457,7 +458,7 @@ pub fn render_window_to_buffer(
         buffer: &WlBuffer,
         renderer: &mut R,
         dt: &'d mut OutputDamageTracker,
-        age: usize,
+        mut age: usize,
         additional_damage: Vec<Rectangle<i32, BufferCoords>>,
         draw_cursor: bool,
         common: &mut Common,
@@ -563,6 +564,7 @@ pub fn render_window_to_buffer(
             let render_buffer =
                 Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, size)
                     .map_err(DTError::Rendering)?;
+            age = 0;
             renderer.bind(render_buffer).map_err(DTError::Rendering)?;
         }
 
@@ -694,7 +696,7 @@ pub fn render_cursor_to_buffer(
         buffer: &WlBuffer,
         renderer: &mut R,
         dt: &'d mut OutputDamageTracker,
-        age: usize,
+        mut age: usize,
         additional_damage: Vec<Rectangle<i32, BufferCoords>>,
         common: &mut Common,
         seat: &Seat<State>,
@@ -752,6 +754,7 @@ pub fn render_cursor_to_buffer(
             let render_buffer =
                 Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, size)
                     .map_err(DTError::Rendering)?;
+            age = 0;
             renderer.bind(render_buffer).map_err(DTError::Rendering)?;
         }
 


### PR DESCRIPTION
It seems we allocate a new `GlesRenderbuffer` every time we screencopy to an shm buffer.

We probably should use a more complicated approach to do proper damage tracking without any unnecessary copies, and re-using the GPU buffer, but as long as this allocates a buffer the age of that buffer should be treated as `0`.

Fixes corruption in cosmic-workspaces when shm screencopy is used. (For instance, when Cosmic is run with software rendering.)