### PR TITLE
fix: flake.nix under NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
     parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
     crane.url = "github:ipetkov/crane";
-    crane.inputs.nixpkgs.follows = "nixpkgs";
 
     rust.url = "github:oxalica/rust-overlay";
     rust.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,15 @@
 
             runtimeDependencies = with pkgs; [
               libglvnd # For libEGL
+              wayland # winit->wayland-sys wants to dlopen libwayland-egl.so
+              # for running in X11
+              xorg.libX11
+              xorg.libXcursor
+              xorg.libxcb
+              xorg.libXi
+              libxkbcommon
+              # for vulkan backend
+              vulkan-loader
             ];
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,11 +16,29 @@
     nix-filter.url = "github:numtide/nix-filter";
   };
 
-  outputs = inputs@{ self, nixpkgs, parts, crane, rust, nix-filter, ... }:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      parts,
+      crane,
+      rust,
+      nix-filter,
+      ...
+    }:
     parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "aarch64-linux" "x86_64-linux" ];
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
 
-      perSystem = { self', lib, system, ... }:
+      perSystem =
+        {
+          self',
+          lib,
+          system,
+          ...
+        }:
         let
           pkgs = nixpkgs.legacyPackages.${system}.extend rust.overlays.default;
           rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
@@ -77,7 +95,9 @@
           packages.default = cosmic-comp;
 
           devShells.default = craneLib.devShell {
-            LD_LIBRARY_PATH = lib.makeLibraryPath (__concatMap (d: d.runtimeDependencies) (__attrValues self'.checks));
+            LD_LIBRARY_PATH = lib.makeLibraryPath (
+              __concatMap (d: d.runtimeDependencies) (__attrValues self'.checks)
+            );
 
             # include build inputs
             inputsFrom = [ cosmic-comp ];

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.80"
+components = [ "rust-src" ]


### PR DESCRIPTION
There are multiple issues with `flake.nix`.

1. `rust-src` is missing in `rust-toolchain.toml`.
Because of that, Rust Analyzer fails to resolve `std`, rendering RA pretty much unusable. 

(Zed log)
```
[WARN  project] Language server rust-analyzer-2024-09-02 (id 1) status update: Workspace `~/cosmic/cosmic-comp/Cargo.toml` has sysroot errors: can't load standard library from sysroot
{sysroot_path}
(discovered via `rustc --print sysroot`)
try installing the Rust source the same way you installed rustc
```
![image](https://github.com/user-attachments/assets/7b78cc52-c135-4207-b56d-c76d4026691d)
`flake.nix` imports rust toolchain from it:
https://github.com/pop-os/cosmic-comp/blob/52280e9823506a480248e84caaf7545426a871c8/flake.nix#L26 

2. When running in Wayland session in NixOS, `cosmic-comp` fails since `libwayland-egl.so` is missing in runtime.
```
2024-09-04T12:46:55.406051Z ERROR backend_winit: panic: thread 'main' panicked at 'Library libwayland-egl.so could not be loaded.': /home/dvtfl/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wayland-sys-0.31.4/src/egl.rs:46
<...>
  26: smithay::backend::winit::init
             at /home/dvtfl/.cargo/git/checkouts/smithay-0141b1fcb9e16729/65c4abf/src/backend/winit/mod.rs:71:5
  27: cosmic_comp::backend::winit::init_backend
             at /home/dvtfl/projects/rust/cosmic/cosmic-comp/src/backend/winit.rs:132:9
  28: cosmic_comp::backend::init_backend_auto
             at /home/dvtfl/projects/rust/cosmic/cosmic-comp/src/backend/mod.rs:35:25
  29: cosmic_comp::main
             at /home/dvtfl/projects/rust/cosmic/cosmic-comp/src/main.rs:108:
<...>
```
[full backtrace](https://yaso.su/o6UzZvyb)
3. When running in X11 session in NixOS, `cosmic-comp` fails since it fails to instantiate Vulkan and GBM.
```
INFO cosmic_comp::backend::x11: EGL hardware-acceleration enabled.
WARN cosmic_comp::backend::x11: Failed to instanciate vulkan, falling back to gbm allocator. err=Load(LoadError)
INFO smithay::backend::drm::device::fd: Dropping device: Some("/dev/dri/renderD128")
ERROR cosmic_comp::backend::x11: Failed to create GBM device. err=Os { code: 2, kind: NotFound, message: "No such file or directory" }
WARN cosmic_comp::backend: Initializing X11 Backend failed. err=Failed to create allocator for x11
INFO cosmic_comp::backend: Falling back to winit backend.
INFO backend_winit: smithay::backend::winit: Initializing a winit backend
Error: Failed to initilize winit backend: EventLoopCreation(NotSupported(NotSupportedError))
```
This PR addresses issues above and additionally reformats `flake.nix` using [`nixfmt-rfc-style`](https://github.com/NixOS/rfcs/pull/166).
<!-- okay maybe refomating is a bit overkill --> 