### PR TITLE
Destroy `X11Wm` when we lose connect to X server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,16 +539,16 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58a38167d6fba8c67cce63c4a91f2a73ca42cbdaf6fb9ba164f1e07b43ecc10"
+checksum = "a1ead1e1514bce44c0f40e027899fbc595907fc112635bed21b3b5d975c0a5e7"
 dependencies = [
  "async-task",
  "bitflags 2.6.0",
- "log",
  "polling",
  "rustix",
  "slab",
+ "tracing",
 ]
 
 [[package]]
@@ -823,7 +823,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.6.0",
  "bytemuck",
- "calloop 0.14.0",
+ "calloop 0.14.1",
  "cosmic-comp-config",
  "cosmic-config",
  "cosmic-protocols",
@@ -888,7 +888,7 @@ version = "0.1.0"
 source = "git+https://github.com/pop-os/libcosmic/#b40839638ab0e1d96de3f817eded647e6952db40"
 dependencies = [
  "atomicwrites",
- "calloop 0.14.0",
+ "calloop 0.14.1",
  "cosmic-config-derive",
  "dirs",
  "iced_futures",
@@ -4086,9 +4086,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
 ]
@@ -4703,12 +4703,12 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=65c4abf#65c4abf4cbdf122abff96ad17a440c76a8cf7cea"
+source = "git+https://github.com/smithay//smithay?rev=f364c73#f364c73cae953aebfa189075e9f118f9008e100b"
 dependencies = [
  "appendlist",
  "ash 0.38.0+1.3.281",
  "bitflags 2.6.0",
- "calloop 0.14.0",
+ "calloop 0.14.1",
  "cc",
  "cgmath",
  "cursor-icon",
@@ -5233,6 +5233,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5702,9 +5703,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
+checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -5716,9 +5717,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
+checksum = "e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d"
 dependencies = [
  "bitflags 2.6.0",
  "rustix",
@@ -5760,9 +5761,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa"
+checksum = "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -5813,9 +5814,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.4"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
+checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -5824,9 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.4"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a4bab6d420ee4a609b63ef4d5f9b5d309c6b93a029fccab70f2594c0cb3ae"
+checksum = "0f18d47038c0b10479e695d99ed073e400ccd9bdbb60e6e503c96f62adcb12b6"
 dependencies = [
  "bitflags 2.6.0",
  "downcast-rs",
@@ -5838,9 +5839,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.4"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
+checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
 dependencies = [
  "dlib",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 anyhow = {version = "1.0.51", features = ["backtrace"]}
 bitflags = "2.4"
 bytemuck = "1.12"
-calloop = {version = "0.14.0", features = ["executor"]}
+calloop = {version = "0.14.1", features = ["executor"]}
 cosmic-comp-config = {path = "cosmic-comp-config"}
 cosmic-config = {git = "https://github.com/pop-os/libcosmic/", features = ["calloop", "macro"]}
 cosmic-protocols = {git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"]}
@@ -116,4 +116,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "65c4abf" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "f364c73" }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -773,4 +773,9 @@ impl XwmHandler for State {
             }
         }
     }
+
+    fn disconnected(&mut self, _xwm: XwmId) {
+        let xwayland_state = self.common.xwayland_state.as_mut().unwrap();
+        xwayland_state.xwm = None;
+    }
 }


### PR DESCRIPTION
This fixes the issue where X11 windows freeze and can't be closed when Xwayland dies.

Requires https://github.com/Smithay/smithay/pull/1527 and a calloop release with https://github.com/Smithay/calloop/pull/208 (it seems https://github.com/Smithay/calloop/commit/0ab5cc22ed224d0fabf6e901b0d0a58ea494357a fixed an issue, but https://github.com/Smithay/calloop/commit/86c6713980ce08e3b2111efb9056aca9fd5f8d9 broke things).