### PR TITLE
Fixes for behavior when workspaces are moved back to on output on hotplug

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -678,6 +678,9 @@ impl Workspaces {
             if set.workspaces.is_empty() {
                 set.add_empty_workspace(workspace_state);
             }
+            for (i, workspace) in set.workspaces.iter_mut().enumerate() {
+                workspace_set_idx(workspace_state, i as u8 + 1, set.idx, &workspace.handle);
+            }
             set.active = set
                 .workspaces
                 .iter()

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -729,13 +729,17 @@ impl Workspaces {
                 let new_set = self.sets.get_mut(&new_output).unwrap();
                 let workspace_group = new_set.group;
                 for mut workspace in set.workspaces.into_iter() {
-                    // update workspace protocol state
-                    move_workspace_to_group(&mut workspace, &workspace_group, workspace_state);
+                    if workspace.is_empty() {
+                        workspace_state.remove_workspace(workspace.handle);
+                    } else {
+                        // update workspace protocol state
+                        move_workspace_to_group(&mut workspace, &workspace_group, workspace_state);
 
-                    // update mapping
-                    workspace.set_output(&new_output);
-                    workspace.refresh(xdg_activation_state);
-                    new_set.workspaces.push(workspace);
+                        // update mapping
+                        workspace.set_output(&new_output);
+                        workspace.refresh(xdg_activation_state);
+                        new_set.workspaces.push(workspace);
+                    }
                 }
 
                 for window in set.sticky_layer.mapped() {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -668,6 +668,7 @@ impl Workspaces {
         self.sets.insert(output.clone(), set);
         let mut moved_workspaces = Vec::new();
         for set in self.sets.values_mut() {
+            let active_handle = set.workspaces[set.active].handle;
             let (prefers, doesnt) = set
                 .workspaces
                 .drain(..)
@@ -677,7 +678,11 @@ impl Workspaces {
             if set.workspaces.is_empty() {
                 set.add_empty_workspace(workspace_state);
             }
-            set.active = set.active.min(set.workspaces.len() - 1);
+            set.active = set
+                .workspaces
+                .iter()
+                .position(|w| w.handle == active_handle)
+                .unwrap_or(set.workspaces.len() - 1);
         }
         {
             let set = self.sets.get_mut(output).unwrap();

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -668,11 +668,11 @@ impl Workspaces {
         self.sets.insert(output.clone(), set);
         let mut moved_workspaces = Vec::new();
         for set in self.sets.values_mut() {
-            let (preferrs, doesnt) = set
+            let (prefers, doesnt) = set
                 .workspaces
                 .drain(..)
-                .partition(|w| w.preferrs_output(output));
-            moved_workspaces.extend(preferrs);
+                .partition(|w| w.prefers_output(output));
+            moved_workspaces.extend(prefers);
             set.workspaces = doesnt;
             if set.workspaces.is_empty() {
                 set.add_empty_workspace(workspace_state);

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -419,22 +419,6 @@ impl WorkspaceSet {
         theme: cosmic::Theme,
     ) -> WorkspaceSet {
         let group_handle = state.create_workspace_group();
-        let workspaces = {
-            let workspace = create_workspace(
-                state,
-                output,
-                &group_handle,
-                true,
-                tiling_enabled,
-                theme.clone(),
-            );
-            workspace_set_idx(state, 1, idx, &workspace.handle);
-            state.set_workspace_capabilities(
-                &workspace.handle,
-                [WorkspaceCapabilities::Activate].into_iter(),
-            );
-            vec![workspace]
-        };
         let sticky_layer = FloatingLayout::new(theme.clone(), output);
 
         WorkspaceSet {
@@ -446,7 +430,7 @@ impl WorkspaceSet {
             theme,
             sticky_layer,
             minimized_windows: Vec::new(),
-            workspaces,
+            workspaces: Vec::new(),
             output: output.clone(),
         }
     }
@@ -698,6 +682,9 @@ impl Workspaces {
             move_workspace_to_group(workspace, &set.group, workspace_state);
         }
         set.workspaces.extend(moved_workspaces);
+        if set.workspaces.is_empty() {
+            set.add_empty_workspace(workspace_state);
+        }
         for (i, workspace) in set.workspaces.iter_mut().enumerate() {
             workspace.set_output(output);
             workspace.refresh(xdg_activation_state);

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -374,7 +374,7 @@ impl Workspace {
         self.output = output.clone();
     }
 
-    pub fn preferrs_output(&self, output: &Output) -> bool {
+    pub fn prefers_output(&self, output: &Output) -> bool {
         self.output_stack.contains(&output.name())
     }
 

--- a/src/wayland/protocols/screencopy.rs
+++ b/src/wayland/protocols/screencopy.rs
@@ -139,14 +139,10 @@ impl Session {
             let node = Vec::from(dma.node.dev_id().to_ne_bytes());
             self.obj.dmabuf_device(node);
             for (fmt, modifiers) in &dma.formats {
-                let mut modifiers = modifiers.clone();
-                let modifiers: Vec<u8> = {
-                    let ptr = modifiers.as_mut_ptr() as *mut u8;
-                    let len = modifiers.len() * 4;
-                    let cap = modifiers.capacity() * 4;
-                    std::mem::forget(modifiers);
-                    unsafe { Vec::from_raw_parts(ptr, len, cap) }
-                };
+                let modifiers = modifiers
+                    .iter()
+                    .flat_map(|modifier| u64::from(*modifier).to_ne_bytes())
+                    .collect::<Vec<u8>>();
                 self.obj.dmabuf_format(*fmt as u32, modifiers);
             }
         }
@@ -249,14 +245,10 @@ impl CursorSession {
                 let node = Vec::from(dma.node.dev_id().to_ne_bytes());
                 session_obj.dmabuf_device(node);
                 for (fmt, modifiers) in &dma.formats {
-                    let mut modifiers = modifiers.clone();
-                    let modifiers: Vec<u8> = {
-                        let ptr = modifiers.as_mut_ptr() as *mut u8;
-                        let len = modifiers.len() * 4;
-                        let cap = modifiers.capacity() * 4;
-                        std::mem::forget(modifiers);
-                        unsafe { Vec::from_raw_parts(ptr, len, cap) }
-                    };
+                    let modifiers = modifiers
+                        .iter()
+                        .flat_map(|modifier| u64::from(*modifier).to_ne_bytes())
+                        .collect::<Vec<u8>>();
                     session_obj.dmabuf_format(*fmt as u32, modifiers);
                 }
             }
@@ -747,14 +739,10 @@ where
                         let node = Vec::from(dma.node.dev_id().to_ne_bytes());
                         session.dmabuf_device(node);
                         for (fmt, modifiers) in &dma.formats {
-                            let mut modifiers = modifiers.clone();
-                            let modifiers: Vec<u8> = {
-                                let ptr = modifiers.as_mut_ptr() as *mut u8;
-                                let len = modifiers.len() * 4;
-                                let cap = modifiers.capacity() * 4;
-                                std::mem::forget(modifiers);
-                                unsafe { Vec::from_raw_parts(ptr, len, cap) }
-                            };
+                            let modifiers = modifiers
+                                .iter()
+                                .flat_map(|modifier| u64::from(*modifier).to_ne_bytes())
+                                .collect::<Vec<u8>>();
                             session.dmabuf_format(*fmt as u32, modifiers);
                         }
                     }

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -509,14 +509,10 @@ where
         }
         handle_state.states = states.clone();
 
-        let states: Vec<u8> = {
-            let ratio = std::mem::size_of::<States>() / std::mem::size_of::<u8>();
-            let ptr = states.as_mut_ptr() as *mut u8;
-            let len = states.len() * ratio;
-            let cap = states.capacity() * ratio;
-            std::mem::forget(states);
-            unsafe { Vec::from_raw_parts(ptr, len, cap) }
-        };
+        let states = states
+            .iter()
+            .flat_map(|state| (*state as u32).to_ne_bytes())
+            .collect::<Vec<u8>>();
         instance.state(states);
         changed = true;
     }

--- a/src/wayland/protocols/toplevel_management.rs
+++ b/src/wayland/protocols/toplevel_management.rs
@@ -151,15 +151,13 @@ where
         data_init: &mut DataInit<'_, D>,
     ) {
         let instance = data_init.init(resource, ());
-        let capabilities = {
-            let mut caps = state.toplevel_management_state().capabilities.clone();
-            let ratio = std::mem::size_of::<ManagementCapabilities>() / std::mem::size_of::<u8>();
-            let ptr = caps.as_mut_ptr() as *mut u8;
-            let len = caps.len() * ratio;
-            let cap = caps.capacity() * ratio;
-            std::mem::forget(caps);
-            unsafe { Vec::from_raw_parts(ptr, len, cap) }
-        };
+        let capabilities = state
+            .toplevel_management_state()
+            .capabilities
+            .iter()
+            .flat_map(|cap| (*cap as u32).to_ne_bytes())
+            .collect::<Vec<u8>>();
+
         instance.capabilities(capabilities);
         state.toplevel_management_state().instances.push(instance);
     }

--- a/src/wayland/protocols/workspace.rs
+++ b/src/wayland/protocols/workspace.rs
@@ -929,15 +929,11 @@ where
     }
 
     if handle_state.capabilities != group.capabilities {
-        let caps: Vec<u8> = {
-            let mut caps = group.capabilities.clone();
-            let ratio = std::mem::size_of::<GroupCapabilities>() / std::mem::size_of::<u8>();
-            let ptr = caps.as_mut_ptr() as *mut u8;
-            let len = caps.len() * ratio;
-            let cap = caps.capacity() * ratio;
-            std::mem::forget(caps);
-            unsafe { Vec::from_raw_parts(ptr, len, cap) }
-        };
+        let caps = group
+            .capabilities
+            .iter()
+            .flat_map(|cap| (*cap as u32).to_ne_bytes())
+            .collect::<Vec<u8>>();
         instance.capabilities(caps);
         handle_state.capabilities = group.capabilities.clone();
         changed = true;
@@ -1005,44 +1001,31 @@ where
         changed = true;
     }
     if handle_state.coordinates != workspace.coordinates {
-        let coords: Vec<u8> = {
-            let mut coords = workspace.coordinates.clone();
-            let ratio = std::mem::size_of::<u32>() / std::mem::size_of::<u8>();
-            let ptr = coords.as_mut_ptr() as *mut u8;
-            let len = coords.len() * ratio;
-            let cap = coords.capacity() * ratio;
-            std::mem::forget(coords);
-            unsafe { Vec::from_raw_parts(ptr, len, cap) }
-        };
+        let coords = workspace
+            .coordinates
+            .iter()
+            .flat_map(|coord| coord.to_ne_bytes())
+            .collect::<Vec<u8>>();
         instance.coordinates(coords);
         handle_state.coordinates = workspace.coordinates.clone();
         changed = true;
     }
     if handle_state.capabilities != workspace.capabilities {
-        let caps: Vec<u8> = {
-            let mut caps = workspace.capabilities.clone();
-            let ratio = std::mem::size_of::<WorkspaceCapabilities>() / std::mem::size_of::<u8>();
-            let ptr = caps.as_mut_ptr() as *mut u8;
-            let len = caps.len() * ratio;
-            let cap = caps.capacity() * ratio;
-            std::mem::forget(caps);
-            unsafe { Vec::from_raw_parts(ptr, len, cap) }
-        };
+        let caps = workspace
+            .capabilities
+            .iter()
+            .flat_map(|cap| (*cap as u32).to_ne_bytes())
+            .collect::<Vec<u8>>();
         instance.capabilities(caps);
         handle_state.capabilities = workspace.capabilities.clone();
         changed = true;
     }
     if handle_state.states != workspace.states {
-        let states: Vec<u8> = {
-            let mut states = workspace.states.iter().cloned().collect::<Vec<_>>();
-            let ratio = std::mem::size_of::<zcosmic_workspace_handle_v1::State>()
-                / std::mem::size_of::<u8>();
-            let ptr = states.as_mut_ptr() as *mut u8;
-            let len = states.len() * ratio;
-            let cap = states.capacity() * ratio;
-            std::mem::forget(states);
-            unsafe { Vec::from_raw_parts(ptr, len, cap) }
-        };
+        let states = workspace
+            .states
+            .iter()
+            .flat_map(|state| (*state as u32).to_ne_bytes())
+            .collect::<Vec<u8>>();
         instance.state(states);
         handle_state.states = workspace.states.clone();
         changed = true;


### PR DESCRIPTION
I've been annoyed by how this adds an empty initial workspace which ends up focused instead of one of the non-empty ones. For some reason that's still happening... I also see some other things that could be fixed.

It seems there also is (sometimes?) an issue where a window becomes unresponsive after being moved. Probably a frame callback issue... I need to look into that more.