### PR TITLE
toplevel-info/mgmt: Update to v2/v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "ordered-float",
  "png",
  "profiling",
+ "rand",
  "regex",
  "ron",
  "rust-embed",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#de2fead49d6af3a221db153642e4d7c2235aafc4"
+source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#91aeb55052a8e6e15a7ddd53e039a9350f16fa69"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -1078,7 +1078,7 @@ version = "0.19.0"
 source = "git+https://github.com/gfx-rs/wgpu?rev=20fda69#20fda698341efbdc870b8027d6d49f5bf3f36109"
 dependencies = [
  "bitflags 2.6.0",
- "libloading 0.8.5",
+ "libloading 0.7.4",
  "winapi",
 ]
 
@@ -1219,7 +1219,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.5",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -2156,7 +2156,7 @@ dependencies = [
  "bitflags 2.6.0",
  "com",
  "libc",
- "libloading 0.8.5",
+ "libloading 0.7.4",
  "thiserror",
  "widestring",
  "winapi",
@@ -2837,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5950,7 +5950,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.5",
+ "libloading 0.7.4",
  "log",
  "metal",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ zbus = "4.4.0"
 profiling = { version = "1.0" }
 rustix = { version = "0.38.32", features = ["process"] }
 smallvec = "1.13.2"
+rand = "0.8.5"
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"

--- a/src/state.rs
+++ b/src/state.rs
@@ -68,7 +68,6 @@ use smithay::{
         compositor::{CompositorClientState, CompositorState, SurfaceData},
         cursor_shape::CursorShapeManagerState,
         dmabuf::{DmabufFeedback, DmabufGlobal, DmabufState},
-        foreign_toplevel_list::ForeignToplevelListState,
         fractional_scale::{with_fractional_scale, FractionalScaleManagerState},
         idle_inhibit::IdleInhibitManagerState,
         idle_notify::IdleNotifierState,
@@ -195,7 +194,6 @@ pub struct Common {
     pub compositor_state: CompositorState,
     pub data_device_state: DataDeviceState,
     pub dmabuf_state: DmabufState,
-    pub foreign_toplevel_list: ForeignToplevelListState,
     pub fractional_scale_state: FractionalScaleManagerState,
     pub keyboard_shortcuts_inhibit_state: KeyboardShortcutsInhibitState,
     pub output_state: OutputManagerState,
@@ -496,8 +494,6 @@ impl State {
         let compositor_state = CompositorState::new::<Self>(dh);
         let data_device_state = DataDeviceState::new::<Self>(dh);
         let dmabuf_state = DmabufState::new();
-        let foreign_toplevel_list =
-            ForeignToplevelListState::new_with_filter::<State>(dh, client_is_privileged);
         let fractional_scale_state = FractionalScaleManagerState::new::<State>(dh);
         let keyboard_shortcuts_inhibit_state = KeyboardShortcutsInhibitState::new::<Self>(dh);
         let output_state = OutputManagerState::new_with_xdg_output::<Self>(dh);
@@ -595,7 +591,6 @@ impl State {
                 compositor_state,
                 data_device_state,
                 dmabuf_state,
-                foreign_toplevel_list,
                 fractional_scale_state,
                 idle_notifier_state,
                 idle_inhibit_manager_state,

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -265,7 +265,6 @@ impl State {
                     let res = shell.map_window(
                         &window,
                         &mut self.common.toplevel_info_state,
-                        &mut self.common.foreign_toplevel_list,
                         &mut self.common.workspace_state,
                         &self.common.event_loop_handle,
                     );

--- a/src/wayland/handlers/foreign_toplevel_list.rs
+++ b/src/wayland/handlers/foreign_toplevel_list.rs
@@ -1,67 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{
-    shell::{CosmicSurface, Shell},
-    state::State,
-};
+use crate::{state::State, wayland::protocols::toplevel_info::ToplevelInfoHandler};
 use smithay::wayland::foreign_toplevel_list::{
-    ForeignToplevelHandle, ForeignToplevelListHandler, ForeignToplevelListState,
+    ForeignToplevelListHandler, ForeignToplevelListState,
 };
-use std::sync::Mutex;
 
 impl ForeignToplevelListHandler for State {
     fn foreign_toplevel_list_state(&mut self) -> &mut ForeignToplevelListState {
-        &mut self.common.foreign_toplevel_list
-    }
-}
-
-pub fn new_foreign_toplevel(
-    window: &CosmicSurface,
-    foreign_toplevel_list: &mut ForeignToplevelListState,
-) {
-    let toplevel_handle =
-        foreign_toplevel_list.new_toplevel::<State>(window.title(), window.app_id());
-    *window
-        .user_data()
-        .get_or_insert::<Mutex<Option<ForeignToplevelHandle>>, _>(Default::default)
-        .lock()
-        .unwrap() = Some(toplevel_handle);
-}
-
-pub fn remove_foreign_toplevel(
-    window: &CosmicSurface,
-    foreign_toplevel_list: &mut ForeignToplevelListState,
-) {
-    if let Some(handle) = window
-        .user_data()
-        .get::<Mutex<Option<ForeignToplevelHandle>>>()
-    {
-        if let Some(handle) = handle.lock().unwrap().take() {
-            foreign_toplevel_list.remove_toplevel(&handle);
-        }
-    }
-}
-
-pub fn refresh_foreign_toplevels(shell: &Shell) {
-    for (window, _) in shell
-        .workspaces
-        .spaces()
-        .flat_map(|workspace| workspace.mapped())
-        .flat_map(|mapped| mapped.windows())
-    {
-        let foreign_toplevel_handle = window
-            .user_data()
-            .get::<Mutex<Option<ForeignToplevelHandle>>>()
-            .and_then(|handle| handle.lock().unwrap().clone());
-        if let Some(handle) = foreign_toplevel_handle {
-            let app_id = window.app_id();
-            let title = window.title();
-            if handle.app_id() != app_id || handle.title() != title {
-                handle.send_app_id(&app_id);
-                handle.send_title(&title);
-                handle.send_done();
-            }
-        }
+        &mut self.toplevel_info_state_mut().foreign_toplevel_list
     }
 }
 

--- a/src/wayland/handlers/toplevel_info.rs
+++ b/src/wayland/handlers/toplevel_info.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use smithay::utils::user_data::UserDataMap;
+use smithay::utils::{user_data::UserDataMap, Rectangle};
 
 use crate::{
-    shell::CosmicSurface,
+    shell::{element::surface::GlobalGeometry, CosmicSurface},
     state::State,
+    utils::prelude::Global,
     wayland::protocols::toplevel_info::{
         delegate_toplevel_info, ToplevelInfoHandler, ToplevelInfoState, Window,
     },
@@ -44,6 +45,20 @@ impl Window for CosmicSurface {
 
     fn is_minimized(&self) -> bool {
         CosmicSurface::is_minimized(self)
+    }
+
+    fn is_sticky(&self) -> bool {
+        CosmicSurface::is_sticky(&self)
+    }
+
+    fn global_geometry(&self) -> Option<Rectangle<i32, Global>> {
+        self.user_data()
+            .get_or_insert(GlobalGeometry::default)
+            .0
+            .lock()
+            .unwrap()
+            .clone()
+            .filter(|_| !self.is_minimized())
     }
 
     fn user_data(&self) -> &UserDataMap {

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -228,6 +228,34 @@ impl ToplevelManagementHandler for State {
             }
         }
     }
+
+    fn set_sticky(&mut self, _dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {
+        if window.is_sticky() {
+            return;
+        }
+
+        let mut shell = self.common.shell.write().unwrap();
+        if let Some(mapped) = shell.element_for_surface(window).cloned() {
+            let seat = shell.seats.last_active().clone();
+            shell.toggle_sticky(&seat, &mapped);
+        }
+    }
+
+    fn unset_sticky(
+        &mut self,
+        _dh: &DisplayHandle,
+        window: &<Self as ToplevelInfoHandler>::Window,
+    ) {
+        if !window.is_sticky() {
+            return;
+        }
+
+        let mut shell = self.common.shell.write().unwrap();
+        if let Some(mapped) = shell.element_for_surface(window).cloned() {
+            let seat = shell.seats.last_active().clone();
+            shell.toggle_sticky(&seat, &mapped);
+        }
+    }
 }
 
 impl ManagementWindow for CosmicSurface {

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -387,7 +387,6 @@ impl XdgShellHandler for State {
                 surface.wl_surface(),
                 &seat,
                 &mut self.common.toplevel_info_state,
-                &mut self.common.foreign_toplevel_list,
             );
 
             let output = shell

--- a/src/wayland/protocols/mod.rs
+++ b/src/wayland/protocols/mod.rs
@@ -3,6 +3,7 @@
 pub mod drm;
 pub mod image_source;
 pub mod output_configuration;
+pub mod overlap_notify;
 pub mod screencopy;
 pub mod toplevel_info;
 pub mod toplevel_management;

--- a/src/wayland/protocols/overlap_notify.rs
+++ b/src/wayland/protocols/overlap_notify.rs
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{collections::HashMap, sync::Mutex};
+
+use cosmic_protocols::{
+    overlap_notify::v1::server::{
+        zcosmic_overlap_notification_v1::ZcosmicOverlapNotificationV1,
+        zcosmic_overlap_notify_v1::{self, ZcosmicOverlapNotifyV1},
+    },
+    toplevel_info::v1::server::{
+        zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1,
+    },
+};
+use rand::distributions::{Alphanumeric, DistString};
+use smithay::{
+    desktop::{layer_map_for_output, LayerSurface},
+    output::Output,
+    reexports::{
+        wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        wayland_protocols_wlr::layer_shell::v1::server::{
+            zwlr_layer_shell_v1::Layer as WlrLayer, zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
+        },
+        wayland_server::{Client, Dispatch, DisplayHandle, GlobalDispatch, Resource, Weak},
+    },
+    utils::{Logical, Rectangle},
+    wayland::{
+        foreign_toplevel_list::ForeignToplevelListHandler,
+        shell::wlr_layer::{ExclusiveZone, Layer},
+    },
+};
+use wayland_backend::server::GlobalId;
+
+use crate::utils::prelude::{RectExt, RectGlobalExt, RectLocalExt};
+
+use super::toplevel_info::{
+    ToplevelHandleState, ToplevelInfoGlobalData, ToplevelInfoHandler, ToplevelState, Window,
+};
+
+pub struct OverlapNotifyState {
+    instances: Vec<ZcosmicOverlapNotifyV1>,
+    global: GlobalId,
+}
+
+impl OverlapNotifyState {
+    pub fn new<D, F>(dh: &DisplayHandle, client_filter: F) -> OverlapNotifyState
+    where
+        D: GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData>
+            + Dispatch<ZcosmicOverlapNotifyV1, ()>
+            + Dispatch<ZcosmicOverlapNotificationV1, ()>
+            + OverlapNotifyHandler
+            + 'static,
+        F: for<'a> Fn(&'a Client) -> bool + Send + Sync + 'static,
+    {
+        let global = dh.create_global::<D, ZcosmicOverlapNotifyV1, _>(
+            1,
+            OverlapNotifyGlobalData {
+                filter: Box::new(client_filter),
+            },
+        );
+        OverlapNotifyState {
+            instances: Vec::new(),
+            global,
+        }
+    }
+
+    pub fn global_id(&self) -> GlobalId {
+        self.global.clone()
+    }
+
+    pub fn refresh<D, W>(state: &mut D)
+    where
+        D: GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData>
+            + Dispatch<ZcosmicOverlapNotifyV1, ()>
+            + Dispatch<ZcosmicOverlapNotificationV1, ()>
+            + OverlapNotifyHandler
+            + GlobalDispatch<ZcosmicToplevelInfoV1, ToplevelInfoGlobalData>
+            + Dispatch<ZcosmicToplevelInfoV1, ()>
+            + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
+            + ForeignToplevelListHandler
+            + ToplevelInfoHandler<Window = W>
+            + 'static,
+        W: Window + 'static,
+    {
+        for output in state.outputs() {
+            let map = layer_map_for_output(output);
+            for layer_surface in map.layers() {
+                if let Some(data) = layer_surface
+                    .user_data()
+                    .get::<LayerOverlapNotificationData>()
+                {
+                    let mut inner = data.lock().unwrap();
+
+                    if inner.has_active_notifications() {
+                        let mut new_snapshot = OverlapSnapshot::default();
+
+                        let layer_geo = layer_surface.bbox().as_local().to_global(output);
+
+                        for window in state.toplevel_info_state().registered_toplevels() {
+                            if let Some(window_geo) = window.global_geometry() {
+                                if let Some(intersection) = layer_geo.intersection(window_geo) {
+                                    // relative to window location
+                                    let region = Rectangle::from_loc_and_size(
+                                        intersection.loc - window_geo.loc,
+                                        intersection.size,
+                                    )
+                                    .as_logical();
+                                    new_snapshot.add_toplevel(window, region);
+                                }
+                            }
+                        }
+
+                        for other_surface in map.layers().filter(|s| *s != layer_surface) {
+                            let other_geo = other_surface.bbox().as_local().to_global(output);
+                            if let Some(intersection) = layer_geo.intersection(other_geo) {
+                                // relative to window location
+                                let region = Rectangle::from_loc_and_size(
+                                    intersection.loc - other_geo.loc,
+                                    intersection.size,
+                                )
+                                .as_logical();
+                                new_snapshot.add_layer(other_surface, region);
+                            }
+                        }
+
+                        inner.update_snapshot(new_snapshot);
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub trait OverlapNotifyHandler: ToplevelInfoHandler {
+    fn overlap_notify_state(&mut self) -> &mut OverlapNotifyState;
+    fn layer_surface_from_resource(&self, resource: ZwlrLayerSurfaceV1) -> Option<LayerSurface>;
+    fn outputs(&self) -> impl Iterator<Item = &Output>;
+}
+
+pub struct OverlapNotifyGlobalData {
+    filter: Box<dyn for<'a> Fn(&'a Client) -> bool + Send + Sync>,
+}
+
+type LayerOverlapNotificationData = Mutex<LayerOverlapNotificationDataInternal>;
+
+#[derive(Debug, Default)]
+struct LayerOverlapNotificationDataInternal {
+    active_notifications: Vec<Weak<ZcosmicOverlapNotificationV1>>,
+    last_snapshot: OverlapSnapshot,
+}
+
+impl LayerOverlapNotificationDataInternal {
+    pub fn has_active_notifications(&mut self) -> bool {
+        self.active_notifications.retain(|w| w.upgrade().is_ok());
+        !self.active_notifications.is_empty()
+    }
+
+    pub fn add_notification(&mut self, new_notification: ZcosmicOverlapNotificationV1) {
+        for (toplevel, overlap) in &self.last_snapshot.toplevel_overlaps {
+            if let Ok(toplevel) = toplevel.upgrade() {
+                new_notification.toplevel_enter(
+                    &toplevel,
+                    overlap.loc.x,
+                    overlap.loc.y,
+                    overlap.size.w,
+                    overlap.size.h,
+                );
+            }
+        }
+        for (layer_surface, (exclusive, layer, overlap)) in &self.last_snapshot.layer_overlaps {
+            new_notification.layer_enter(
+                layer_surface.clone(),
+                if *exclusive { 1 } else { 0 },
+                match layer {
+                    Layer::Background => WlrLayer::Background,
+                    Layer::Bottom => WlrLayer::Bottom,
+                    Layer::Top => WlrLayer::Top,
+                    Layer::Overlay => WlrLayer::Overlay,
+                },
+                overlap.loc.x,
+                overlap.loc.y,
+                overlap.size.w,
+                overlap.size.h,
+            );
+        }
+        self.active_notifications.push(new_notification.downgrade());
+    }
+
+    pub fn update_snapshot(&mut self, new_snapshot: OverlapSnapshot) {
+        let notifications = self
+            .active_notifications
+            .iter()
+            .flat_map(|w| w.upgrade().ok())
+            .collect::<Vec<_>>();
+
+        for toplevel in self.last_snapshot.toplevel_overlaps.keys() {
+            if !new_snapshot.toplevel_overlaps.contains_key(toplevel) {
+                if let Ok(toplevel) = toplevel.upgrade() {
+                    for notification in &notifications {
+                        notification.toplevel_leave(&toplevel);
+                    }
+                }
+            }
+        }
+        for (toplevel, overlap) in &new_snapshot.toplevel_overlaps {
+            if !self.last_snapshot.toplevel_overlaps.contains_key(toplevel) {
+                if let Ok(toplevel) = toplevel.upgrade() {
+                    for notification in &notifications {
+                        notification.toplevel_enter(
+                            &toplevel,
+                            overlap.loc.x,
+                            overlap.loc.y,
+                            overlap.size.w,
+                            overlap.size.h,
+                        );
+                    }
+                }
+            }
+        }
+
+        for layer_surface in self.last_snapshot.layer_overlaps.keys() {
+            if new_snapshot.layer_overlaps.contains_key(layer_surface) {
+                for notification in &notifications {
+                    notification.layer_leave(layer_surface.clone());
+                }
+            }
+        }
+        for (layer_surface, (exclusive, layer, overlap)) in &new_snapshot.layer_overlaps {
+            if !self
+                .last_snapshot
+                .layer_overlaps
+                .contains_key(layer_surface)
+            {
+                for notification in &notifications {
+                    notification.layer_enter(
+                        layer_surface.clone(),
+                        if *exclusive { 1 } else { 0 },
+                        match layer {
+                            Layer::Background => WlrLayer::Background,
+                            Layer::Bottom => WlrLayer::Bottom,
+                            Layer::Top => WlrLayer::Top,
+                            Layer::Overlay => WlrLayer::Overlay,
+                        },
+                        overlap.loc.x,
+                        overlap.loc.y,
+                        overlap.size.w,
+                        overlap.size.h,
+                    );
+                }
+            }
+        }
+
+        self.last_snapshot = new_snapshot;
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct OverlapSnapshot {
+    toplevel_overlaps: HashMap<Weak<ExtForeignToplevelHandleV1>, Rectangle<i32, Logical>>,
+    layer_overlaps: HashMap<String, (bool, Layer, Rectangle<i32, Logical>)>,
+}
+
+impl OverlapSnapshot {
+    pub fn add_toplevel(&mut self, window: &impl Window, overlap: Rectangle<i32, Logical>) {
+        if let Some(handles) = window
+            .user_data()
+            .get::<ToplevelState>()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .foreign_handle()
+            .map(|handle| handle.resources())
+        {
+            for handle in handles.into_iter().map(|h| h.downgrade()) {
+                self.toplevel_overlaps.insert(handle, overlap);
+            }
+        }
+    }
+
+    pub fn add_layer(&mut self, layer_surface: &LayerSurface, overlap: Rectangle<i32, Logical>) {
+        let exclusive = matches!(
+            layer_surface.cached_state().exclusive_zone,
+            ExclusiveZone::Exclusive(_)
+        );
+        let layer = layer_surface.layer();
+        let identifier = layer_surface.user_data().get_or_insert(Identifier::default);
+
+        self.layer_overlaps
+            .insert(identifier.0.clone(), (exclusive, layer, overlap));
+    }
+}
+
+struct Identifier(String);
+
+impl Default for Identifier {
+    fn default() -> Self {
+        Identifier(Alphanumeric.sample_string(&mut rand::thread_rng(), 32))
+    }
+}
+
+impl<D> GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData, D> for OverlapNotifyState
+where
+    D: GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData>
+        + Dispatch<ZcosmicOverlapNotifyV1, ()>
+        + Dispatch<ZcosmicOverlapNotificationV1, ()>
+        + OverlapNotifyHandler
+        + 'static,
+{
+    fn bind(
+        state: &mut D,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: smithay::reexports::wayland_server::New<ZcosmicOverlapNotifyV1>,
+        _global_data: &OverlapNotifyGlobalData,
+        data_init: &mut smithay::reexports::wayland_server::DataInit<'_, D>,
+    ) {
+        let instance = data_init.init(resource, ());
+        state.overlap_notify_state().instances.push(instance);
+    }
+
+    fn can_view(client: Client, global_data: &OverlapNotifyGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<ZcosmicOverlapNotifyV1, (), D> for OverlapNotifyState
+where
+    D: GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData>
+        + Dispatch<ZcosmicOverlapNotifyV1, ()>
+        + Dispatch<ZcosmicOverlapNotificationV1, ()>
+        + OverlapNotifyHandler
+        + 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        _resource: &ZcosmicOverlapNotifyV1,
+        request: <ZcosmicOverlapNotifyV1 as smithay::reexports::wayland_server::Resource>::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut smithay::reexports::wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            zcosmic_overlap_notify_v1::Request::NotifyOnOverlap {
+                overlap_notification,
+                layer_surface,
+            } => {
+                let notification = data_init.init(overlap_notification, ());
+                if let Some(surface) = state.layer_surface_from_resource(layer_surface) {
+                    let mut data = surface
+                        .user_data()
+                        .get_or_insert_threadsafe(LayerOverlapNotificationData::default)
+                        .lock()
+                        .unwrap();
+                    data.add_notification(notification);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn destroyed(
+        state: &mut D,
+        _client: wayland_backend::server::ClientId,
+        resource: &ZcosmicOverlapNotifyV1,
+        _data: &(),
+    ) {
+        let overlap_state = state.overlap_notify_state();
+        overlap_state.instances.retain(|i| i != resource);
+    }
+}
+
+impl<D> Dispatch<ZcosmicOverlapNotificationV1, (), D> for OverlapNotifyState
+where
+    D: GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData>
+        + Dispatch<ZcosmicOverlapNotifyV1, ()>
+        + Dispatch<ZcosmicOverlapNotificationV1, ()>
+        + OverlapNotifyHandler
+        + 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        _resource: &ZcosmicOverlapNotificationV1,
+        request: <ZcosmicOverlapNotificationV1 as Resource>::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        _data_init: &mut smithay::reexports::wayland_server::DataInit<'_, D>,
+    ) {
+        match request {
+            _ => {}
+        }
+    }
+}

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -10,7 +10,12 @@ use smithay::{
         Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
     },
     utils::{user_data::UserDataMap, IsAlive, Logical, Rectangle},
+    wayland::foreign_toplevel_list::{
+        ForeignToplevelHandle, ForeignToplevelListHandler, ForeignToplevelListState,
+    },
 };
+
+use crate::utils::prelude::{Global, OutputExt, RectGlobalExt};
 
 use super::workspace::{WorkspaceHandle, WorkspaceHandler, WorkspaceState};
 
@@ -18,6 +23,7 @@ use cosmic_protocols::toplevel_info::v1::server::{
     zcosmic_toplevel_handle_v1::{self, State as States, ZcosmicToplevelHandleV1},
     zcosmic_toplevel_info_v1::{self, ZcosmicToplevelInfoV1},
 };
+use tracing::error;
 
 pub trait Window: IsAlive + Clone + PartialEq + Send {
     fn title(&self) -> String;
@@ -26,6 +32,8 @@ pub trait Window: IsAlive + Clone + PartialEq + Send {
     fn is_maximized(&self) -> bool;
     fn is_fullscreen(&self) -> bool;
     fn is_minimized(&self) -> bool;
+    fn is_sticky(&self) -> bool;
+    fn global_geometry(&self) -> Option<Rectangle<i32, Global>>;
     fn user_data(&self) -> &UserDataMap;
 }
 
@@ -34,11 +42,14 @@ pub struct ToplevelInfoState<D, W: Window> {
     dh: DisplayHandle,
     pub(super) toplevels: Vec<W>,
     instances: Vec<ZcosmicToplevelInfoV1>,
+    dirty: bool,
+    last_dirty: bool,
+    pub(in crate::wayland) foreign_toplevel_list: ForeignToplevelListState,
     global: GlobalId,
     _dispatch_data: std::marker::PhantomData<D>,
 }
 
-pub trait ToplevelInfoHandler: WorkspaceHandler + Sized {
+pub trait ToplevelInfoHandler: ForeignToplevelListHandler + WorkspaceHandler + Sized {
     type Window: Window;
     fn toplevel_info_state(&self) -> &ToplevelInfoState<Self, Self::Window>;
     fn toplevel_info_state_mut(&mut self) -> &mut ToplevelInfoState<Self, Self::Window>;
@@ -50,6 +61,7 @@ pub struct ToplevelInfoGlobalData {
 
 #[derive(Default)]
 pub(super) struct ToplevelStateInner {
+    foreign_handle: Option<ForeignToplevelHandle>,
     instances: Vec<ZcosmicToplevelHandleV1>,
     outputs: Vec<Output>,
     workspaces: Vec<WorkspaceHandle>,
@@ -57,8 +69,18 @@ pub(super) struct ToplevelStateInner {
 }
 pub(super) type ToplevelState = Mutex<ToplevelStateInner>;
 
+impl ToplevelStateInner {
+    fn from_foreign(foreign_handle: ForeignToplevelHandle) -> Mutex<Self> {
+        Mutex::new(ToplevelStateInner {
+            foreign_handle: Some(foreign_handle),
+            ..Default::default()
+        })
+    }
+}
+
 pub struct ToplevelHandleStateInner<W: Window> {
     outputs: Vec<Output>,
+    geometry: Option<Rectangle<i32, Global>>,
     wl_outputs: HashSet<WlOutput>,
     workspaces: Vec<WorkspaceHandle>,
     title: String,
@@ -72,6 +94,7 @@ impl<W: Window> ToplevelHandleStateInner<W> {
     fn from_window(window: &W) -> ToplevelHandleState<W> {
         ToplevelHandleState::new(ToplevelHandleStateInner {
             outputs: Vec::new(),
+            geometry: None,
             wl_outputs: HashSet::new(),
             workspaces: Vec::new(),
             title: String::new(),
@@ -119,7 +142,7 @@ where
         + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
         + ToplevelInfoHandler<Window = W>
         + 'static,
-    W: Window,
+    W: Window + 'static,
 {
     fn request(
         state: &mut D,
@@ -128,14 +151,47 @@ where
         request: zcosmic_toplevel_info_v1::Request,
         _data: &(),
         _dh: &DisplayHandle,
-        _data_init: &mut DataInit<'_, D>,
+        data_init: &mut DataInit<'_, D>,
     ) {
         match request {
+            zcosmic_toplevel_info_v1::Request::GetCosmicToplevel {
+                cosmic_toplevel,
+                foreign_toplevel,
+            } => {
+                let toplevel_state = state.toplevel_info_state();
+                if let Some(window) = toplevel_state.toplevels.iter().find(|w| {
+                    w.user_data().get::<ToplevelState>().and_then(|inner| {
+                        inner
+                            .lock()
+                            .unwrap()
+                            .foreign_handle
+                            .as_ref()
+                            .map(|handle| handle.identifier())
+                    }) == ForeignToplevelHandle::from_resource(&foreign_toplevel)
+                        .map(|handle| handle.identifier())
+                }) {
+                    let instance = data_init.init(
+                        cosmic_toplevel,
+                        ToplevelHandleStateInner::from_window(window),
+                    );
+                    window
+                        .user_data()
+                        .get::<ToplevelState>()
+                        .unwrap()
+                        .lock()
+                        .unwrap()
+                        .instances
+                        .push(instance);
+                } else {
+                    error!(?foreign_toplevel, "Toplevel for foreign-toplevel-list not registered for cosmic-toplevel-info.");
+                }
+            }
             zcosmic_toplevel_info_v1::Request::Stop => {
                 state
                     .toplevel_info_state_mut()
                     .instances
                     .retain(|i| i != obj);
+                obj.finished();
             }
             _ => {}
         }
@@ -216,37 +272,47 @@ where
     D: GlobalDispatch<ZcosmicToplevelInfoV1, ToplevelInfoGlobalData>
         + Dispatch<ZcosmicToplevelInfoV1, ()>
         + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
+        + ForeignToplevelListHandler
         + ToplevelInfoHandler<Window = W>
         + 'static,
     W: Window + 'static,
 {
     pub fn new<F>(dh: &DisplayHandle, client_filter: F) -> ToplevelInfoState<D, W>
     where
-        F: for<'a> Fn(&'a Client) -> bool + Send + Sync + 'static,
+        F: for<'a> Fn(&'a Client) -> bool + Send + Sync + Clone + 'static,
     {
         let global = dh.create_global::<D, ZcosmicToplevelInfoV1, _>(
-            1,
+            2,
             ToplevelInfoGlobalData {
-                filter: Box::new(client_filter),
+                filter: Box::new(client_filter.clone()),
             },
         );
+        let foreign_toplevel_list =
+            ForeignToplevelListState::new_with_filter::<D>(dh, client_filter);
         ToplevelInfoState {
             dh: dh.clone(),
             toplevels: Vec::new(),
             instances: Vec::new(),
+            dirty: false,
+            last_dirty: false,
+            foreign_toplevel_list,
             global,
             _dispatch_data: std::marker::PhantomData,
         }
     }
 
     pub fn new_toplevel(&mut self, toplevel: &W, workspace_state: &WorkspaceState<D>) {
+        let toplevel_handle = self
+            .foreign_toplevel_list
+            .new_toplevel::<D>(toplevel.title(), toplevel.app_id());
         toplevel
             .user_data()
-            .insert_if_missing(ToplevelState::default);
+            .insert_if_missing(move || ToplevelStateInner::from_foreign(toplevel_handle));
         for instance in &self.instances {
             send_toplevel_to_client::<D, W>(&self.dh, workspace_state, instance, toplevel);
         }
         self.toplevels.push(toplevel.clone());
+        self.dirty = true;
     }
 
     pub fn remove_toplevel(&mut self, toplevel: &W) {
@@ -254,20 +320,27 @@ where
             let mut state_inner = state.lock().unwrap();
             for handle in &state_inner.instances {
                 // don't send events to stopped instances
-                if self
-                    .instances
-                    .iter()
-                    .any(|i| i.id().same_client_as(&handle.id()))
+                if handle.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE
+                    && self
+                        .instances
+                        .iter()
+                        .any(|i| i.id().same_client_as(&handle.id()))
                 {
                     handle.closed();
                 }
             }
+            if let Some(handle) = state_inner.foreign_handle.take() {
+                self.foreign_toplevel_list.remove_toplevel(&handle);
+            }
             *state_inner = Default::default();
+            self.dirty = true;
         }
         self.toplevels.retain(|w| w != toplevel);
     }
 
     pub fn refresh(&mut self, workspace_state: &WorkspaceState<D>) {
+        let mut dirty = std::mem::replace(&mut self.dirty, false);
+
         self.toplevels.retain(|window| {
             let mut state = window
                 .user_data()
@@ -281,23 +354,41 @@ where
             if window.alive() {
                 std::mem::drop(state);
                 for instance in &self.instances {
-                    send_toplevel_to_client::<D, W>(&self.dh, workspace_state, instance, window);
+                    let changed = send_toplevel_to_client::<D, W>(
+                        &self.dh,
+                        workspace_state,
+                        instance,
+                        window,
+                    );
+                    dirty = dirty || changed;
                 }
                 true
             } else {
                 for handle in &state.instances {
                     // don't send events to stopped instances
-                    if self
-                        .instances
-                        .iter()
-                        .any(|i| i.id().same_client_as(&handle.id()))
+                    if handle.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE
+                        && self
+                            .instances
+                            .iter()
+                            .any(|i| i.id().same_client_as(&handle.id()))
                     {
                         handle.closed();
                     }
                 }
+                dirty = true;
                 false
             }
         });
+
+        if !dirty && self.last_dirty {
+            for instance in &self.instances {
+                if instance.version() >= zcosmic_toplevel_info_v1::EVT_DONE_SINCE {
+                    instance.done();
+                }
+            }
+        }
+
+        self.last_dirty = dirty;
     }
 
     pub fn global_id(&self) -> GlobalId {
@@ -310,7 +401,8 @@ fn send_toplevel_to_client<D, W: 'static>(
     workspace_state: &WorkspaceState<D>,
     info: &ZcosmicToplevelInfoV1,
     window: &W,
-) where
+) -> bool
+where
     D: GlobalDispatch<ZcosmicToplevelInfoV1, ToplevelInfoGlobalData>
         + Dispatch<ZcosmicToplevelInfoV1, ()>
         + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
@@ -331,22 +423,26 @@ fn send_toplevel_to_client<D, W: 'static>(
     {
         Some(i) => i,
         None => {
-            if let Ok(client) = dh.get_client(info.id()) {
-                if let Ok(toplevel_handle) = client
-                    .create_resource::<ZcosmicToplevelHandleV1, _, D>(
-                        dh,
-                        info.version(),
-                        ToplevelHandleStateInner::from_window(window),
-                    )
-                {
-                    info.toplevel(&toplevel_handle);
-                    state.instances.push(toplevel_handle);
-                    state.instances.last().unwrap()
+            if info.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE {
+                if let Ok(client) = dh.get_client(info.id()) {
+                    if let Ok(toplevel_handle) = client
+                        .create_resource::<ZcosmicToplevelHandleV1, _, D>(
+                            dh,
+                            info.version(),
+                            ToplevelHandleStateInner::from_window(window),
+                        )
+                    {
+                        info.toplevel(&toplevel_handle);
+                        state.instances.push(toplevel_handle);
+                        state.instances.last().unwrap()
+                    } else {
+                        return false;
+                    }
                 } else {
-                    return;
+                    return false;
                 }
             } else {
-                return;
+                return false;
             }
         }
     };
@@ -356,15 +452,27 @@ fn send_toplevel_to_client<D, W: 'static>(
         .unwrap()
         .lock()
         .unwrap();
+    let foreign_toplevel_handle = state.foreign_handle.as_ref();
     let mut changed = false;
+
     if handle_state.title != window.title() {
         handle_state.title = window.title();
-        instance.title(handle_state.title.clone());
+        if instance.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE {
+            instance.title(handle_state.title.clone());
+        }
+        if let Some(handle) = foreign_toplevel_handle {
+            handle.send_title(&handle_state.title);
+        }
         changed = true;
     }
     if handle_state.app_id != window.app_id() {
         handle_state.app_id = window.app_id();
-        instance.app_id(handle_state.app_id.clone());
+        if instance.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE {
+            instance.app_id(handle_state.app_id.clone());
+        }
+        if let Some(handle) = foreign_toplevel_handle {
+            handle.send_app_id(&handle_state.app_id);
+        }
         changed = true;
     }
 
@@ -386,6 +494,11 @@ fn send_toplevel_to_client<D, W: 'static>(
         if window.is_minimized() {
             states.push(States::Minimized);
         }
+        if instance.version() >= zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE
+            && window.is_sticky()
+        {
+            states.push(States::Sticky);
+        }
         handle_state.states = states.clone();
 
         let states: Vec<u8> = {
@@ -400,15 +513,35 @@ fn send_toplevel_to_client<D, W: 'static>(
         changed = true;
     }
 
+    let geometry = window.global_geometry();
+    let mut geometry_changed = false;
+    if handle_state.geometry != geometry {
+        handle_state.geometry = geometry;
+        changed = true;
+        geometry_changed = true;
+    }
+
     if let Ok(client) = dh.get_client(instance.id()) {
         handle_state.outputs = state.outputs.clone();
 
         let handle_state = &mut *handle_state;
         for output in &handle_state.outputs {
+            let geometry = handle_state
+                .geometry
+                .filter(|_| instance.version() >= zcosmic_toplevel_handle_v1::EVT_GEOMETRY_SINCE)
+                .filter(|geo| output.geometry().intersection(*geo).is_some())
+                .map(|geo| geo.to_local(&output));
             for wl_output in output.client_outputs(&client) {
                 if handle_state.wl_outputs.insert(wl_output.clone()) {
                     instance.output_enter(&wl_output);
+                    if let Some(geo) = geometry {
+                        instance.geometry(&wl_output, geo.loc.x, geo.loc.y, geo.size.w, geo.size.h);
+                    }
                     changed = true;
+                } else if geometry_changed {
+                    if let Some(geo) = geometry {
+                        instance.geometry(&wl_output, geo.loc.x, geo.loc.y, geo.size.w, geo.size.h);
+                    }
                 }
             }
         }
@@ -449,8 +582,15 @@ fn send_toplevel_to_client<D, W: 'static>(
     handle_state.workspaces = state.workspaces.clone();
 
     if changed {
-        instance.done();
+        if instance.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE {
+            instance.done();
+        }
+        if let Some(handle) = foreign_toplevel_handle {
+            handle.send_done();
+        }
     }
+
+    changed
 }
 
 pub fn window_from_handle<W: Window + 'static>(handle: ZcosmicToplevelHandleV1) -> Option<W> {

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -76,6 +76,10 @@ impl ToplevelStateInner {
             ..Default::default()
         })
     }
+
+    pub fn foreign_handle(&self) -> Option<&ForeignToplevelHandle> {
+        self.foreign_handle.as_ref()
+    }
 }
 
 pub struct ToplevelHandleStateInner<W: Window> {
@@ -393,6 +397,10 @@ where
 
     pub fn global_id(&self) -> GlobalId {
         self.global.clone()
+    }
+
+    pub fn registered_toplevels(&self) -> impl Iterator<Item = &W> {
+        self.toplevels.iter()
     }
 }
 

--- a/src/wayland/protocols/toplevel_management.rs
+++ b/src/wayland/protocols/toplevel_management.rs
@@ -61,6 +61,9 @@ where
     fn unmaximize(&mut self, dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {}
     fn minimize(&mut self, dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {}
     fn unminimize(&mut self, dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {}
+    fn set_sticky(&mut self, dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {}
+    fn unset_sticky(&mut self, dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {
+    }
     fn move_to_workspace(
         &mut self,
         dh: &DisplayHandle,
@@ -113,7 +116,7 @@ impl ToplevelManagementState {
         F: for<'a> Fn(&'a Client) -> bool + Send + Sync + 'static,
     {
         let global = dh.create_global::<D, ZcosmicToplevelManagerV1, _>(
-            2,
+            3,
             ToplevelManagerGlobalData {
                 filter: Box::new(client_filter),
             },
@@ -215,6 +218,14 @@ where
             zcosmic_toplevel_manager_v1::Request::UnsetMinimized { toplevel } => {
                 let window = window_from_handle(toplevel).unwrap();
                 state.unminimize(dh, &window);
+            }
+            zcosmic_toplevel_manager_v1::Request::SetSticky { toplevel } => {
+                let window = window_from_handle(toplevel).unwrap();
+                state.set_sticky(dh, &window);
+            }
+            zcosmic_toplevel_manager_v1::Request::UnsetSticky { toplevel } => {
+                let window = window_from_handle(toplevel).unwrap();
+                state.unset_sticky(dh, &window);
             }
             zcosmic_toplevel_manager_v1::Request::SetRectangle {
                 toplevel,

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -384,7 +384,6 @@ impl XwmHandler for State {
             let res = shell.map_window(
                 &window,
                 &mut self.common.toplevel_info_state,
-                &mut self.common.foreign_toplevel_list,
                 &mut self.common.workspace_state,
                 &self.common.event_loop_handle,
             );
@@ -414,12 +413,7 @@ impl XwmHandler for State {
             shell.override_redirect_windows.retain(|or| or != &window);
         } else {
             let seat = shell.seats.last_active().clone();
-            shell.unmap_surface(
-                &window,
-                &seat,
-                &mut self.common.toplevel_info_state,
-                &mut self.common.foreign_toplevel_list,
-            );
+            shell.unmap_surface(&window, &seat, &mut self.common.toplevel_info_state);
         }
 
         let outputs = if let Some(wl_surface) = window.wl_surface() {


### PR DESCRIPTION
Swallows up the foreign-toplevel-list protocol handling as well, to be able to guarantee event-order between the cosmic-toplevel-info protocol and foreign-toplevel-list (e.g. it's `done`-event).

Untested, but this should basically work..