### PR TITLE
design: use active_window_hint as the thickness for floating window snap outline

### DIFF
--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -145,6 +145,7 @@ impl MoveGrabState {
         };
 
         let gaps = (theme.gaps.0 as i32, theme.gaps.1 as i32);
+        let thickness = self.indicator_thickness.max(1);
 
         let snapping_indicator = match &self.snapping_zone {
             Some(t) if &self.cursor_output == output => {
@@ -155,7 +156,7 @@ impl MoveGrabState {
                         renderer,
                         Key::Window(Usage::SnappingIndicator, self.window.key()),
                         overlay_geometry,
-                        3,
+                        thickness,
                         theme.radius_s()[0] as u8, // TODO: Fix once shaders support 4 corner radii customization
                         1.0,
                         output_scale.x,


### PR DESCRIPTION
This commit changes the snapping indicator's thickness to match the active window hint, per design recommendation by Maria. The thickness for this outline never goes under 1, also per Maria's spec.

![screenshot-2024-11-06-02-53-33](https://github.com/user-attachments/assets/aa768939-0f6c-496d-b7f8-97c792d8bf2b)
