### PR TITLE
fix: apply transform to damage before blitting

### DIFF
--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1205,13 +1205,23 @@ impl SurfaceThreadState {
                                     .into_iter()
                                     .flatten();
 
+                                // If the screen is rotated, we must convert damage to match output.
+                                let adjusted = damage.iter().copied().map(|mut d| {
+                                    d.size = d
+                                        .size
+                                        .to_logical(1)
+                                        .to_buffer(1, output_transform)
+                                        .to_logical(1, Transform::Normal)
+                                        .to_physical(1);
+                                    d
+                                });
                                 match frame_result
                                     .blit_frame_result(
                                         output_size,
                                         output_transform,
                                         output_scale,
                                         &mut renderer,
-                                        damage.iter().copied(),
+                                        adjusted,
                                         filter,
                                     )
                                     .map_err(|err| match err {


### PR DESCRIPTION
There seems to be something off about the types of damage being passed around for screencopy. The screencopy damage is clipped because it isn't rotated, so for a rotated screen 1920x1080, it becomes 1080x1080 in `blit_frame_result` when intersected with the dmabuf geometry.  This fix can be tested with https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/105 but this is really just a bandaid. Maybe `blit_frame_result` shouldn't be taking physical damage, because it copies buffer to buffer? I think the dmabuf geometry  used in `blit_frame_result` seems like it should be Buffer too, but I'm not as familiar with smithay.