### PR TITLE
Minimize sticky window as temporary scratchpad

### DIFF
--- a/data/keybindings.ron
+++ b/data/keybindings.ron
@@ -14,6 +14,7 @@
     (modifiers: [Super], key: "8"): Workspace(8),
     (modifiers: [Super], key: "9"): Workspace(9),
     (modifiers: [Super], key: "0"): LastWorkspace,
+    (modifiers: [Super], key: "p"): ToggleStickyVisibility,
     (modifiers: [Super, Shift], key: "1"): MoveToWorkspace(1),
     (modifiers: [Super, Shift], key: "2"): MoveToWorkspace(2),
     (modifiers: [Super, Shift], key: "3"): MoveToWorkspace(3),

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -182,6 +182,18 @@ impl State {
                 );
             }
 
+            Action::ToggleStickyVisibility => {
+                let mut shell = self.common.shell.write().unwrap();
+                let sticky_visible = shell.workspaces.sticky_visible;
+                if sticky_visible {
+                    shell.workspaces.sticky_visible = false;
+                    shell.minimize_sticky();
+                } else {
+                    shell.workspaces.sticky_visible = true;
+                    shell.unminimize_sticky();
+                }
+            }
+
             Action::NextWorkspace => {
                 let next = to_next_workspace(
                     &mut *self.common.shell.write().unwrap(),


### PR DESCRIPTION
Implements #879 

Super + p to toggle Sticky window Visibility for use as scratchpad. 

The current implementation needs to be modified. Open for suggestion.