### PR TITLE
Cleanup: remove unnecessary lifetimes

### DIFF
--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1329,7 +1329,7 @@ impl SurfaceThreadState {
     }
 }
 
-fn source_node_for_surface<'a>(w: &WlSurface) -> Option<DrmNode> {
+fn source_node_for_surface(w: &WlSurface) -> Option<DrmNode> {
     with_renderer_surface_state(w, |state| {
         state
             .buffer()

--- a/src/backend/render/element.rs
+++ b/src/backend/render/element.rs
@@ -186,9 +186,9 @@ where
     <R as Renderer>::Error: FromGlesError,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
-    fn draw<'frame>(
+    fn draw(
         &self,
-        frame: &mut R::Frame<'frame>,
+        frame: &mut R::Frame<'_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -545,7 +545,7 @@ impl DynamicConfig {
         &self.outputs.1
     }
 
-    pub fn outputs_mut<'a>(&'a mut self) -> PersistenceGuard<'a, OutputsConfig> {
+    pub fn outputs_mut(&mut self) -> PersistenceGuard<'_, OutputsConfig> {
         PersistenceGuard(self.outputs.0.clone(), &mut self.outputs.1)
     }
 }

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -588,9 +588,9 @@ impl CosmicMapped {
         }
     }
 
-    pub fn convert_to_stack<'a>(
+    pub fn convert_to_stack(
         &mut self,
-        (output, overlap): (&'a Output, Rectangle<i32, Logical>),
+        (output, overlap): (&Output, Rectangle<i32, Logical>),
         theme: cosmic::Theme,
     ) {
         match &self.element {
@@ -614,10 +614,10 @@ impl CosmicMapped {
         }
     }
 
-    pub fn convert_to_surface<'a>(
+    pub fn convert_to_surface(
         &mut self,
         surface: CosmicSurface,
-        (output, overlap): (&'a Output, Rectangle<i32, Logical>),
+        (output, overlap): (&Output, Rectangle<i32, Logical>),
         theme: cosmic::Theme,
     ) {
         let handle = self.loop_handle();
@@ -1276,9 +1276,9 @@ where
     <R as Renderer>::TextureId: 'static,
     <R as Renderer>::Error: FromGlesError,
 {
-    fn draw<'frame>(
+    fn draw(
         &self,
-        frame: &mut R::Frame<'frame>,
+        frame: &mut R::Frame<'_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -166,7 +166,7 @@ impl Shell {
         }
     }
 
-    fn update_active<'a, 'b>(&mut self) {
+    fn update_active(&mut self) {
         // update activate status
         let focused_windows = self
             .seats

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -953,7 +953,7 @@ impl FloatingLayout {
         }
     }
 
-    pub fn toggle_stacking_focused<'a>(
+    pub fn toggle_stacking_focused(
         &mut self,
         seat: &Seat<State>,
         focus_stack: FocusStackMut,
@@ -966,7 +966,7 @@ impl FloatingLayout {
         self.toggle_stacking(&elem, focus_stack)
     }
 
-    pub fn move_element<'a>(
+    pub fn move_element(
         &mut self,
         direction: Direction,
         seat: &Seat<State>,
@@ -1133,7 +1133,7 @@ impl FloatingLayout {
         }
     }
 
-    pub fn move_current_element<'a>(
+    pub fn move_current_element(
         &mut self,
         direction: Direction,
         seat: &Seat<State>,

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -534,7 +534,7 @@ impl TilingLayout {
         self.map_internal(window, focus_stack, None, Some(from));
     }
 
-    fn map_to_tree<'a>(
+    fn map_to_tree(
         mut tree: &mut Tree<Data>,
         window: impl Into<CosmicMapped>,
         output: &Output,
@@ -1467,11 +1467,7 @@ impl TilingLayout {
         }
     }
 
-    pub fn move_current_node<'a>(
-        &mut self,
-        direction: Direction,
-        seat: &Seat<State>,
-    ) -> MoveResult {
+    pub fn move_current_node(&mut self, direction: Direction, seat: &Seat<State>) -> MoveResult {
         let gaps = self.gaps();
 
         let mut tree = self.queue.trees.back().unwrap().0.copy_clone();
@@ -2059,11 +2055,7 @@ impl TilingLayout {
         FocusResult::None
     }
 
-    pub fn update_orientation<'a>(
-        &mut self,
-        new_orientation: Option<Orientation>,
-        seat: &Seat<State>,
-    ) {
+    pub fn update_orientation(&mut self, new_orientation: Option<Orientation>, seat: &Seat<State>) {
         let gaps = self.gaps();
 
         let Some(target) = seat.get_keyboard().unwrap().current_focus() else {
@@ -2225,7 +2217,7 @@ impl TilingLayout {
         Some(result)
     }
 
-    pub fn toggle_stacking_focused<'a>(
+    pub fn toggle_stacking_focused(
         &mut self,
         seat: &Seat<State>,
         mut focus_stack: FocusStackMut,

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -524,7 +524,7 @@ impl WorkspaceSet {
         self.output = new_output.clone();
     }
 
-    fn refresh<'a>(&mut self, xdg_activation_state: &XdgActivationState) {
+    fn refresh(&mut self, xdg_activation_state: &XdgActivationState) {
         if let Some((_, start)) = self.previously_active {
             match start {
                 WorkspaceDelta::Shortcut(st) => {
@@ -567,7 +567,7 @@ impl WorkspaceSet {
         self.workspaces.push(workspace);
     }
 
-    fn ensure_last_empty<'a>(&mut self, state: &mut WorkspaceUpdateGuard<State>) {
+    fn ensure_last_empty(&mut self, state: &mut WorkspaceUpdateGuard<State>) {
         // add empty at the end, if necessary
         if self
             .workspaces
@@ -2642,7 +2642,7 @@ impl Shell {
     }
 
     #[must_use]
-    pub fn next_focus<'a>(&self, direction: FocusDirection, seat: &Seat<State>) -> FocusResult {
+    pub fn next_focus(&self, direction: FocusDirection, seat: &Seat<State>) -> FocusResult {
         let overview = self.overview_mode().0;
         let output = seat.active_output();
 
@@ -2791,11 +2791,7 @@ impl Shell {
     }
 
     #[must_use]
-    pub fn move_current_element<'a>(
-        &mut self,
-        direction: Direction,
-        seat: &Seat<State>,
-    ) -> MoveResult {
+    pub fn move_current_element(&mut self, direction: Direction, seat: &Seat<State>) -> MoveResult {
         let output = seat.active_output();
         let workspace = self.active_space(&output);
         let focus_stack = workspace.focus_stack.get(seat);
@@ -3261,7 +3257,7 @@ impl Shell {
         }
     }
 
-    pub fn toggle_sticky<'a>(&mut self, seat: &Seat<State>, mapped: &CosmicMapped) {
+    pub fn toggle_sticky(&mut self, seat: &Seat<State>, mapped: &CosmicMapped) {
         // clean from focus-stacks
         for workspace in self.workspaces.spaces_mut() {
             for seat in self.seats.iter() {
@@ -3335,7 +3331,7 @@ impl Shell {
         self.append_focus_stack(&mapped, seat);
     }
 
-    pub fn toggle_sticky_current<'a>(&mut self, seat: &Seat<State>) {
+    pub fn toggle_sticky_current(&mut self, seat: &Seat<State>) {
         let set = self.workspaces.sets.get_mut(&seat.active_output()).unwrap();
         let workspace = &mut set.workspaces[set.active];
         let maybe_window = workspace.focus_stack.get(seat).iter().next().cloned();
@@ -3428,8 +3424,8 @@ impl Shell {
     }
 }
 
-fn workspace_set_idx<'a>(
-    state: &mut WorkspaceUpdateGuard<'a, State>,
+fn workspace_set_idx(
+    state: &mut WorkspaceUpdateGuard<'_, State>,
     idx: u8,
     output_pos: usize,
     handle: &WorkspaceHandle,

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1339,9 +1339,9 @@ where
     <R as Renderer>::TextureId: 'static,
     <R as Renderer>::Error: FromGlesError,
 {
-    fn draw<'frame>(
+    fn draw(
         &self,
-        frame: &mut R::Frame<'frame>,
+        frame: &mut R::Frame<'_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, smithay::utils::Physical>],

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -79,7 +79,7 @@ fn layer_surface_check_inital_configure(surface: &LayerSurface) -> bool {
     initial_configure_sent
 }
 
-pub fn client_compositor_state<'a>(client: &'a Client) -> &'a CompositorClientState {
+pub fn client_compositor_state(client: &Client) -> &CompositorClientState {
     if let Some(state) = client.get_data::<XWaylandClientData>() {
         return &state.compositor_state;
     }

--- a/src/wayland/protocols/workspace.rs
+++ b/src/wayland/protocols/workspace.rs
@@ -567,7 +567,7 @@ where
             .cloned()
     }
 
-    pub fn update<'a>(&'a mut self) -> WorkspaceUpdateGuard<'a, D> {
+    pub fn update(&mut self) -> WorkspaceUpdateGuard<'_, D> {
         WorkspaceUpdateGuard(self)
     }
 


### PR DESCRIPTION
This refactor removes lifetimes where the compiler can imply them, making function signatures a bit simpler.

Example:
```
fn update_active<'a, 'b>(&mut self) {
```
becomes:
```
fn update_active(&mut self) {
```

Resolves 2 types of clippy warnings, in 25 instances:
1. https://rust-lang.github.io/rust-clippy/master/index.html#/extra_unused_lifetimes
2. https://rust-lang.github.io/rust-clippy/master/index.html#/needless_lifetimes