### PR TITLE
Set default output transform based on DRM `panel orientation`

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -645,10 +645,10 @@ fn populate_modes(
         output.add_mode(mode);
     }
     output.set_preferred(output_mode);
+    let transform = drm_helpers::panel_orientation(drm, conn).unwrap_or(Transform::Normal);
     output.change_current_state(
         Some(output_mode),
-        // TODO: Readout property for monitor rotation
-        Some(Transform::Normal),
+        Some(transform),
         Some(Scale::Fractional(scale)),
         Some(Point::from((position.0 as i32, position.1 as i32))),
     );
@@ -663,6 +663,7 @@ fn populate_modes(
         position,
         max_bpc,
         scale,
+        transform,
         ..std::mem::take(&mut *output_config)
     };
 

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -237,7 +237,7 @@ impl State {
                 ) {
                     Ok((output, should_expose)) => {
                         if should_expose {
-                            w += output.config().mode_size().w as u32;
+                            w += output.config().transformed_size().w as u32;
                             wl_outputs.push(output.clone());
                         }
                         device.outputs.insert(conn, output);
@@ -335,7 +335,7 @@ impl State {
                     ) {
                         Ok((output, should_expose)) => {
                             if should_expose {
-                                w += output.config().mode_size().w as u32;
+                                w += output.config().transformed_size().w as u32;
                                 outputs_added.push(output.clone());
                             }
 

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -686,7 +686,7 @@ impl KmsState {
                         startup_done.clone(),
                     )?;
                     if output.mirroring().is_none() {
-                        w += output.config().mode_size().w as u32;
+                        w += output.config().transformed_size().w as u32;
                     }
                     all_outputs.push(output);
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -139,6 +139,10 @@ impl OutputConfig {
         self.mode.1.unwrap_or(60_000)
     }
 
+    pub fn transformed_size(&self) -> Size<i32, Physical> {
+        self.transform.transform_size(self.mode_size())
+    }
+
     pub fn output_mode(&self) -> Mode {
         Mode {
             size: self.mode_size(),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -46,7 +46,6 @@ use smithay::{
     utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
     wayland::{
         compositor::{with_states, SurfaceAttributes},
-        foreign_toplevel_list::ForeignToplevelListState,
         seat::WaylandFocus,
         session_lock::LockSurface,
         shell::wlr_layer::{KeyboardInteractivity, Layer, LayerSurfaceCachedState},

--- a/src/state.rs
+++ b/src/state.rs
@@ -51,7 +51,7 @@ use smithay::{
         PopupManager,
     },
     input::{pointer::CursorImageStatus, SeatState},
-    output::{Mode as OutputMode, Output, Scale},
+    output::{Output, Scale},
     reexports::{
         calloop::{LoopHandle, LoopSignal},
         wayland_protocols::xdg::shell::server::xdg_toplevel::WmCapabilities,
@@ -306,11 +306,7 @@ impl BackendData {
                 .unwrap()
                 .borrow();
 
-            let mode = Some(OutputMode {
-                size: final_config.mode_size(),
-                refresh: final_config.mode_refresh() as i32,
-            })
-            .filter(|m| match output.current_mode() {
+            let mode = Some(final_config.output_mode()).filter(|m| match output.current_mode() {
                 None => true,
                 Some(c_m) => m.size != c_m.size || m.refresh != c_m.refresh,
             });


### PR DESCRIPTION
This works, but with multiple outputs results in overlapping outputs in the display configuration (which has weird effects). So I guess that will also need a change go consider the orientation.