### PR TITLE
Recalculate tiling layout on change of display configuration

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -358,6 +358,9 @@ impl BackendData {
             self.schedule_render(&output);
         }
 
+        // Update layout for changes in resolution, scale, orientation
+        shell.workspaces.recalculate();
+
         loop_handle.insert_idle(|state| state.common.update_xwayland_scale());
 
         Ok(())


### PR DESCRIPTION
Previously, changing the resolution, scale, or orientation of a display left tiling layouts that don't fill the screen and/or extend off of the screen area, until an action like opening a window makes it recalculate window positions.

Now this is done immediately when the output configuration changes.

Perhaps we should consider if we want a different animation for things like rotating a screen, but the current behavior isn't too bad.

For floating layouts, `refresh` already remaps windows that are out of bounds for the output, so this doesn't change that. Perhaps decreasing the resolution (or moving to a lower resolution output) should try to reduce the window size. But the current behavior generally seems okay.