### PR TITLE
Refactor and unify {render, input}-order

### DIFF
--- a/src/backend/render/element.rs
+++ b/src/backend/render/element.rs
@@ -24,7 +24,7 @@ where
     <R as Renderer>::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
-    Workspace(RelocateRenderElement<WorkspaceRenderElement<R>>),
+    Workspace(RelocateRenderElement<CropRenderElement<WorkspaceRenderElement<R>>>),
     Cursor(RelocateRenderElement<CursorRenderElement<R>>),
     Dnd(WaylandSurfaceRenderElement<R>),
     MoveGrab(CosmicMappedRenderElement<R>),
@@ -266,13 +266,13 @@ where
     }
 }
 
-impl<R> From<WorkspaceRenderElement<R>> for CosmicElement<R>
+impl<R> From<CropRenderElement<WorkspaceRenderElement<R>>> for CosmicElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
     <R as Renderer>::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
-    fn from(elem: WorkspaceRenderElement<R>) -> Self {
+    fn from(elem: CropRenderElement<WorkspaceRenderElement<R>>) -> Self {
         Self::Workspace(RelocateRenderElement::from_element(
             elem,
             (0, 0),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
+    backend::render::ElementFilter,
     config::{
         key_bindings::{
             cosmic_keystate_from_smithay, cosmic_modifiers_eq_smithay,
@@ -10,7 +11,11 @@ use crate::{
     },
     input::gestures::{GestureState, SwipeAction},
     shell::{
-        focus::target::{KeyboardFocusTarget, PointerFocusTarget},
+        focus::{
+            render_input_order,
+            target::{KeyboardFocusTarget, PointerFocusTarget},
+            Stage,
+        },
         grabs::{ReleaseMode, ResizeEdge},
         layout::{
             floating::ResizeGrabMarker,
@@ -39,10 +44,7 @@ use smithay::{
         TabletToolButtonEvent, TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent,
         TabletToolTipState, TouchEvent,
     },
-    desktop::{
-        layer_map_for_output, space::SpaceElement, utils::under_from_surface_tree,
-        WindowSurfaceType,
-    },
+    desktop::{utils::under_from_surface_tree, WindowSurfaceType},
     input::{
         keyboard::{FilterResult, KeysymHandle, ModifiersState},
         pointer::{
@@ -58,15 +60,13 @@ use smithay::{
     reexports::{
         input::Device as InputDevice, wayland_server::protocol::wl_shm::Format as ShmFormat,
     },
-    utils::{Point, Serial, SERIAL_COUNTER},
+    utils::{Point, Rectangle, Serial, SERIAL_COUNTER},
     wayland::{
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
         pointer_constraints::{with_pointer_constraint, PointerConstraint},
         seat::WaylandFocus,
-        shell::wlr_layer::Layer as WlrLayer,
         tablet_manager::{TabletDescriptor, TabletSeatTrait},
     },
-    xwayland::X11Surface,
 };
 use tracing::{error, trace};
 use xkbcommon::xkb::{Keycode, Keysym};
@@ -76,6 +76,7 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     collections::HashSet,
+    ops::ControlFlow,
     time::{Duration, Instant},
 };
 
@@ -329,9 +330,8 @@ impl State {
                     } else if self.common.config.cosmic_conf.focus_follows_cursor {
                         let shell = self.common.shell.read().unwrap();
                         let old_keyboard_target =
-                            shell.keyboard_target_from_position(original_position, &current_output);
-                        let new_keyboard_target =
-                            shell.keyboard_target_from_position(position, &output);
+                            State::element_under(original_position, &current_output, &*shell);
+                        let new_keyboard_target = State::element_under(position, &output, &*shell);
 
                         if old_keyboard_target != new_keyboard_target
                             && new_keyboard_target.is_some()
@@ -497,7 +497,8 @@ impl State {
                         });
                     }
 
-                    let shell = self.common.shell.read().unwrap();
+                    let mut shell = self.common.shell.write().unwrap();
+                    shell.update_pointer_position(position.to_local(&output), &output);
 
                     if output != current_output {
                         for session in cursor_sessions_for_output(&*shell, &current_output) {
@@ -638,15 +639,15 @@ impl State {
 
                         let global_position =
                             seat.get_pointer().unwrap().current_location().as_global();
-                        let shell = self.common.shell.write().unwrap();
-                        let under = shell.keyboard_target_from_position(global_position, &output);
-                        // Don't check override redirect windows, because we don't set keyboard focus to them explicitly.
-                        // These cases are handled by the XwaylandKeyboardGrab.
-                        if let Some(target) = shell.element_under(global_position, &output) {
-                            if seat.get_keyboard().unwrap().modifier_state().logo
-                                && !shortcuts_inhibited
-                            {
-                                if let Some(surface) = target.toplevel().map(Cow::into_owned) {
+                        let under = {
+                            let shell = self.common.shell.read().unwrap();
+                            State::element_under(global_position, &output, &shell)
+                        };
+                        if let Some(target) = under {
+                            if let Some(surface) = target.toplevel().map(Cow::into_owned) {
+                                if seat.get_keyboard().unwrap().modifier_state().logo
+                                    && !shortcuts_inhibited
+                                {
                                     let seat_clone = seat.clone();
                                     let mouse_button = PointerButtonEvent::button(&event);
 
@@ -754,10 +755,9 @@ impl State {
                                     }
                                 }
                             }
-                        }
 
-                        std::mem::drop(shell);
-                        Shell::set_focus(self, under.as_ref(), &seat, Some(serial), false);
+                            Shell::set_focus(self, Some(&target), &seat, Some(serial), false);
+                        }
                     }
                 } else {
                     let mut shell = self.common.shell.write().unwrap();
@@ -1814,142 +1814,263 @@ impl State {
         }
     }
 
-    // TODO: Try to get rid of the *mutable* Shell references (needed for hovered_stack in floating_layout)
+    pub fn element_under(
+        global_pos: Point<f64, Global>,
+        output: &Output,
+        shell: &Shell,
+    ) -> Option<KeyboardFocusTarget> {
+        let (previous_workspace, workspace) = shell.workspaces.active(output);
+        let (previous_idx, idx) = shell.workspaces.active_num(output);
+        let previous_workspace = previous_workspace
+            .zip(previous_idx)
+            .map(|((w, start), idx)| (w.handle, idx, start));
+        let workspace = (workspace.handle, idx);
+        let element_filter = if workspace_overview_is_open(output) {
+            ElementFilter::LayerShellOnly
+        } else {
+            ElementFilter::All
+        };
+
+        render_input_order(
+            shell,
+            output,
+            previous_workspace,
+            workspace,
+            element_filter,
+            |stage| {
+                match stage {
+                    Stage::SessionLock(lock_surface) => {
+                        return ControlFlow::Break(Ok(lock_surface
+                            .cloned()
+                            .map(KeyboardFocusTarget::LockSurface)))
+                    }
+                    Stage::LayerPopup {
+                        layer,
+                        popup,
+                        location,
+                    } => {
+                        if layer.can_receive_keyboard_focus() {
+                            let surface = popup.wl_surface();
+                            if under_from_surface_tree(
+                                surface,
+                                global_pos.as_logical(),
+                                location.as_logical(),
+                                WindowSurfaceType::POPUP | WindowSurfaceType::SUBSURFACE,
+                            )
+                            .is_some()
+                            {
+                                return ControlFlow::Break(Ok(Some(
+                                    KeyboardFocusTarget::LayerSurface(layer),
+                                )));
+                            }
+                        }
+                    }
+                    Stage::LayerSurface { layer, location } => {
+                        if layer.can_receive_keyboard_focus() {
+                            if under_from_surface_tree(
+                                layer.wl_surface(),
+                                global_pos.as_logical(),
+                                location.as_logical(),
+                                WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
+                            )
+                            .is_some()
+                            {
+                                return ControlFlow::Break(Ok(Some(
+                                    KeyboardFocusTarget::LayerSurface(layer),
+                                )));
+                            }
+                        }
+                    }
+                    Stage::OverrideRedirect { .. } => {
+                        // Override redirect windows take a grab on their own via
+                        // the Xwayland keyboard grab protocol. Don't focus them via click.
+                    }
+                    Stage::StickyPopups(layout) => {
+                        if let Some(element) =
+                            layout.popup_element_under(global_pos.to_local(output))
+                        {
+                            return ControlFlow::Break(Ok(Some(element)));
+                        }
+                    }
+                    Stage::Sticky(layout) => {
+                        if let Some(element) =
+                            layout.toplevel_element_under(global_pos.to_local(output))
+                        {
+                            return ControlFlow::Break(Ok(Some(element)));
+                        }
+                    }
+                    Stage::WorkspacePopups { workspace, offset } => {
+                        let location = global_pos + offset.as_global().to_f64();
+                        let output = workspace.output();
+                        let output_geo = output.geometry().to_local(output);
+                        if Rectangle::from_loc_and_size(offset.as_local(), output_geo.size)
+                            .intersection(output_geo)
+                            .is_some_and(|geometry| {
+                                geometry.contains(global_pos.to_local(output).to_i32_round())
+                            })
+                        {
+                            if let Some(element) = workspace.popup_element_under(location) {
+                                return ControlFlow::Break(Ok(Some(element)));
+                            }
+                        }
+                    }
+                    Stage::Workspace { workspace, offset } => {
+                        let location = global_pos + offset.as_global().to_f64();
+                        let output = workspace.output();
+                        let output_geo = output.geometry().to_local(output);
+                        if Rectangle::from_loc_and_size(offset.as_local(), output_geo.size)
+                            .intersection(output_geo)
+                            .is_some_and(|geometry| {
+                                geometry.contains(global_pos.to_local(output).to_i32_round())
+                            })
+                        {
+                            if let Some(element) = workspace.toplevel_element_under(location) {
+                                return ControlFlow::Break(Ok(Some(element)));
+                            }
+                        }
+                    }
+                }
+                ControlFlow::Continue(())
+            },
+        )
+        .ok()
+        .flatten()
+    }
+
     pub fn surface_under(
         global_pos: Point<f64, Global>,
         output: &Output,
-        shell: &mut Shell,
+        shell: &Shell,
     ) -> Option<(PointerFocusTarget, Point<f64, Global>)> {
-        let session_lock = shell.session_lock.as_ref();
+        let (previous_workspace, workspace) = shell.workspaces.active(output);
+        let (previous_idx, idx) = shell.workspaces.active_num(output);
+        let previous_workspace = previous_workspace
+            .zip(previous_idx)
+            .map(|((w, start), idx)| (w.handle, idx, start));
+        let workspace = (workspace.handle, idx);
+
+        let element_filter = if workspace_overview_is_open(output) {
+            ElementFilter::LayerShellOnly
+        } else {
+            ElementFilter::All
+        };
+
         let relative_pos = global_pos.to_local(output);
         let output_geo = output.geometry();
+        let overview = shell.overview_mode().0;
 
-        if let Some(session_lock) = session_lock {
-            return session_lock.surfaces.get(output).map(|surface| {
-                (
-                    PointerFocusTarget::WlSurface {
-                        surface: surface.wl_surface().clone(),
-                        toplevel: None,
-                    },
-                    output_geo.loc.to_f64(),
-                )
-            });
-        }
-
-        if let Some(window) = shell.workspaces.active(output).1.get_fullscreen() {
-            let layers = layer_map_for_output(output);
-            if let Some(layer) = layers.layer_under(WlrLayer::Overlay, relative_pos.as_logical()) {
-                let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-                if let Some((wl_surface, surface_loc)) = layer.surface_under(
-                    relative_pos.as_logical() - layer_loc.to_f64(),
-                    WindowSurfaceType::ALL,
-                ) {
-                    return Some((
-                        PointerFocusTarget::WlSurface {
-                            surface: wl_surface,
-                            toplevel: None,
-                        },
-                        (output_geo.loc + layer_loc.as_global() + surface_loc.as_global()).to_f64(),
-                    ));
-                }
-            }
-            if let Some((surface, geo)) = shell
-                .override_redirect_windows
-                .iter()
-                .find(|or| {
-                    or.is_in_input_region(
-                        &(global_pos.as_logical() - X11Surface::geometry(*or).loc.to_f64()),
-                    )
-                })
-                .and_then(|or| {
-                    or.wl_surface()
-                        .map(|surface| (surface, X11Surface::geometry(or).loc.as_global().to_f64()))
-                })
-            {
-                return Some((
-                    PointerFocusTarget::WlSurface {
-                        surface,
-                        toplevel: None,
-                    },
-                    geo,
-                ));
-            }
-            PointerFocusTarget::under_surface(window, relative_pos.as_logical()).map(
-                |(target, surface_loc)| {
-                    (target, (output_geo.loc + surface_loc.as_global()).to_f64())
-                },
-            )
-        } else {
-            {
-                let layers = layer_map_for_output(output);
-                if let Some(layer) = layers
-                    .layer_under(WlrLayer::Overlay, relative_pos.as_logical())
-                    .or_else(|| layers.layer_under(WlrLayer::Top, relative_pos.as_logical()))
-                {
-                    let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-                    if let Some((wl_surface, surface_loc)) = layer.surface_under(
-                        relative_pos.as_logical() - layer_loc.to_f64(),
-                        WindowSurfaceType::ALL,
-                    ) {
-                        return Some((
-                            PointerFocusTarget::WlSurface {
-                                surface: wl_surface,
-                                toplevel: None,
-                            },
-                            (output_geo.loc + layer_loc.as_global() + surface_loc.as_global())
-                                .to_f64(),
-                        ));
+        render_input_order(
+            shell,
+            output,
+            previous_workspace,
+            workspace,
+            element_filter,
+            |stage| {
+                match stage {
+                    Stage::SessionLock(lock_surface) => {
+                        return ControlFlow::Break(Ok(lock_surface.map(|surface| {
+                            (
+                                PointerFocusTarget::WlSurface {
+                                    surface: surface.wl_surface().clone(),
+                                    toplevel: None,
+                                },
+                                output_geo.loc.to_f64(),
+                            )
+                        })));
+                    }
+                    Stage::LayerPopup {
+                        popup, location, ..
+                    } => {
+                        let surface = popup.wl_surface();
+                        if let Some((surface, surface_loc)) = under_from_surface_tree(
+                            surface,
+                            global_pos.as_logical(),
+                            location.as_logical(),
+                            WindowSurfaceType::ALL,
+                        ) {
+                            return ControlFlow::Break(Ok(Some((
+                                PointerFocusTarget::WlSurface {
+                                    surface,
+                                    toplevel: None,
+                                },
+                                surface_loc.as_global().to_f64(),
+                            ))));
+                        }
+                    }
+                    Stage::LayerSurface { layer, location } => {
+                        let surface = layer.wl_surface();
+                        if let Some((surface, surface_loc)) = under_from_surface_tree(
+                            surface,
+                            global_pos.as_logical(),
+                            location.as_logical(),
+                            WindowSurfaceType::ALL,
+                        ) {
+                            return ControlFlow::Break(Ok(Some((
+                                PointerFocusTarget::WlSurface {
+                                    surface,
+                                    toplevel: None,
+                                },
+                                surface_loc.as_global().to_f64(),
+                            ))));
+                        }
+                    }
+                    Stage::OverrideRedirect { surface, location } => {
+                        if let Some(surface) = surface.wl_surface() {
+                            if let Some((surface, surface_loc)) = under_from_surface_tree(
+                                &surface,
+                                global_pos.as_logical(),
+                                location.as_logical(),
+                                WindowSurfaceType::ALL,
+                            ) {
+                                return ControlFlow::Break(Ok(Some((
+                                    PointerFocusTarget::WlSurface {
+                                        surface,
+                                        toplevel: None,
+                                    },
+                                    surface_loc.as_global().to_f64(),
+                                ))));
+                            }
+                        }
+                    }
+                    Stage::StickyPopups(floating_layer) => {
+                        if let Some(under) = floating_layer
+                            .popup_surface_under(relative_pos)
+                            .map(|(target, point)| (target, point.to_global(output)))
+                        {
+                            return ControlFlow::Break(Ok(Some(under)));
+                        }
+                    }
+                    Stage::Sticky(floating_layer) => {
+                        if let Some(under) = floating_layer
+                            .toplevel_surface_under(relative_pos)
+                            .map(|(target, point)| (target, point.to_global(output)))
+                        {
+                            return ControlFlow::Break(Ok(Some(under)));
+                        }
+                    }
+                    Stage::WorkspacePopups { workspace, offset } => {
+                        let global_pos = global_pos + offset.to_f64().as_global();
+                        if let Some(under) =
+                            workspace.popup_surface_under(global_pos, overview.clone())
+                        {
+                            return ControlFlow::Break(Ok(Some(under)));
+                        }
+                    }
+                    Stage::Workspace { workspace, offset } => {
+                        let global_pos = global_pos + offset.to_f64().as_global();
+                        if let Some(under) =
+                            workspace.toplevel_surface_under(global_pos, overview.clone())
+                        {
+                            return ControlFlow::Break(Ok(Some(under)));
+                        }
                     }
                 }
-            }
-            if let Some((surface, geo)) = shell
-                .override_redirect_windows
-                .iter()
-                .find(|or| {
-                    or.is_in_input_region(
-                        &(global_pos.as_logical() - X11Surface::geometry(*or).loc.to_f64()),
-                    )
-                })
-                .and_then(|or| {
-                    or.wl_surface()
-                        .map(|surface| (surface, X11Surface::geometry(or).loc.as_global().to_f64()))
-                })
-            {
-                return Some((
-                    PointerFocusTarget::WlSurface {
-                        surface,
-                        toplevel: None,
-                    },
-                    geo,
-                ));
-            }
-            if let Some((target, loc)) = shell.surface_under(global_pos, output) {
-                return Some((target, loc));
-            }
-            {
-                let layers = layer_map_for_output(output);
-                if let Some(layer) = layers
-                    .layer_under(WlrLayer::Bottom, relative_pos.as_logical())
-                    .or_else(|| layers.layer_under(WlrLayer::Background, relative_pos.as_logical()))
-                {
-                    let layer_loc = layers.layer_geometry(layer).unwrap().loc;
-                    if let Some((wl_surface, surface_loc)) = layer.surface_under(
-                        relative_pos.as_logical() - layer_loc.to_f64(),
-                        WindowSurfaceType::ALL,
-                    ) {
-                        return Some((
-                            PointerFocusTarget::WlSurface {
-                                surface: wl_surface,
-                                toplevel: None,
-                            },
-                            (output_geo.loc + layer_loc.as_global() + surface_loc.as_global())
-                                .to_f64(),
-                        ));
-                    }
-                }
-            }
-            None
-        }
+
+                ControlFlow::Continue(())
+            },
+        )
+        .ok()
+        .flatten()
     }
 }
 

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -302,10 +302,11 @@ impl CosmicMapped {
     pub fn focus_under(
         &self,
         relative_pos: Point<f64, Logical>,
+        surface_type: WindowSurfaceType,
     ) -> Option<(PointerFocusTarget, Point<f64, Logical>)> {
         match &self.element {
-            CosmicMappedInternal::Stack(stack) => stack.focus_under(relative_pos),
-            CosmicMappedInternal::Window(window) => window.focus_under(relative_pos),
+            CosmicMappedInternal::Stack(stack) => stack.focus_under(relative_pos, surface_type),
+            CosmicMappedInternal::Window(window) => window.focus_under(relative_pos, surface_type),
             _ => unreachable!(),
         }
     }

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -1,8 +1,5 @@
 use crate::{
-    backend::render::{
-        element::{AsGlowRenderer, FromGlesError},
-        SplitRenderElements,
-    },
+    backend::render::element::{AsGlowRenderer, FromGlesError},
     state::State,
     utils::{iced::IcedElementInternal, prelude::*},
 };
@@ -657,13 +654,42 @@ impl CosmicMapped {
         }
     }
 
-    pub fn split_render_elements<R, C>(
+    pub fn popup_render_elements<R, C>(
         &self,
         renderer: &mut R,
         location: smithay::utils::Point<i32, smithay::utils::Physical>,
         scale: smithay::utils::Scale<f64>,
         alpha: f32,
-    ) -> SplitRenderElements<C>
+    ) -> Vec<C>
+    where
+        R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
+        <R as Renderer>::TextureId: Send + Clone + 'static,
+        CosmicMappedRenderElement<R>: RenderElement<R>,
+        C: From<CosmicMappedRenderElement<R>>,
+    {
+        match &self.element {
+            CosmicMappedInternal::Stack(s) => s
+                .popup_render_elements::<R, CosmicMappedRenderElement<R>>(
+                    renderer, location, scale, alpha,
+                ),
+            CosmicMappedInternal::Window(w) => w
+                .popup_render_elements::<R, CosmicMappedRenderElement<R>>(
+                    renderer, location, scale, alpha,
+                ),
+            _ => unreachable!(),
+        }
+        .into_iter()
+        .map(C::from)
+        .collect()
+    }
+
+    pub fn render_elements<R, C>(
+        &self,
+        renderer: &mut R,
+        location: smithay::utils::Point<i32, smithay::utils::Physical>,
+        scale: smithay::utils::Scale<f64>,
+        alpha: f32,
+    ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
         <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -671,7 +697,7 @@ impl CosmicMapped {
         C: From<CosmicMappedRenderElement<R>>,
     {
         #[cfg(feature = "debug")]
-        let debug_elements = if let Some(debug) = self.debug.lock().unwrap().as_mut() {
+        let mut elements = if let Some(debug) = self.debug.lock().unwrap().as_mut() {
             let window = self.active_window();
             let window_geo = window.geometry();
             let (min_size, max_size, size) =
@@ -840,30 +866,21 @@ impl CosmicMapped {
             Vec::new()
         };
         #[cfg(not(feature = "debug"))]
-        let debug_elements = Vec::new();
-
-        let mut elements = SplitRenderElements {
-            w_elements: debug_elements,
-            p_elements: Vec::new(),
-        };
+        let mut elements = Vec::new();
 
         #[cfg_attr(not(feature = "debug"), allow(unused_mut))]
-        elements.extend_map(
-            match &self.element {
-                CosmicMappedInternal::Stack(s) => s
-                    .split_render_elements::<R, CosmicMappedRenderElement<R>>(
-                        renderer, location, scale, alpha,
-                    ),
-                CosmicMappedInternal::Window(w) => w
-                    .split_render_elements::<R, CosmicMappedRenderElement<R>>(
-                        renderer, location, scale, alpha,
-                    ),
-                _ => unreachable!(),
-            },
-            C::from,
-        );
+        elements.extend(match &self.element {
+            CosmicMappedInternal::Stack(s) => s.render_elements::<R, CosmicMappedRenderElement<R>>(
+                renderer, location, scale, alpha,
+            ),
+            CosmicMappedInternal::Window(w) => w
+                .render_elements::<R, CosmicMappedRenderElement<R>>(
+                    renderer, location, scale, alpha,
+                ),
+            _ => unreachable!(),
+        });
 
-        elements
+        elements.into_iter().map(C::from).collect()
     }
 
     pub(crate) fn update_theme(&self, theme: cosmic::Theme) {

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -35,7 +35,9 @@ use smithay::{
         },
         wayland_server::protocol::wl_surface::WlSurface,
     },
-    utils::{user_data::UserDataMap, IsAlive, Logical, Rectangle, Serial, Size},
+    utils::{
+        user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size,
+    },
     wayland::{
         compositor::{with_states, SurfaceData},
         seat::WaylandFocus,
@@ -45,7 +47,6 @@ use smithay::{
 };
 
 use crate::{
-    backend::render::SplitRenderElements,
     state::{State, SurfaceDmabufFeedback},
     utils::prelude::*,
     wayland::handlers::decoration::PreferredDecorationMode,
@@ -590,13 +591,13 @@ impl CosmicSurface {
         self.0.user_data()
     }
 
-    pub fn split_render_elements<R, C>(
+    pub fn popup_render_elements<R, C>(
         &self,
         renderer: &mut R,
-        location: smithay::utils::Point<i32, smithay::utils::Physical>,
-        scale: smithay::utils::Scale<f64>,
+        location: Point<i32, Physical>,
+        scale: Scale<f64>,
         alpha: f32,
-    ) -> SplitRenderElements<C>
+    ) -> Vec<C>
     where
         R: Renderer + ImportAll,
         <R as Renderer>::TextureId: Clone + 'static,
@@ -605,9 +606,8 @@ impl CosmicSurface {
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
                 let surface = toplevel.wl_surface();
-
-                let p_elements = PopupManager::popups_for_surface(surface)
-                    .flat_map(|(popup, popup_offset)| {
+                PopupManager::popups_for_surface(surface)
+                    .flat_map(move |(popup, popup_offset)| {
                         let offset = (self.0.geometry().loc + popup_offset - popup.geometry().loc)
                             .to_physical_precise_round(scale);
 
@@ -620,26 +620,40 @@ impl CosmicSurface {
                             element::Kind::Unspecified,
                         )
                     })
-                    .collect();
+                    .collect()
+            }
+            WindowSurface::X11(_) => Vec::new(),
+        }
+    }
 
-                let w_elements = render_elements_from_surface_tree(
+    pub fn render_elements<R, C>(
+        &self,
+        renderer: &mut R,
+        location: Point<i32, Physical>,
+        scale: Scale<f64>,
+        alpha: f32,
+    ) -> Vec<C>
+    where
+        R: Renderer + ImportAll,
+        <R as Renderer>::TextureId: Clone + 'static,
+        C: From<WaylandSurfaceRenderElement<R>>,
+    {
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => {
+                let surface = toplevel.wl_surface();
+
+                render_elements_from_surface_tree(
                     renderer,
                     surface,
                     location,
                     scale,
                     alpha,
                     element::Kind::Unspecified,
-                );
-
-                SplitRenderElements {
-                    w_elements,
-                    p_elements,
-                }
+                )
             }
-            WindowSurface::X11(surface) => SplitRenderElements {
-                w_elements: surface.render_elements(renderer, location, scale, alpha),
-                p_elements: Vec::new(),
-            },
+            WindowSurface::X11(surface) => {
+                surface.render_elements(renderer, location, scale, alpha)
+            }
         }
     }
 
@@ -663,10 +677,7 @@ impl SpaceElement for CosmicSurface {
         SpaceElement::bbox(&self.0)
     }
 
-    fn is_in_input_region(
-        &self,
-        point: &smithay::utils::Point<f64, smithay::utils::Logical>,
-    ) -> bool {
+    fn is_in_input_region(&self, point: &Point<f64, smithay::utils::Logical>) -> bool {
         SpaceElement::is_in_input_region(&self.0, point)
     }
 
@@ -784,8 +795,8 @@ where
     fn render_elements<C: From<Self::RenderElement>>(
         &self,
         renderer: &mut R,
-        location: smithay::utils::Point<i32, smithay::utils::Physical>,
-        scale: smithay::utils::Scale<f64>,
+        location: Point<i32, Physical>,
+        scale: Scale<f64>,
         alpha: f32,
     ) -> Vec<C> {
         self.0.render_elements(renderer, location, scale, alpha)

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -232,8 +232,8 @@ fn update_focus_state(
         if should_update_cursor && state.common.config.cosmic_conf.cursor_follows_focus {
             if target.is_some() {
                 //need to borrow mutably for surface under
-                let mut shell = state.common.shell.write().unwrap();
-                // get geometry of the target element
+                let shell = state.common.shell.read().unwrap();
+                // get the top left corner of the target element
                 let geometry = shell.focused_geometry(target.unwrap());
                 if let Some(geometry) = geometry {
                     // get the center of the target element
@@ -247,10 +247,9 @@ fn update_focus_state(
                         .cloned()
                         .unwrap_or(seat.active_output());
 
-                    let focus = shell
-                        .surface_under(new_pos, &output)
+                    let focus = State::surface_under(new_pos, &output, &*shell)
                         .map(|(focus, loc)| (focus, loc.as_logical()));
-                    //drop here to avoid multiple mutable borrows
+                    //drop here to avoid multiple borrows
                     mem::drop(shell);
                     seat.get_pointer().unwrap().motion(
                         state,

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -21,10 +21,12 @@ use std::{borrow::Cow, mem, sync::Mutex};
 
 use tracing::{debug, trace};
 
+pub use self::order::{render_input_order, Stage};
 use self::target::{KeyboardFocusTarget, WindowGroup};
 
 use super::{grabs::SeatMoveGrabState, layout::floating::FloatingLayout, SeatExt};
 
+mod order;
 pub mod target;
 
 pub struct FocusStack<'a>(pub(super) Option<&'a IndexSet<CosmicMapped>>);

--- a/src/shell/focus/order.rs
+++ b/src/shell/focus/order.rs
@@ -1,0 +1,374 @@
+use std::{ops::ControlFlow, time::Instant};
+
+use cosmic_comp_config::workspace::WorkspaceLayout;
+use keyframe::{ease, functions::EaseInOutCubic};
+use smithay::{
+    desktop::{layer_map_for_output, LayerSurface, PopupKind, PopupManager},
+    output::{Output, OutputNoMode},
+    utils::{Logical, Point},
+    wayland::{session_lock::LockSurface, shell::wlr_layer::Layer},
+    xwayland::X11Surface,
+};
+
+use crate::{
+    backend::render::ElementFilter,
+    shell::{
+        layout::{floating::FloatingLayout, tiling::ANIMATION_DURATION},
+        Shell, Workspace, WorkspaceDelta,
+    },
+    utils::{geometry::*, prelude::OutputExt, quirks::WORKSPACE_OVERVIEW_NAMESPACE},
+    wayland::protocols::workspace::WorkspaceHandle,
+};
+
+pub enum Stage<'a> {
+    SessionLock(Option<&'a LockSurface>),
+    LayerPopup {
+        layer: LayerSurface,
+        popup: &'a PopupKind,
+        location: Point<i32, Global>,
+    },
+    LayerSurface {
+        layer: LayerSurface,
+        location: Point<i32, Global>,
+    },
+    OverrideRedirect {
+        surface: &'a X11Surface,
+        location: Point<i32, Global>,
+    },
+    StickyPopups(&'a FloatingLayout),
+    Sticky(&'a FloatingLayout),
+    WorkspacePopups {
+        workspace: &'a Workspace,
+        offset: Point<i32, Logical>,
+    },
+    Workspace {
+        workspace: &'a Workspace,
+        offset: Point<i32, Logical>,
+    },
+}
+
+pub fn render_input_order<R: Default + 'static>(
+    shell: &Shell,
+    output: &Output,
+    previous: Option<(WorkspaceHandle, usize, WorkspaceDelta)>,
+    current: (WorkspaceHandle, usize),
+    element_filter: ElementFilter,
+    callback: impl FnMut(Stage) -> ControlFlow<Result<R, OutputNoMode>, ()>,
+) -> Result<R, OutputNoMode> {
+    match render_input_order_internal(shell, output, previous, current, element_filter, callback) {
+        ControlFlow::Break(result) => result,
+        ControlFlow::Continue(_) => Ok(R::default()),
+    }
+}
+
+fn render_input_order_internal<R: 'static>(
+    shell: &Shell,
+    output: &Output,
+    previous: Option<(WorkspaceHandle, usize, WorkspaceDelta)>,
+    current: (WorkspaceHandle, usize),
+    element_filter: ElementFilter,
+    mut callback: impl FnMut(Stage) -> ControlFlow<Result<R, OutputNoMode>, ()>,
+) -> ControlFlow<Result<R, OutputNoMode>, ()> {
+    // Session Lock
+    if let Some(session_lock) = &shell.session_lock {
+        return callback(Stage::SessionLock(session_lock.surfaces.get(output)));
+    }
+
+    // Overlay-level layer shell
+    // overlay is above everything
+    for (layer, popup, location) in layer_popups(output, Layer::Overlay, element_filter) {
+        callback(Stage::LayerPopup {
+            layer,
+            popup: &popup,
+            location,
+        })?;
+    }
+    for (layer, location) in layer_surfaces(output, Layer::Overlay, element_filter) {
+        callback(Stage::LayerSurface { layer, location })?;
+    }
+
+    // calculate a bunch of stuff for workspace transitions
+
+    let Some(set) = shell.workspaces.sets.get(output) else {
+        return ControlFlow::Break(Err(OutputNoMode));
+    };
+    let Some(workspace) = set.workspaces.iter().find(|w| w.handle == current.0) else {
+        return ControlFlow::Break(Err(OutputNoMode));
+    };
+    let output_size = output.geometry().size;
+    let has_fullscreen = workspace
+        .fullscreen
+        .as_ref()
+        .filter(|f| !f.is_animating())
+        .is_some();
+
+    let (previous, current_offset) = match previous.as_ref() {
+        Some((previous, previous_idx, start)) => {
+            let layout = shell.workspaces.layout;
+
+            let Some(workspace) = shell.workspaces.space_for_handle(&previous) else {
+                return ControlFlow::Break(Err(OutputNoMode));
+            };
+            let has_fullscreen = workspace.fullscreen.is_some();
+
+            let percentage = match start {
+                WorkspaceDelta::Shortcut(st) => ease(
+                    EaseInOutCubic,
+                    0.0,
+                    1.0,
+                    Instant::now().duration_since(*st).as_millis() as f32
+                        / ANIMATION_DURATION.as_millis() as f32,
+                ),
+                WorkspaceDelta::Gesture(prog) => *prog as f32,
+                WorkspaceDelta::GestureEnd(st, spring) => {
+                    (spring.value_at(Instant::now().duration_since(*st)) as f32).clamp(0.0, 1.0)
+                }
+            };
+
+            let offset = Point::<i32, Logical>::from(match (layout, *previous_idx < current.1) {
+                (WorkspaceLayout::Vertical, true) => {
+                    (0, (-output_size.h as f32 * percentage).round() as i32)
+                }
+                (WorkspaceLayout::Vertical, false) => {
+                    (0, (output_size.h as f32 * percentage).round() as i32)
+                }
+                (WorkspaceLayout::Horizontal, true) => {
+                    ((-output_size.w as f32 * percentage).round() as i32, 0)
+                }
+                (WorkspaceLayout::Horizontal, false) => {
+                    ((output_size.w as f32 * percentage).round() as i32, 0)
+                }
+            });
+
+            (
+                Some((previous, has_fullscreen, offset)),
+                Point::<i32, Logical>::from(match (layout, *previous_idx < current.1) {
+                    (WorkspaceLayout::Vertical, true) => (0, output_size.h + offset.y),
+                    (WorkspaceLayout::Vertical, false) => (0, -(output_size.h - offset.y)),
+                    (WorkspaceLayout::Horizontal, true) => (output_size.w + offset.x, 0),
+                    (WorkspaceLayout::Horizontal, false) => (-(output_size.w - offset.x), 0),
+                }),
+            )
+        }
+        None => (None, Point::default()),
+    };
+
+    // Top-level layer shell popups
+    if !has_fullscreen {
+        for (layer, popup, location) in layer_popups(output, Layer::Top, element_filter) {
+            callback(Stage::LayerPopup {
+                layer,
+                popup: &popup,
+                location,
+            })?;
+        }
+    }
+
+    if element_filter != ElementFilter::LayerShellOnly {
+        // overlay redirect windows
+        // they need to be over sticky windows, because they could be popups of sticky windows,
+        // and we can't differenciate that.
+        for (surface, location) in shell
+            .override_redirect_windows
+            .iter()
+            .filter(|or| {
+                (*or)
+                    .geometry()
+                    .as_global()
+                    .intersection(output.geometry())
+                    .is_some()
+            })
+            .map(|or| (or, or.geometry().loc.as_global()))
+        {
+            callback(Stage::OverrideRedirect { surface, location })?;
+        }
+
+        // sticky window popups
+        if !has_fullscreen {
+            callback(Stage::StickyPopups(&set.sticky_layer))?;
+        }
+    }
+
+    if element_filter != ElementFilter::LayerShellOnly {
+        // previous workspace popups
+        if let Some((previous_handle, _, offset)) = previous.as_ref() {
+            let Some(workspace) = shell.workspaces.space_for_handle(previous_handle) else {
+                return ControlFlow::Break(Err(OutputNoMode));
+            };
+
+            callback(Stage::WorkspacePopups {
+                workspace,
+                offset: *offset,
+            })?;
+        }
+
+        // current workspace popups
+        let Some(workspace) = shell.workspaces.space_for_handle(&current.0) else {
+            return ControlFlow::Break(Err(OutputNoMode));
+        };
+
+        callback(Stage::WorkspacePopups {
+            workspace,
+            offset: current_offset,
+        })?;
+    }
+
+    if !has_fullscreen {
+        // bottom layer popups
+        for (layer, popup, location) in layer_popups(output, Layer::Bottom, element_filter) {
+            callback(Stage::LayerPopup {
+                layer,
+                popup: &popup,
+                location,
+            })?;
+        }
+    }
+
+    if let Some((_, has_fullscreen, offset)) = previous.as_ref() {
+        if !has_fullscreen {
+            // previous bottom layer popups
+            for (layer, popup, location) in layer_popups(output, Layer::Bottom, element_filter) {
+                callback(Stage::LayerPopup {
+                    layer,
+                    popup: &popup,
+                    location: location + offset.as_global(),
+                })?;
+            }
+        }
+    }
+
+    if !has_fullscreen {
+        // background layer popups
+        for (layer, popup, location) in layer_popups(output, Layer::Background, element_filter) {
+            callback(Stage::LayerPopup {
+                layer,
+                popup: &popup,
+                location,
+            })?;
+        }
+    }
+
+    if let Some((_, has_fullscreen, offset)) = previous.as_ref() {
+        if !has_fullscreen {
+            // previous background layer popups
+            for (layer, popup, location) in layer_popups(output, Layer::Background, element_filter)
+            {
+                callback(Stage::LayerPopup {
+                    layer,
+                    popup: &popup,
+                    location: location + offset.as_global(),
+                })?;
+            }
+        }
+    }
+
+    if !has_fullscreen {
+        // top-layer shell
+        for (layer, location) in layer_surfaces(output, Layer::Top, element_filter) {
+            callback(Stage::LayerSurface { layer, location })?;
+        }
+
+        // sticky windows
+        if element_filter != ElementFilter::LayerShellOnly {
+            callback(Stage::Sticky(&set.sticky_layer))?;
+        }
+    }
+
+    if element_filter != ElementFilter::LayerShellOnly {
+        // workspace windows
+        callback(Stage::Workspace {
+            workspace,
+            offset: current_offset,
+        })?;
+
+        // previous workspace windows
+        if let Some((previous_handle, _, offset)) = previous.as_ref() {
+            let Some(workspace) = shell.workspaces.space_for_handle(previous_handle) else {
+                return ControlFlow::Break(Err(OutputNoMode));
+            };
+            callback(Stage::Workspace {
+                workspace,
+                offset: *offset,
+            })?;
+        }
+    }
+
+    if !has_fullscreen {
+        // bottom layer
+        for (layer, mut location) in layer_surfaces(output, Layer::Bottom, element_filter) {
+            location += current_offset.as_global();
+            callback(Stage::LayerSurface { layer, location })?;
+        }
+    }
+
+    if let Some((_, has_fullscreen, offset)) = previous.as_ref() {
+        if !has_fullscreen {
+            // previous bottom layer
+            for (layer, mut location) in layer_surfaces(output, Layer::Bottom, element_filter) {
+                location += offset.as_global();
+                callback(Stage::LayerSurface { layer, location })?;
+            }
+        }
+    }
+
+    if !has_fullscreen {
+        // background layer
+        for (layer, mut location) in layer_surfaces(output, Layer::Background, element_filter) {
+            location += current_offset.as_global();
+            callback(Stage::LayerSurface { layer, location })?;
+        }
+    }
+
+    if let Some((_, has_fullscreen, offset)) = previous.as_ref() {
+        if !has_fullscreen {
+            // previous background layer
+            for (layer, mut location) in layer_surfaces(output, Layer::Background, element_filter) {
+                location += offset.as_global();
+                callback(Stage::LayerSurface { layer, location })?;
+            }
+        }
+    }
+
+    ControlFlow::Continue(())
+}
+
+fn layer_popups<'a>(
+    output: &'a Output,
+    layer: Layer,
+    element_filter: ElementFilter,
+) -> impl Iterator<Item = (LayerSurface, PopupKind, Point<i32, Global>)> + 'a {
+    layer_surfaces(output, layer, element_filter).flat_map(move |(surface, location)| {
+        let location_clone = location.clone();
+        let surface_clone = surface.clone();
+        PopupManager::popups_for_surface(surface.wl_surface()).map(move |(popup, popup_offset)| {
+            let offset = (popup_offset - popup.geometry().loc)
+                .as_local()
+                .to_global(output);
+            (surface_clone.clone(), popup, (location_clone + offset))
+        })
+    })
+}
+
+fn layer_surfaces<'a>(
+    output: &'a Output,
+    layer: Layer,
+    element_filter: ElementFilter,
+) -> impl Iterator<Item = (LayerSurface, Point<i32, Global>)> + 'a {
+    // we want to avoid deadlocks on the layer-map in callbacks, so we need to clone the layer surfaces
+    let layers = {
+        let layer_map = layer_map_for_output(output);
+        layer_map
+            .layers_on(layer)
+            .rev()
+            .map(|s| (s.clone(), layer_map.layer_geometry(s).unwrap()))
+            .collect::<Vec<_>>()
+    };
+
+    layers
+        .into_iter()
+        .filter(move |(s, _)| {
+            !(element_filter == ElementFilter::ExcludeWorkspaceOverview
+                && s.namespace() == WORKSPACE_OVERVIEW_NAMESPACE)
+        })
+        .map(|(surface, geometry)| (surface, geometry.loc.as_local().to_global(output)))
+}

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -27,7 +27,7 @@ use smithay::{
             ImportAll, ImportMem, Renderer,
         },
     },
-    desktop::{layer_map_for_output, space::SpaceElement},
+    desktop::{layer_map_for_output, space::SpaceElement, WindowSurfaceType},
     input::{
         pointer::{
             AxisFrame, ButtonEvent, CursorIcon, GestureHoldBeginEvent, GestureHoldEndEvent,
@@ -864,7 +864,7 @@ impl Drop for MoveGrab {
                     let current_location = pointer.current_location();
 
                     if let Some((target, offset)) =
-                        mapped.focus_under(current_location - position.as_logical().to_f64())
+                        mapped.focus_under(current_location - position.as_logical().to_f64(), WindowSurfaceType::ALL)
                     {
                         pointer.motion(
                             state,

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -2,8 +2,7 @@
 
 use crate::{
     backend::render::{
-        cursor::CursorState, element::AsGlowRenderer, BackdropShader, IndicatorShader, Key,
-        SplitRenderElements, Usage,
+        cursor::CursorState, element::AsGlowRenderer, BackdropShader, IndicatorShader, Key, Usage,
     },
     shell::{
         element::{
@@ -181,12 +180,18 @@ impl MoveGrabState {
             _ => vec![],
         };
 
-        let SplitRenderElements {
-            w_elements,
-            p_elements,
-        } = self
+        let w_elements = self
             .window
-            .split_render_elements::<R, CosmicMappedRenderElement<R>>(
+            .render_elements::<R, CosmicMappedRenderElement<R>>(
+                renderer,
+                (render_location - self.window.geometry().loc)
+                    .to_physical_precise_round(output_scale),
+                output_scale,
+                alpha,
+            );
+        let p_elements = self
+            .window
+            .popup_render_elements::<R, CosmicMappedRenderElement<R>>(
                 renderer,
                 (render_location - self.window.geometry().loc)
                     .to_physical_precise_round(output_scale),

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     backend::render::{
-        element::AsGlowRenderer, BackdropShader, IndicatorShader, Key, SplitRenderElements, Usage,
-        ACTIVE_GROUP_COLOR, GROUP_COLOR,
+        element::AsGlowRenderer, BackdropShader, IndicatorShader, Key, Usage, ACTIVE_GROUP_COLOR,
+        GROUP_COLOR,
     },
     shell::{
         element::{
@@ -60,7 +60,7 @@ use smithay::{
     input::Seat,
     output::Output,
     reexports::wayland_server::Client,
-    utils::{IsAlive, Logical, Point, Rectangle, Scale, Size},
+    utils::{IsAlive, Logical, Physical, Point, Rectangle, Scale, Size},
     wayland::{compositor::add_blocker, seat::WaylandFocus},
 };
 use std::{
@@ -3863,7 +3863,7 @@ impl TilingLayout {
         resize_indicator: Option<(ResizeMode, ResizeIndicator)>,
         indicator_thickness: u8,
         theme: &cosmic::theme::CosmicTheme,
-    ) -> Result<SplitRenderElements<CosmicMappedRenderElement<R>>, OutputNotMapped>
+    ) -> Result<Vec<CosmicMappedRenderElement<R>>, OutputNotMapped>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
         <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -3896,7 +3896,7 @@ impl TilingLayout {
         };
         let draw_groups = overview.0.alpha();
 
-        let mut elements = SplitRenderElements::default();
+        let mut elements = Vec::default();
 
         let is_overview = !matches!(overview.0, OverviewMode::None);
         let is_mouse_tiling = (matches!(overview.0.trigger(), Some(Trigger::Pointer(_))))
@@ -3931,7 +3931,7 @@ impl TilingLayout {
             .unzip();
 
             // all old windows we want to fade out
-            elements.extend(render_old_tree(
+            elements.extend(render_old_tree_windows(
                 reference_tree,
                 target_tree,
                 renderer,
@@ -3969,7 +3969,7 @@ impl TilingLayout {
         .unzip();
 
         // all alive windows
-        elements.extend(render_new_tree(
+        elements.extend(render_new_tree_windows(
             target_tree,
             reference_tree,
             renderer,
@@ -4001,8 +4001,135 @@ impl TilingLayout {
 
         // tiling hints
         if let Some(group_elements) = group_elements {
-            elements.w_elements.extend(group_elements);
+            elements.extend(group_elements);
         }
+
+        Ok(elements)
+    }
+
+    #[profiling::function]
+    pub fn render_popups<R>(
+        &self,
+        renderer: &mut R,
+        seat: Option<&Seat<State>>,
+        non_exclusive_zone: Rectangle<i32, Local>,
+        overview: (OverviewMode, Option<(SwapIndicator, Option<&Tree<Data>>)>),
+        theme: &cosmic::theme::CosmicTheme,
+    ) -> Result<Vec<CosmicMappedRenderElement<R>>, OutputNotMapped>
+    where
+        R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
+        <R as Renderer>::TextureId: Send + Clone + 'static,
+        CosmicMappedRenderElement<R>: RenderElement<R>,
+        CosmicWindowRenderElement<R>: RenderElement<R>,
+        CosmicStackRenderElement<R>: RenderElement<R>,
+    {
+        let output_scale = self.output.current_scale().fractional_scale();
+
+        let (target_tree, duration, _) = if self.queue.animation_start.is_some() {
+            self.queue
+                .trees
+                .get(1)
+                .expect("Animation ongoing, should have two trees")
+        } else {
+            self.queue.trees.front().unwrap()
+        };
+        let reference_tree = self
+            .queue
+            .animation_start
+            .is_some()
+            .then(|| &self.queue.trees.front().unwrap().0);
+
+        let percentage = if let Some(animation_start) = self.queue.animation_start {
+            let percentage = Instant::now().duration_since(animation_start).as_millis() as f32
+                / duration.as_millis() as f32;
+            ease(EaseInOutCubic, 0.0, 1.0, percentage)
+        } else {
+            1.0
+        };
+        let draw_groups = overview.0.alpha();
+
+        let mut elements = Vec::default();
+
+        let is_mouse_tiling = (matches!(overview.0.trigger(), Some(Trigger::Pointer(_))))
+            .then(|| self.last_overview_hover.as_ref().map(|x| &x.1));
+        let swap_desc = if let Some(Trigger::KeyboardSwap(_, desc)) = overview.0.trigger() {
+            Some(desc.clone())
+        } else {
+            None
+        };
+
+        // all gone windows and fade them out
+        let old_geometries = if let Some(reference_tree) = reference_tree.as_ref() {
+            let (geometries, _) = if let Some(transition) = draw_groups {
+                Some(geometries_for_groupview(
+                    reference_tree,
+                    &mut *renderer,
+                    non_exclusive_zone,
+                    seat, // TODO: Would be better to be an old focus,
+                    // but for that we have to associate focus with a tree (and animate focus changes properly)
+                    1.0 - transition,
+                    transition,
+                    output_scale,
+                    &self.placeholder_id,
+                    is_mouse_tiling,
+                    swap_desc.clone(),
+                    overview.1.as_ref().and_then(|(_, tree)| tree.clone()),
+                    theme,
+                ))
+            } else {
+                None
+            }
+            .unzip();
+
+            // all old windows we want to fade out
+            elements.extend(render_old_tree_popups(
+                reference_tree,
+                target_tree,
+                renderer,
+                geometries.clone(),
+                output_scale,
+                percentage,
+                swap_desc.is_some(),
+            ));
+
+            geometries
+        } else {
+            None
+        };
+
+        let (geometries, _) = if let Some(transition) = draw_groups {
+            Some(geometries_for_groupview(
+                target_tree,
+                &mut *renderer,
+                non_exclusive_zone,
+                seat,
+                transition,
+                transition,
+                output_scale,
+                &self.placeholder_id,
+                is_mouse_tiling,
+                swap_desc.clone(),
+                overview.1.as_ref().and_then(|(_, tree)| tree.clone()),
+                theme,
+            ))
+        } else {
+            None
+        }
+        .unzip();
+
+        // all alive windows
+        elements.extend(render_new_tree_popups(
+            target_tree,
+            reference_tree,
+            renderer,
+            geometries,
+            old_geometries,
+            seat,
+            &self.output,
+            percentage,
+            overview,
+            swap_desc.clone(),
+        ));
 
         Ok(elements)
     }
@@ -4690,7 +4817,48 @@ where
     (geometries, elements)
 }
 
-fn render_old_tree<R>(
+fn render_old_tree_popups<R>(
+    reference_tree: &Tree<Data>,
+    target_tree: &Tree<Data>,
+    renderer: &mut R,
+    geometries: Option<HashMap<NodeId, Rectangle<i32, Local>>>,
+    output_scale: f64,
+    percentage: f32,
+    is_swap_mode: bool,
+) -> Vec<CosmicMappedRenderElement<R>>
+where
+    R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
+    <R as Renderer>::TextureId: Send + Clone + 'static,
+    CosmicMappedRenderElement<R>: RenderElement<R>,
+    CosmicWindowRenderElement<R>: RenderElement<R>,
+    CosmicStackRenderElement<R>: RenderElement<R>,
+{
+    let mut elements = Vec::default();
+
+    render_old_tree(
+        reference_tree,
+        target_tree,
+        geometries,
+        output_scale,
+        percentage,
+        is_swap_mode,
+        |mapped, elem_geometry, geo, alpha, _| {
+            elements.extend(
+                mapped.popup_render_elements::<R, CosmicMappedRenderElement<R>>(
+                    renderer,
+                    geo.loc.as_logical().to_physical_precise_round(output_scale)
+                        - elem_geometry.loc,
+                    Scale::from(output_scale),
+                    alpha,
+                ),
+            );
+        },
+    );
+
+    elements
+}
+
+fn render_old_tree_windows<R>(
     reference_tree: &Tree<Data>,
     target_tree: &Tree<Data>,
     renderer: &mut R,
@@ -4700,7 +4868,7 @@ fn render_old_tree<R>(
     indicator_thickness: u8,
     is_swap_mode: bool,
     theme: &cosmic::theme::CosmicTheme,
-) -> SplitRenderElements<CosmicMappedRenderElement<R>>
+) -> Vec<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
     <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -4709,8 +4877,80 @@ where
     CosmicStackRenderElement<R>: RenderElement<R>,
 {
     let window_hint = crate::theme::active_window_hint(theme);
-    let mut elements = SplitRenderElements::default();
+    let mut elements = Vec::default();
 
+    render_old_tree(
+        reference_tree,
+        target_tree,
+        geometries,
+        output_scale,
+        percentage,
+        is_swap_mode,
+        |mapped, elem_geometry, geo, alpha, is_minimizing| {
+            let window_elements = mapped.render_elements::<R, CosmicMappedRenderElement<R>>(
+                renderer,
+                geo.loc.as_logical().to_physical_precise_round(output_scale) - elem_geometry.loc,
+                Scale::from(output_scale),
+                alpha,
+            );
+
+            elements.extend(window_elements.into_iter().flat_map(|element| {
+                match element {
+                    CosmicMappedRenderElement::Stack(elem) => constrain_render_elements(
+                        std::iter::once(elem),
+                        geo.loc.as_logical().to_physical_precise_round(output_scale)
+                            - elem_geometry.loc,
+                        geo.as_logical().to_physical_precise_round(output_scale),
+                        elem_geometry,
+                        ConstrainScaleBehavior::Stretch,
+                        ConstrainAlign::CENTER,
+                        output_scale,
+                    )
+                    .next()
+                    .map(CosmicMappedRenderElement::TiledStack),
+                    CosmicMappedRenderElement::Window(elem) => constrain_render_elements(
+                        std::iter::once(elem),
+                        geo.loc.as_logical().to_physical_precise_round(output_scale)
+                            - elem_geometry.loc,
+                        geo.as_logical().to_physical_precise_round(output_scale),
+                        elem_geometry,
+                        ConstrainScaleBehavior::Stretch,
+                        ConstrainAlign::CENTER,
+                        output_scale,
+                    )
+                    .next()
+                    .map(CosmicMappedRenderElement::TiledWindow),
+                    x => Some(x),
+                }
+            }));
+            if is_minimizing && indicator_thickness > 0 {
+                elements.push(CosmicMappedRenderElement::FocusIndicator(
+                    IndicatorShader::focus_element(
+                        renderer,
+                        Key::Window(Usage::FocusIndicator, mapped.clone().key()),
+                        geo,
+                        indicator_thickness,
+                        output_scale,
+                        alpha,
+                        [window_hint.red, window_hint.green, window_hint.blue],
+                    ),
+                ));
+            }
+        },
+    );
+
+    elements
+}
+
+fn render_old_tree(
+    reference_tree: &Tree<Data>,
+    target_tree: &Tree<Data>,
+    geometries: Option<HashMap<NodeId, Rectangle<i32, Local>>>,
+    output_scale: f64,
+    percentage: f32,
+    is_swap_mode: bool,
+    mut processor: impl FnMut(&CosmicMapped, Rectangle<i32, Physical>, Rectangle<i32, Local>, f32, bool),
+) {
     if let Some(root) = reference_tree.root_node_id() {
         let geometries = geometries.unwrap_or_default();
         reference_tree
@@ -4779,71 +5019,71 @@ where
                 };
 
                 let elem_geometry = mapped.geometry().to_physical_precise_round(output_scale);
-                let SplitRenderElements {
-                    w_elements,
-                    p_elements,
-                } = mapped.split_render_elements::<R, CosmicMappedRenderElement<R>>(
-                    renderer,
-                    geo.loc.as_logical().to_physical_precise_round(output_scale)
-                        - elem_geometry.loc,
-                    Scale::from(output_scale),
-                    alpha,
-                );
 
-                elements
-                    .w_elements
-                    .extend(w_elements.into_iter().flat_map(|element| {
-                        match element {
-                            CosmicMappedRenderElement::Stack(elem) => constrain_render_elements(
-                                std::iter::once(elem),
-                                geo.loc.as_logical().to_physical_precise_round(output_scale)
-                                    - elem_geometry.loc,
-                                geo.as_logical().to_physical_precise_round(output_scale),
-                                elem_geometry,
-                                ConstrainScaleBehavior::Stretch,
-                                ConstrainAlign::CENTER,
-                                output_scale,
-                            )
-                            .next()
-                            .map(CosmicMappedRenderElement::TiledStack),
-                            CosmicMappedRenderElement::Window(elem) => constrain_render_elements(
-                                std::iter::once(elem),
-                                geo.loc.as_logical().to_physical_precise_round(output_scale)
-                                    - elem_geometry.loc,
-                                geo.as_logical().to_physical_precise_round(output_scale),
-                                elem_geometry,
-                                ConstrainScaleBehavior::Stretch,
-                                ConstrainAlign::CENTER,
-                                output_scale,
-                            )
-                            .next()
-                            .map(CosmicMappedRenderElement::TiledWindow),
-                            x => Some(x),
-                        }
-                    }));
-                if minimize_geo.is_some() && indicator_thickness > 0 {
-                    elements
-                        .w_elements
-                        .push(CosmicMappedRenderElement::FocusIndicator(
-                            IndicatorShader::focus_element(
-                                renderer,
-                                Key::Window(Usage::FocusIndicator, mapped.clone().key()),
-                                geo,
-                                indicator_thickness,
-                                output_scale,
-                                alpha,
-                                [window_hint.red, window_hint.green, window_hint.blue],
-                            ),
-                        ));
-                }
-                elements.p_elements.extend(p_elements);
+                processor(mapped, elem_geometry, geo, alpha, minimize_geo.is_some())
             });
     }
-
-    elements
 }
 
-fn render_new_tree<R>(
+fn render_new_tree_popups<R>(
+    target_tree: &Tree<Data>,
+    reference_tree: Option<&Tree<Data>>,
+    renderer: &mut R,
+    geometries: Option<HashMap<NodeId, Rectangle<i32, Local>>>,
+    old_geometries: Option<HashMap<NodeId, Rectangle<i32, Local>>>,
+    seat: Option<&Seat<State>>,
+    output: &Output,
+    percentage: f32,
+    overview: (OverviewMode, Option<(SwapIndicator, Option<&Tree<Data>>)>),
+    swap_desc: Option<NodeDesc>,
+) -> Vec<CosmicMappedRenderElement<R>>
+where
+    R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
+    <R as Renderer>::TextureId: Send + Clone + 'static,
+    CosmicMappedRenderElement<R>: RenderElement<R>,
+    CosmicWindowRenderElement<R>: RenderElement<R>,
+    CosmicStackRenderElement<R>: RenderElement<R>,
+{
+    let mut popup_elements = Vec::new();
+    let output_scale = output.current_scale().fractional_scale();
+
+    let is_active_output = seat
+        .map(|seat| &seat.active_output() == output)
+        .unwrap_or(false);
+
+    let (_, swap_tree) = overview.1.unzip();
+    let swap_desc = swap_desc.filter(|_| is_active_output);
+    let swap_tree = swap_tree.flatten().filter(|_| is_active_output);
+
+    render_new_tree(
+        target_tree,
+        reference_tree,
+        geometries,
+        old_geometries,
+        percentage,
+        swap_tree,
+        swap_desc.as_ref(),
+        |_node_id, data, geo, _original_geo, alpha, _| {
+            if let Data::Mapped { mapped, .. } = data {
+                let elem_geometry = mapped.geometry().to_physical_precise_round(output_scale);
+
+                popup_elements.extend(
+                    mapped.popup_render_elements::<R, CosmicMappedRenderElement<R>>(
+                        renderer,
+                        geo.loc.as_logical().to_physical_precise_round(output_scale)
+                            - elem_geometry.loc,
+                        Scale::from(output_scale),
+                        alpha,
+                    ),
+                );
+            }
+        },
+    );
+
+    popup_elements
+}
+
+fn render_new_tree_windows<R>(
     target_tree: &Tree<Data>,
     reference_tree: Option<&Tree<Data>>,
     renderer: &mut R,
@@ -4862,7 +5102,7 @@ fn render_new_tree<R>(
     swapping_stack_surface_id: &Id,
     placeholder_id: &Id,
     theme: &cosmic::theme::CosmicTheme,
-) -> SplitRenderElements<CosmicMappedRenderElement<R>>
+) -> Vec<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
     <R as Renderer>::TextureId: Send + Clone + 'static,
@@ -4905,7 +5145,6 @@ where
 
     let mut animating_window_elements = Vec::new();
     let mut window_elements = Vec::new();
-    let mut popup_elements = Vec::new();
 
     let mut group_backdrop = None;
     let mut indicators = Vec::new();
@@ -4916,10 +5155,11 @@ where
     let output_scale = output.current_scale().fractional_scale();
 
     let (swap_indicator, swap_tree) = overview.1.unzip();
-    let swap_tree = swap_tree.flatten().filter(|_| is_active_output);
     let swap_desc = swap_desc.filter(|_| is_active_output);
+    let swap_tree = swap_tree.flatten().filter(|_| is_active_output);
     let window_hint = crate::theme::active_window_hint(theme);
     let group_color = GROUP_COLOR;
+
     // render placeholder, if we are swapping to an empty workspace
     if target_tree.root_node_id().is_none() && swap_desc.is_some() {
         window_elements.push(
@@ -4968,165 +5208,48 @@ where
             (swap_geo.loc.as_logical() - window_geo.loc).to_physical_precise_round(output_scale);
 
         swap_elements.extend(
-            window
-                .render_elements::<CosmicWindowRenderElement<R>>(
-                    renderer,
-                    render_loc,
-                    output_scale.into(),
-                    1.0,
-                )
-                .into_iter()
-                .map(|window| {
-                    CosmicMappedRenderElement::GrabbedWindow(RescaleRenderElement::from_element(
-                        window,
-                        swap_geo
-                            .loc
-                            .as_logical()
-                            .to_physical_precise_round(output_scale),
-                        ease(
-                            Linear,
-                            1.0,
-                            swap_factor(window_geo.size),
-                            transition.unwrap_or(1.0),
-                        ),
-                    ))
-                }),
+            AsRenderElements::render_elements::<CosmicWindowRenderElement<R>>(
+                &window,
+                renderer,
+                render_loc,
+                output_scale.into(),
+                1.0,
+            )
+            .into_iter()
+            .map(|window| {
+                CosmicMappedRenderElement::GrabbedWindow(RescaleRenderElement::from_element(
+                    window,
+                    swap_geo
+                        .loc
+                        .as_logical()
+                        .to_physical_precise_round(output_scale),
+                    ease(
+                        Linear,
+                        1.0,
+                        swap_factor(window_geo.size),
+                        transition.unwrap_or(1.0),
+                    ),
+                ))
+            }),
         )
     }
 
     // render actual tree nodes
-    let old_geometries = old_geometries.unwrap_or_default();
-    let geometries = geometries.unwrap_or_default();
-    target_tree
-        .root_node_id()
-        .into_iter()
-        .flat_map(|root| target_tree.traverse_pre_order_ids(root).unwrap())
-        .map(|id| (target_tree, id))
-        .chain(
-            swap_tree
-                .into_iter()
-                .flat_map(|tree| {
-                    let sub_root = &swap_desc.as_ref().unwrap().node;
-                    if swap_desc.as_ref().unwrap().stack_window.is_none() {
-                        Some(
-                            tree.traverse_pre_order_ids(sub_root)
-                                .unwrap()
-                                .map(move |id| (tree, id)),
-                        )
-                    } else {
-                        None
-                    }
-                })
-                .flatten(),
-        )
-        .for_each(|(target_tree, node_id)| {
-            let data = target_tree.get(&node_id).unwrap().data();
-            let (original_geo, scaled_geo) = (data.geometry(), geometries.get(&node_id));
-
-            let (old_original_geo, old_scaled_geo) =
-                if let Some(reference_tree) = reference_tree.as_ref() {
-                    if let Some(root) = reference_tree.root_node_id() {
-                        reference_tree
-                            .traverse_pre_order_ids(root)
-                            .unwrap()
-                            .find(|id| &node_id == id)
-                            .map(|node_id| {
-                                (
-                                    reference_tree.get(&node_id).unwrap().data().geometry(),
-                                    old_geometries.get(&node_id),
-                                )
-                            })
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-                .unzip();
-            let mut old_geo = old_original_geo.map(|original_geo| {
-                let (scale, offset) = old_scaled_geo
-                    .unwrap()
-                    .map(|adapted_geo| scale_to_center(original_geo, adapted_geo))
-                    .unwrap_or_else(|| (1.0.into(), (0, 0).into()));
-                (
-                    old_scaled_geo
-                        .unwrap()
-                        .map(|adapted_geo| {
-                            Rectangle::from_loc_and_size(
-                                adapted_geo.loc + offset,
-                                (
-                                    (original_geo.size.w as f64 * scale).round() as i32,
-                                    (original_geo.size.h as f64 * scale).round() as i32,
-                                ),
-                            )
-                        })
-                        .unwrap_or(*original_geo),
-                    1.0,
-                )
-            });
-
-            let was_minimized = if let Data::Mapped {
-                minimize_rect: Some(minimize_rect),
-                ..
-            } = &data
-            {
-                old_geo = Some((*minimize_rect, (percentage * 2.0).min(1.0)));
-                true
-            } else {
-                false
-            };
-
-            let (scale, offset) = scaled_geo
-                .map(|adapted_geo| scale_to_center(original_geo, adapted_geo))
-                .unwrap_or_else(|| (1.0.into(), (0, 0).into()));
-            let new_geo = scaled_geo
-                .map(|adapted_geo| {
-                    Rectangle::from_loc_and_size(
-                        adapted_geo.loc + offset,
-                        (
-                            (original_geo.size.w as f64 * scale).round() as i32,
-                            (original_geo.size.h as f64 * scale).round() as i32,
-                        ),
-                    )
-                })
-                .unwrap_or(*original_geo);
-
-            let (geo, alpha, animating) = if let Some((old_geo, alpha)) = old_geo.filter(|_| {
-                swap_desc
-                    .as_ref()
-                    .map(|desc| desc.node != node_id && desc.stack_window.is_none())
-                    .unwrap_or(true)
-            }) {
-                (
-                    if was_minimized {
-                        ease(
-                            EaseInOutCubic,
-                            EaseRectangle(old_geo),
-                            EaseRectangle(new_geo),
-                            percentage,
-                        )
-                        .unwrap()
-                    } else {
-                        ease(
-                            Linear,
-                            EaseRectangle(old_geo),
-                            EaseRectangle(new_geo),
-                            percentage,
-                        )
-                        .unwrap()
-                    },
-                    alpha,
-                    old_geo != new_geo,
-                )
-            } else {
-                (new_geo, percentage, false)
-            };
-
+    render_new_tree(
+        target_tree,
+        reference_tree,
+        geometries,
+        old_geometries,
+        percentage,
+        swap_tree,
+        swap_desc.as_ref(),
+        |node_id, data, geo, original_geo, alpha, animating| {
             if swap_desc.as_ref().map(|desc| &desc.node) == Some(&node_id)
                 || focused.as_ref() == Some(&node_id)
             {
                 if indicator_thickness > 0 || data.is_group() {
                     let mut geo = geo.clone();
+
                     if data.is_group() {
                         let outer_gap: i32 = (if is_overview { GAP_KEYBOARD } else { 4 } as f32
                             * percentage)
@@ -5251,10 +5374,8 @@ where
 
             if let Data::Mapped { mapped, .. } = data {
                 let elem_geometry = mapped.geometry().to_physical_precise_round(output_scale);
-                let SplitRenderElements {
-                    mut w_elements,
-                    p_elements,
-                } = mapped.split_render_elements::<R, CosmicMappedRenderElement<R>>(
+
+                let mut elements = mapped.render_elements::<R, CosmicMappedRenderElement<R>>(
                     renderer,
                     //original_location,
                     geo.loc.as_logical().to_physical_precise_round(output_scale)
@@ -5262,6 +5383,7 @@ where
                     Scale::from(output_scale),
                     alpha,
                 );
+
                 if swap_desc
                     .as_ref()
                     .filter(|swap_desc| swap_desc.node == node_id)
@@ -5284,7 +5406,7 @@ where
                 {
                     let mut geo = mapped.active_window_geometry().as_local();
                     geo.loc += original_geo.loc;
-                    w_elements.insert(
+                    elements.insert(
                         0,
                         CosmicMappedRenderElement::Overlay(BackdropShader::element(
                             renderer,
@@ -5305,7 +5427,7 @@ where
                     (ConstrainScaleBehavior::CutOff, ConstrainAlign::TOP_LEFT)
                 };
 
-                let w_elements = w_elements.into_iter().flat_map(|element| match element {
+                let elements = elements.into_iter().flat_map(|element| match element {
                     CosmicMappedRenderElement::Stack(elem) => constrain_render_elements(
                         std::iter::once(elem),
                         geo.loc.as_logical().to_physical_precise_round(output_scale)
@@ -5344,6 +5466,7 @@ where
                     .map(CosmicMappedRenderElement::TiledOverlay),
                     x => Some(x),
                 });
+
                 if swap_desc
                     .as_ref()
                     .map(|swap_desc| {
@@ -5356,21 +5479,19 @@ where
                     })
                     .unwrap_or(false)
                 {
-                    swap_elements.extend(w_elements);
+                    swap_elements.extend(elements);
                 } else {
                     if animating {
-                        animating_window_elements.extend(w_elements);
+                        animating_window_elements.extend(elements);
                     } else {
-                        window_elements.extend(w_elements);
-                    }
-                    if !mapped.is_maximized(false) {
-                        popup_elements.extend(p_elements);
+                        window_elements.extend(elements);
                     }
                 }
             }
-        });
+        },
+    );
 
-    window_elements = resize_elements
+    resize_elements
         .into_iter()
         .flatten()
         .chain(swap_elements)
@@ -5378,12 +5499,147 @@ where
         .chain(window_elements)
         .chain(animating_window_elements)
         .chain(group_backdrop.into_iter().map(Into::into))
-        .collect();
+        .collect()
+}
 
-    SplitRenderElements {
-        w_elements: window_elements,
-        p_elements: popup_elements,
-    }
+fn render_new_tree(
+    target_tree: &Tree<Data>,
+    reference_tree: Option<&Tree<Data>>,
+    geometries: Option<HashMap<NodeId, Rectangle<i32, Local>>>,
+    old_geometries: Option<HashMap<NodeId, Rectangle<i32, Local>>>,
+    percentage: f32,
+    swap_tree: Option<&Tree<Data>>,
+    swap_desc: Option<&NodeDesc>,
+    mut processor: impl FnMut(NodeId, &Data, Rectangle<i32, Local>, &Rectangle<i32, Local>, f32, bool),
+) {
+    let old_geometries = old_geometries.unwrap_or_default();
+    let geometries = geometries.unwrap_or_default();
+    target_tree
+        .root_node_id()
+        .into_iter()
+        .flat_map(|root| target_tree.traverse_pre_order_ids(root).unwrap())
+        .map(|id| (target_tree, id))
+        .chain(
+            swap_tree
+                .into_iter()
+                .flat_map(|tree| {
+                    let sub_root = &swap_desc.unwrap().node;
+                    if swap_desc.unwrap().stack_window.is_none() {
+                        Some(
+                            tree.traverse_pre_order_ids(sub_root)
+                                .unwrap()
+                                .map(move |id| (tree, id)),
+                        )
+                    } else {
+                        None
+                    }
+                })
+                .flatten(),
+        )
+        .for_each(|(target_tree, node_id)| {
+            let data = target_tree.get(&node_id).unwrap().data();
+            let (original_geo, scaled_geo) = (data.geometry(), geometries.get(&node_id));
+
+            let (old_original_geo, old_scaled_geo) =
+                if let Some(reference_tree) = reference_tree.as_ref() {
+                    if let Some(root) = reference_tree.root_node_id() {
+                        reference_tree
+                            .traverse_pre_order_ids(root)
+                            .unwrap()
+                            .find(|id| &node_id == id)
+                            .map(|node_id| {
+                                (
+                                    reference_tree.get(&node_id).unwrap().data().geometry(),
+                                    old_geometries.get(&node_id),
+                                )
+                            })
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+                .unzip();
+            let mut old_geo = old_original_geo.map(|original_geo| {
+                let (scale, offset) = old_scaled_geo
+                    .unwrap()
+                    .map(|adapted_geo| scale_to_center(original_geo, adapted_geo))
+                    .unwrap_or_else(|| (1.0.into(), (0, 0).into()));
+                (
+                    old_scaled_geo
+                        .unwrap()
+                        .map(|adapted_geo| {
+                            Rectangle::from_loc_and_size(
+                                adapted_geo.loc + offset,
+                                (
+                                    (original_geo.size.w as f64 * scale).round() as i32,
+                                    (original_geo.size.h as f64 * scale).round() as i32,
+                                ),
+                            )
+                        })
+                        .unwrap_or(*original_geo),
+                    1.0,
+                )
+            });
+
+            let was_minimized = if let Data::Mapped {
+                minimize_rect: Some(minimize_rect),
+                ..
+            } = &data
+            {
+                old_geo = Some((*minimize_rect, (percentage * 2.0).min(1.0)));
+                true
+            } else {
+                false
+            };
+
+            let (scale, offset) = scaled_geo
+                .map(|adapted_geo| scale_to_center(original_geo, adapted_geo))
+                .unwrap_or_else(|| (1.0.into(), (0, 0).into()));
+            let new_geo = scaled_geo
+                .map(|adapted_geo| {
+                    Rectangle::from_loc_and_size(
+                        adapted_geo.loc + offset,
+                        (
+                            (original_geo.size.w as f64 * scale).round() as i32,
+                            (original_geo.size.h as f64 * scale).round() as i32,
+                        ),
+                    )
+                })
+                .unwrap_or(*original_geo);
+
+            let (geo, alpha, animating) = if let Some((old_geo, alpha)) = old_geo.filter(|_| {
+                swap_desc
+                    .map(|desc| desc.node != node_id && desc.stack_window.is_none())
+                    .unwrap_or(true)
+            }) {
+                (
+                    if was_minimized {
+                        ease(
+                            EaseInOutCubic,
+                            EaseRectangle(old_geo),
+                            EaseRectangle(new_geo),
+                            percentage,
+                        )
+                        .unwrap()
+                    } else {
+                        ease(
+                            Linear,
+                            EaseRectangle(old_geo),
+                            EaseRectangle(new_geo),
+                            percentage,
+                        )
+                        .unwrap()
+                    },
+                    alpha,
+                    old_geo != new_geo,
+                )
+            } else {
+                (new_geo, percentage, false)
+            };
+
+            processor(node_id, data, geo, original_geo, alpha, animating)
+        });
 }
 
 fn scale_to_center<C>(


### PR DESCRIPTION
Draft because this needs more testing.

In theory this should fix:
- https://github.com/pop-os/cosmic-comp/issues/769
- https://github.com/pop-os/cosmic-comp/issues/698
- and probably some more similar issues

Essentially this tries to use common code for iterating through all of the surfaces/clients/whatever that can be rendered and receive input.

Unfortunately this means dropping `SplitRenderElements`, as that was/is a source of disagreement between the input-code (which doesn't have a similar method) and the render-code.

As such this duplicates a bit of code, but usually the popup code path is much shorter anyway, so we introduce separate code paths for popups and toplevels all over.

This also cleans up some of the code introduced as part of the focus-follows-cursor (and vise versa) mode, which duplicated some more of the input logic. Everything should now either use `State::surface_under` or `State::element_under` depending if it would affect pointer or keyboard focus.

Initial tests seem promising and don't show any obvious breakage, however this definitely needs more testing and possibly some in-depth reviews, though I would ideally like to merge this before it starts to seriously bitrot.