### PR TITLE
use `Grabbing` cursor instead of `Grab` cursor

### DIFF
--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -709,7 +709,7 @@ impl MoveGrab {
 
         {
             let cursor_state = seat.user_data().get::<CursorState>().unwrap();
-            cursor_state.lock().unwrap().set_shape(CursorIcon::Grab);
+            cursor_state.lock().unwrap().set_shape(CursorIcon::Grabbing);
         }
 
         MoveGrab {


### PR DESCRIPTION
when i implemented the cursor-shape-v1 protocol in #844 i didn't notice that the previous `CursorShape::Grab` actually mapped to `CursorIcon::Grabbing` instead of `CursorIcon::Grab`. this fixes that "regression".