### PR TITLE
Add com.system76.CosmicFilesDialog as floating window exception

### DIFF
--- a/data/tiling-exceptions.ron
+++ b/data/tiling-exceptions.ron
@@ -20,6 +20,7 @@
 	(appid: "Authy Desktop", titles: [".*"]),
 	(appid: "Com.github.amezin.ddterm", titles: [".*"]),
 	(appid: "Com.github.donadigo.eddy", titles: [".*"]),
+	(appid: "com.system76.CosmicFilesDialog", titles: [".*"]),
 	(appid: "Enpass", titles: ["Enpass Assistant"]),
 	(appid: "Gjs", titles: ["Settings"]),
 	(appid: "Gnome-initial-setup", titles: [".*"]),


### PR DESCRIPTION
Part of https://github.com/pop-os/cosmic-files/issues/335