### PR TITLE
[Menu] Use corner radius from theme

### DIFF
--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -441,7 +441,7 @@ impl Program for ContextMenu {
                 text_color: Some(component.on.into()),
                 background: Some(Background::Color(component.base.into())),
                 border: Border {
-                    radius: 8.0.into(),
+                    radius: cosmic.radius_s().into(),
                     width: 1.0,
                     color: component.divider.into(),
                 },


### PR DESCRIPTION
Just makes the context menu use `@radius_s` for the corner radius, to match the highlight for items inside.
I also tried to make the stack header do the same, but it didn't seem to pick up roundness changes.