### PR TITLE
WIP atspi: `add_virtual_modifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#ec1616b90fa6b4568709cfe2c0627b1e8cc887e0"
+source = "git+https://github.com/pop-os/cosmic-protocols?branch=virtual-mods#604f50abccb91583567555ebe4377cd02f8360ce"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = "1.12"
 calloop = {version = "0.14.1", features = ["executor"]}
 cosmic-comp-config = {path = "cosmic-comp-config"}
 cosmic-config = {git = "https://github.com/pop-os/libcosmic/", features = ["calloop", "macro"]}
-cosmic-protocols = {git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"]}
+cosmic-protocols = {git = "https://github.com/pop-os/cosmic-protocols", branch = "virtual-mods", default-features = false, features = ["server"]}
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
 edid-rs = {version = "0.1"}
 egui = {version = "0.29.0", optional = true}

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -307,7 +307,9 @@ impl State {
                         let surface = device.surfaces.remove(&crtc).unwrap();
                         if surface.output.mirroring().is_none() {
                             // TODO: move up later outputs?
-                            w = w.saturating_sub(surface.output.config().transformed_size().w as u32);
+                            w = w.saturating_sub(
+                                surface.output.config().transformed_size().w as u32,
+                            );
                         }
                     }
 

--- a/src/wayland/protocols/atspi.rs
+++ b/src/wayland/protocols/atspi.rs
@@ -18,6 +18,16 @@ pub trait AtspiHandler {
         key_event_socket: UnixStream,
     );
     fn client_disconnected(&mut self, manager: &cosmic_atspi_manager_v1::CosmicAtspiManagerV1);
+    fn add_virtual_modifier(
+        &mut self,
+        manager: &cosmic_atspi_manager_v1::CosmicAtspiManagerV1,
+        key: Keycode,
+    );
+    fn remove_virtual_modifier(
+        &mut self,
+        manager: &cosmic_atspi_manager_v1::CosmicAtspiManagerV1,
+        key: Keycode,
+    );
     fn add_key_grab(
         &mut self,
         manager: &cosmic_atspi_manager_v1::CosmicAtspiManagerV1,
@@ -48,7 +58,7 @@ impl AtspiState {
         F: for<'a> Fn(&'a Client) -> bool + Send + Sync + 'static,
     {
         let global = dh.create_global::<D, cosmic_atspi_manager_v1::CosmicAtspiManagerV1, _>(
-            1,
+            2,
             AtspiGlobalData {
                 filter: Box::new(client_filter),
             },
@@ -133,6 +143,12 @@ where
             }
             cosmic_atspi_manager_v1::Request::UngrabKeyboard => {
                 state.ungrab_keyboard(manager);
+            }
+            cosmic_atspi_manager_v1::Request::AddVirtualModifier { key } => {
+                state.add_virtual_modifier(manager, (key + 8).into());
+            }
+            cosmic_atspi_manager_v1::Request::RemoveVirtualModifier { key } => {
+                state.remove_virtual_modifier(manager, (key + 8).into());
             }
             cosmic_atspi_manager_v1::Request::Destroy => {}
             _ => unreachable!(),


### PR DESCRIPTION
https://github.com/pop-os/cosmic-protocols/pull/41, https://github.com/pop-os/at-spi2-core/pull/1.

There seems to be a race condition in Orca where it removes all key grabs, then adds a new set of key grabs. As this previously worked, this briefly removed the virtual modifier, which could result in a keypress being sent. (Which could send a caps lock.)

I need to do more testing, and see how other things are working and what other improvements may help, but this seems like a good idea. The virtual modifier is added once at the start.

The fact key input can race with orca/compositor changes to grabs seems bad in general, but I guess that's a limitation of how `AtspiDevice` is currently designed.