### PR TITLE
Split off `KeyboardHandle::filter` callback to separate method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,12 +4481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scan_fmt"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,7 +4697,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=f364c73#f364c73cae953aebfa189075e9f118f9008e100b"
+source = "git+https://github.com/smithay//smithay?rev=08d31e1#08d31e17ea4ac47cddeb56e2ac18ee50b331911b"
 dependencies = [
  "appendlist",
  "ash 0.38.0+1.3.281",
@@ -4723,7 +4717,6 @@ dependencies = [
  "glow 0.12.3",
  "indexmap 2.3.0",
  "input",
- "lazy_static",
  "libc",
  "libloading 0.8.5",
  "libseat",
@@ -4733,7 +4726,6 @@ dependencies = [
  "profiling",
  "rand",
  "rustix",
- "scan_fmt",
  "scopeguard",
  "smallvec",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,4 +116,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "f364c73" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "08d31e1" }

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -165,7 +165,7 @@ fn init_libinput(
             state.backend.kms().input_devices.remove(device.name());
         }
 
-        state.process_input_event(event, true);
+        state.process_input_event(event);
 
         for output in state.common.shell.read().unwrap().outputs() {
             state.backend.kms().schedule_render(output);

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -320,7 +320,7 @@ impl State {
                 render_ping.ping();
             }
             WinitEvent::Redraw => render_ping.ping(),
-            WinitEvent::Input(event) => self.process_input_event(event, false),
+            WinitEvent::Input(event) => self.process_input_event(event),
             WinitEvent::CloseRequested => {
                 self.common.should_stop = true;
             }

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -515,7 +515,7 @@ impl State {
             _ => {}
         };
 
-        self.process_input_event(event, false);
+        self.process_input_event(event);
         // TODO actually figure out the output
         for output in self.common.shell.read().unwrap().outputs() {
             self.backend.x11().schedule_render(output);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -264,7 +264,9 @@ impl Config {
                                     .shell
                                     .write()
                                     .unwrap()
-                                    .update_tiling_exceptions(state.common.config.tiling_exceptions.iter());
+                                    .update_tiling_exceptions(
+                                        state.common.config.tiling_exceptions.iter(),
+                                    );
                             }
                             _ => (),
                         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -391,7 +391,7 @@ impl State {
                                             let action = Action::Private(PrivateAction::Resizing(direction, edge.into(), cosmic_keystate_from_smithay(state)));
                                             let key_pattern = shortcuts::Binding {
                                                 modifiers: cosmic_modifiers_from_smithay(modifiers.clone()),
-                                                key: Some(Keysym::new(handle.raw_code().raw())),
+                                                key: Some(handle.modified_sym()),
                                                 description: None,
                                             };
 

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -63,7 +63,7 @@ pub struct TilingExceptions {
 impl TilingExceptions {
     pub fn new<'a, I>(exceptions_config: I) -> Self
     where
-      I: Iterator<Item=&'a ApplicationException>
+        I: Iterator<Item = &'a ApplicationException>,
     {
         let mut app_ids = Vec::new();
         let mut titles = Vec::new();

--- a/src/shell/layout/tiling/grabs/swap.rs
+++ b/src/shell/layout/tiling/grabs/swap.rs
@@ -1,6 +1,6 @@
 use cosmic_settings_config::shortcuts;
 use smithay::{
-    backend::input::KeyState,
+    backend::input::{KeyState, Keycode},
     input::{
         keyboard::{
             GrabStartData as KeyboardGrabStartData, KeyboardGrab, KeyboardInnerHandle,
@@ -33,7 +33,7 @@ impl KeyboardGrab<State> for SwapWindowGrab {
         &mut self,
         data: &mut State,
         handle: &mut KeyboardInnerHandle<'_, State>,
-        keycode: u32,
+        keycode: Keycode,
         state: KeyState,
         modifiers: Option<ModifiersState>,
         serial: Serial,

--- a/src/shell/layout/tiling/grabs/swap.rs
+++ b/src/shell/layout/tiling/grabs/swap.rs
@@ -10,7 +10,6 @@ use smithay::{
     },
     utils::Serial,
 };
-use xkbcommon::xkb::Keysym;
 
 use crate::{
     config::key_bindings::cosmic_modifiers_from_smithay,
@@ -81,7 +80,7 @@ impl KeyboardGrab<State> for SwapWindowGrab {
                 modifiers: modifiers
                     .map(cosmic_modifiers_from_smithay)
                     .unwrap_or_default(),
-                key: Some(Keysym::new(keycode)),
+                key: Some(handle.keysym_handle(keycode).modified_sym()),
                 description: None,
             },
             None,


### PR DESCRIPTION
Requires https://github.com/Smithay/smithay/pull/1533. If the `input_intercept` changes there are controversial, this could instead use a a few more arguments, or something involving `input_intercept`/`input_forward` instead of `input` (but that's probably not simpler).

https://github.com/pop-os/cosmic-comp/pull/465 will require some additional logic here to filter out the key grabs. I don't really want this to get *more* complicated so a wanted to try splitting things up first. Just moving the callback to a method is a start, though more could be improved.