### PR TITLE
Fix context menu styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#af68a3f660402b850dfd00041372d964d3b098d7"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "atomicwrites",
  "calloop 0.14.1",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#af68a3f660402b850dfd00041372d964d3b098d7"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.12.1"
-source = "git+https://github.com/pop-os/cosmic-text.git#e8f567cf5b456dfab749a575c257acaa36f622d9"
+source = "git+https://github.com/pop-os/cosmic-text.git#4fe90bb6126c22f589b46768d7754d65ae300c5e"
 dependencies = [
  "bitflags 2.6.0",
  "fontdb",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#af68a3f660402b850dfd00041372d964d3b098d7"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1062,7 +1062,7 @@ version = "0.19.0"
 source = "git+https://github.com/gfx-rs/wgpu?rev=20fda69#20fda698341efbdc870b8027d6d49f5bf3f36109"
 dependencies = [
  "bitflags 2.6.0",
- "libloading 0.7.4",
+ "libloading 0.8.5",
  "winapi",
 ]
 
@@ -1197,7 +1197,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.5",
 ]
 
 [[package]]
@@ -2140,7 +2140,7 @@ dependencies = [
  "bitflags 2.6.0",
  "com",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.5",
  "thiserror",
  "widestring",
  "winapi",
@@ -2290,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "futures",
  "iced_core",
@@ -2338,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2362,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2386,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2396,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2442,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic/#a962865230f3b9ecba40c0c09e9c279e832c9f10"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2759,7 +2759,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#af68a3f660402b850dfd00041372d964d3b098d7"
+source = "git+https://github.com/pop-os/libcosmic/#5306649be1cfb6c384da11e2ab25cafc4be79b14"
 dependencies = [
  "apply",
  "chrono",
@@ -2786,6 +2786,7 @@ dependencies = [
  "tracing",
  "unicode-segmentation",
  "url",
+ "ustr",
 ]
 
 [[package]]
@@ -5398,6 +5399,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ustr"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e904a2279a4a36d2356425bb20be271029cc650c335bc82af8bfae30085a3d0"
+dependencies = [
+ "ahash",
+ "byteorder",
+ "lazy_static",
+ "parking_lot 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "usvg"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5772,7 +5786,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5799,7 +5813,7 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "profiling",
  "raw-window-handle",
  "rustc-hash",
@@ -5833,13 +5847,13 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.5",
  "log",
  "metal",
  "naga",
  "objc",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "profiling",
  "range-alloc",
  "raw-window-handle",

--- a/src/shell/element/resize_indicator.rs
+++ b/src/shell/element/resize_indicator.rs
@@ -86,10 +86,10 @@ impl Program for ResizeIndicatorInternal {
                 } else {
                     "go-down-symbolic"
                 })
-                .size(32)
+                .size(20)
                 .prefer_svg(true)
                 .apply(container)
-                .padding(2)
+                .padding(8)
                 .style(icon_container_style())
                 .width(Length::Shrink)
                 .apply(container)
@@ -106,10 +106,10 @@ impl Program for ResizeIndicatorInternal {
                     } else {
                         "go-next-symbolic"
                     })
-                    .size(32)
+                    .size(20)
                     .prefer_svg(true)
                     .apply(container)
-                    .padding(4)
+                    .padding(8)
                     .style(icon_container_style())
                     .width(Length::Shrink)
                     .apply(container)
@@ -120,23 +120,11 @@ impl Program for ResizeIndicatorInternal {
                     horizontal_space(36).into()
                 },
                 row(vec![
-                    text(&self.shortcut1)
-                        .font(cosmic::font::FONT_SEMIBOLD)
-                        .size(14)
-                        .into(),
-                    text(fl!("grow-window"))
-                        .font(cosmic::font::FONT)
-                        .size(14)
-                        .into(),
+                    text::heading(&self.shortcut1).into(),
+                    text::body(fl!("grow-window")).into(),
                     horizontal_space(40).into(),
-                    text(&self.shortcut2)
-                        .font(cosmic::font::FONT_SEMIBOLD)
-                        .size(14)
-                        .into(),
-                    text(fl!("shrink-window"))
-                        .font(cosmic::font::FONT)
-                        .size(14)
-                        .into(),
+                    text::heading(&self.shortcut2).into(),
+                    text::body(fl!("shrink-window")).into(),
                 ])
                 .apply(container)
                 .center_x()
@@ -158,10 +146,10 @@ impl Program for ResizeIndicatorInternal {
                     } else {
                         "go-previous-symbolic"
                     })
-                    .size(32)
+                    .size(20)
                     .prefer_svg(true)
                     .apply(container)
-                    .padding(4)
+                    .padding(8)
                     .style(icon_container_style())
                     .height(Length::Shrink)
                     .apply(container)
@@ -181,10 +169,10 @@ impl Program for ResizeIndicatorInternal {
                 } else {
                     "go-up-symbolic"
                 })
-                .size(32)
+                .size(20)
                 .prefer_svg(true)
                 .apply(container)
-                .padding(4)
+                .padding(8)
                 .style(icon_container_style())
                 .width(Length::Shrink)
                 .apply(container)

--- a/src/shell/element/stack/tab.rs
+++ b/src/shell/element/stack/tab.rs
@@ -158,7 +158,7 @@ impl<Message: TabMessage + 'static> Tab<Message> {
             id,
             app_icon: from_name(app_id.into()).size(16).icon(),
             title: title.into(),
-            font: cosmic::font::FONT,
+            font: cosmic::font::default(),
             close_message: None,
             press_message: None,
             right_click_message: None,

--- a/src/shell/element/stack/tab_text.rs
+++ b/src/shell/element/stack/tab_text.rs
@@ -39,7 +39,7 @@ impl TabText {
         TabText {
             width: Length::Shrink,
             height: Length::Shrink,
-            font: cosmic::font::DEFAULT,
+            font: cosmic::font::default(),
             font_size: 14.0,
             selected,
             text,

--- a/src/shell/element/stack/tabs.rs
+++ b/src/shell/element/stack/tabs.rs
@@ -134,7 +134,7 @@ where
                     } else {
                         TabBackgroundTheme::ActiveDeactivated
                     })
-                    .font(cosmic::font::FONT_SEMIBOLD)
+                    .font(cosmic::font::semibold())
                     .active()
             } else if i.checked_sub(1) == Some(active) {
                 tab.rule_style(rule).non_active()

--- a/src/shell/element/stack_hover.rs
+++ b/src/shell/element/stack_hover.rs
@@ -39,10 +39,7 @@ impl Program for StackHoverInternal {
                 .icon()
                 .into(),
             horizontal_space(16).into(),
-            text(fl!("stack-windows"))
-                .font(cosmic::font::FONT)
-                .size(24)
-                .into(),
+            text::title3(fl!("stack-windows")).into(),
         ])
         .align_items(Alignment::Center)
         .apply(container)

--- a/src/shell/element/swap_indicator.rs
+++ b/src/shell/element/swap_indicator.rs
@@ -35,10 +35,7 @@ impl Program for SwapIndicatorInternal {
                 .icon()
                 .into(),
             horizontal_space(16).into(),
-            text(fl!("swap-windows"))
-                .font(cosmic::font::FONT)
-                .size(24)
-                .into(),
+            text::title3(fl!("swap-windows")).into(),
         ])
         .align_items(Alignment::Center)
         .apply(container)

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -11,10 +11,7 @@ use crate::{
     },
 };
 use calloop::LoopHandle;
-use cosmic::{
-    config::Density,
-    iced::{Color, Command},
-};
+use cosmic::iced::{Color, Command};
 use smithay::{
     backend::{
         input::KeyState,
@@ -503,7 +500,6 @@ impl Program for CosmicWindowInternal {
             .on_drag(Message::DragStart)
             .on_close(Message::Close)
             .focused(self.window.is_activated(false))
-            .density(Density::Compact)
             .on_double_click(Message::Maximize)
             .on_right_click(Message::Menu);
 

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -496,6 +496,7 @@ impl Program for CosmicWindowInternal {
 
     fn view(&self) -> cosmic::Element<'_, Self::Message> {
         let mut header = cosmic::widget::header_bar()
+            .start(cosmic::widget::horizontal_space(32))
             .title(self.last_title.lock().unwrap().clone())
             .on_drag(Message::DragStart)
             .on_close(Message::Close)
@@ -504,10 +505,14 @@ impl Program for CosmicWindowInternal {
             .on_right_click(Message::Menu);
 
         if cosmic::config::show_minimize() {
-            header = header.on_minimize(Message::Minimize);
+            header = header
+                .on_minimize(Message::Minimize)
+                .start(cosmic::widget::horizontal_space(40)); // 32 + 8 spacing
         }
         if cosmic::config::show_maximize() {
-            header = header.on_maximize(Message::Maximize);
+            header = header
+                .on_maximize(Message::Maximize)
+                .start(cosmic::widget::horizontal_space(40)); // 32 + 8 spacing
         }
 
         header.into()

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -5,11 +5,11 @@ use std::sync::{
 
 use calloop::LoopHandle;
 use cosmic::{
-    iced::Background,
-    iced_core::{alignment::Horizontal, Border, Length, Pixels, Rectangle as IcedRectangle},
-    iced_widget::{self, horizontal_rule, text::Appearance as TextAppearance, Column, Row},
+    iced::{Alignment, Background},
+    iced_core::{alignment::Horizontal, Border, Length, Rectangle as IcedRectangle},
+    iced_widget::{self, text::Appearance as TextAppearance, Column, Row},
     theme,
-    widget::{button, horizontal_space, icon::from_name, text},
+    widget::{button, divider, horizontal_space, icon::from_name, text},
     Apply as _, Command,
 };
 use smithay::{
@@ -348,13 +348,10 @@ impl Program for ContextMenu {
 
         Column::with_children(self.items.iter().enumerate().map(|(idx, item)| {
             match item {
-                Item::Separator => horizontal_rule(1)
-                    .style(theme::Rule::LightDivider)
-                    .width(mode)
-                    .into(),
+                Item::Separator => divider::horizontal::light().into(),
                 Item::Submenu { title, .. } => Row::with_children(vec![
                     horizontal_space(16).into(),
-                    text(title).width(mode).into(),
+                    text::body(title).width(mode).into(),
                     from_name("go-next-symbolic")
                         .size(16)
                         .prefer_svg(true)
@@ -363,7 +360,8 @@ impl Program for ContextMenu {
                 ])
                 .spacing(8)
                 .width(width)
-                .padding([8, 24])
+                .padding([8, 16])
+                .align_items(Alignment::Center)
                 .apply(|row| item::SubmenuItem::new(row, idx))
                 .style(theme::Button::MenuItem)
                 .into(),
@@ -387,7 +385,7 @@ impl Program for ContextMenu {
                         } else {
                             horizontal_space(16).into()
                         },
-                        text(title)
+                        text::body(title)
                             .width(mode)
                             .style(if *disabled {
                                 theme::Text::Custom(|theme| {
@@ -401,12 +399,11 @@ impl Program for ContextMenu {
                                 theme::Text::Default
                             })
                             .into(),
+                        horizontal_space(16).into(),
                     ];
                     if let Some(shortcut) = shortcut.as_ref() {
                         components.push(
-                            text(shortcut)
-                                .line_height(Pixels(20.))
-                                .size(14)
+                            text::body(shortcut)
                                 .horizontal_alignment(Horizontal::Right)
                                 .width(Length::Shrink)
                                 .style(theme::Text::Custom(|theme| {
@@ -419,14 +416,14 @@ impl Program for ContextMenu {
                                 .into(),
                         );
                     }
-                    components.push(horizontal_space(16).into());
 
                     Row::with_children(components)
                         .spacing(8)
                         .width(mode)
+                        .align_items(Alignment::Center)
                         .apply(button::custom)
                         .width(width)
-                        .padding([8, 24])
+                        .padding([8, 16])
                         .on_press_maybe((!disabled).then_some(Message::ItemPressed(idx)))
                         .style(theme::Button::MenuItem)
                         .into()

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3707,7 +3707,7 @@ impl Shell {
             cosmic::icon_theme::set_default(toolkit.icon_theme.clone());
         }
 
-        let mut container = cosmic::config::COSMIC_TK.lock().unwrap();
+        let mut container = cosmic::config::COSMIC_TK.write().unwrap();
         if &*container != &toolkit {
             *container = toolkit;
             drop(container);

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -180,7 +180,7 @@ impl<P: Program + Send + Clone + 'static> Clone for IcedElementInternal<P> {
         }
         let mut renderer = cosmic::Renderer::TinySkia(IcedGraphicsRenderer::new(
             Backend::new(),
-            cosmic::font::DEFAULT,
+            cosmic::font::default(),
             Pixels(16.0),
         ));
         let mut debug = Debug::new();
@@ -246,7 +246,7 @@ impl<P: Program + Send + 'static> IcedElement<P> {
         let size = size.into();
         let mut renderer = cosmic::Renderer::TinySkia(IcedGraphicsRenderer::new(
             Backend::new(),
-            cosmic::font::DEFAULT,
+            cosmic::font::default(),
             Pixels(16.0),
         ));
         let mut debug = Debug::new();


### PR DESCRIPTION
This makes the menu match other context menus in COSMIC, and ensures some spacing between the shortcut and title. Tried to make the menu change with Density (hence the libcosmic update), but it didn't seem to change anything, regardless of the way of incorporating the spacing variables.
![screenshot-2024-09-28-11-54-22](https://github.com/user-attachments/assets/9bf92ba9-9d66-4573-9fd7-50e34022bcca)
(Edit: Not sure why the text color of the title is the same as the shortcut. I've tried switching the title back to how it was, but it didn't change. But this is also the case in menus in apps)

Also tweaked the resize indicators for better styling. The right indicator still gets cut off slightly at smaller window widths, but not sure why that happens. 

The centering of the SSD header title has a minor issue in some apps at minimum widths (only saw it on GitHub desktop so far; other apps have higher minimum widths), but not sure how that can be avoided. Changing the `header_bar` in libcosmic can improve this, but it also messes up COSMIC app headers.
![screenshot-2024-10-08-10-37-47](https://github.com/user-attachments/assets/b778a25d-5723-4303-a607-a21e3aa38e2b)