### PR TITLE
Cleanup: remove unnecessary casting

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -112,9 +112,9 @@ impl WinitState {
             .get::<RefCell<OutputConfig>>()
             .unwrap()
             .borrow_mut();
-        if dbg!(config.mode.0) != dbg!((size.w as i32, size.h as i32)) {
+        if dbg!(config.mode.0) != dbg!((size.w, size.h)) {
             if !test_only {
-                config.mode = ((size.w as i32, size.h as i32), None);
+                config.mode = ((size.w, size.h), None);
             }
             Err(anyhow::anyhow!("Cannot set window size"))
         } else {
@@ -143,7 +143,7 @@ pub fn init_backend(
         model: name.clone(),
     };
     let mode = Mode {
-        size: (size.w as i32, size.h as i32).into(),
+        size: (size.w, size.h).into(),
         refresh: 60_000,
     };
     let output = Output::new(name, props);
@@ -157,7 +157,7 @@ pub fn init_backend(
     );
     output.user_data().insert_if_missing(|| {
         RefCell::new(OutputConfig {
-            mode: ((size.w as i32, size.h as i32), None),
+            mode: ((size.w, size.h), None),
             transform: Transform::Flipped180.into(),
             ..Default::default()
         })

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1881,7 +1881,7 @@ impl State {
                 let res = shell.move_current_window(
                     seat,
                     &current_output,
-                    (&current_output, Some(workspace as usize)),
+                    (&current_output, Some(workspace)),
                     matches!(x, Action::MoveToLastWorkspace),
                     None,
                     &mut self.common.workspace_state.update(),
@@ -1904,7 +1904,7 @@ impl State {
                     shell.move_current_window(
                         seat,
                         &current_output,
-                        (&current_output, Some(workspace as usize)),
+                        (&current_output, Some(workspace)),
                         matches!(x, Action::MoveToNextWorkspace),
                         direction,
                         &mut self.common.workspace_state.update(),
@@ -1949,7 +1949,7 @@ impl State {
                     shell.move_current_window(
                         seat,
                         &current_output,
-                        (&current_output, Some(workspace as usize)),
+                        (&current_output, Some(workspace)),
                         matches!(x, Action::MoveToPreviousWorkspace),
                         direction,
                         &mut self.common.workspace_state.update(),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2628,7 +2628,7 @@ impl Shell {
             seat,
             initial_window_location,
             cursor_output,
-            active_hint as u8,
+            active_hint,
             layer,
             release,
             evlh.clone(),

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -80,10 +80,10 @@ where
     if matches!(buffer_type(&buffer), Some(BufferType::Shm)) {
         let buffer_size = buffer_dimensions(&buffer).unwrap();
         if let Err(err) = with_buffer_contents_mut(&buffer, |ptr, len, data| {
-            let offset = data.offset as i32;
-            let width = data.width as i32;
-            let height = data.height as i32;
-            let stride = data.stride as i32;
+            let offset = data.offset;
+            let width = data.width;
+            let height = data.height;
+            let stride = data.stride;
             let format = shm_format_to_fourcc(data.format)
                 .expect("We should be able to convert all hardcoded shm screencopy formats");
 

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -55,7 +55,7 @@ impl ToplevelManagementHandler for State {
 
                 let res = shell.activate(
                     &output,
-                    idx as usize,
+                    idx,
                     WorkspaceDelta::new_shortcut(),
                     &mut self.common.workspace_state.update(),
                 );

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -254,7 +254,7 @@ impl Common {
                 .outputs()
                 .map(|o| o.current_scale().integer_scale())
                 .max()
-                .unwrap_or(1) as i32
+                .unwrap_or(1)
         } else {
             1
         };


### PR DESCRIPTION
Removes typecasts where the variable is already that type, e.g.:
```
let offset = data.offset as i32;
let width = data.width as i32;
let height = data.height as i32;
let stride = data.stride as i32;
```
these fields are already `i32`, so `as i32` can be removed.

This resolves 18 instances of this warning.

Found with clippy lint:
https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_cast