### PR TITLE
Use new primary scanout output if old output is disabled

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -38,7 +38,7 @@ use smithay::{
         renderer::{
             element::{
                 default_primary_scanout_output_compare, utils::select_dmabuf_feedback,
-                RenderElementStates,
+                RenderElementState, RenderElementStates,
             },
             ImportDma,
         },
@@ -649,6 +649,19 @@ impl State {
     }
 }
 
+fn primary_scanout_output_compare<'a>(
+    current_output: &'a Output,
+    current_state: &RenderElementState,
+    next_output: &'a Output,
+    next_state: &RenderElementState,
+) -> &'a Output {
+    if !crate::wayland::protocols::output_configuration::head_is_enabled(current_output) {
+        return next_output;
+    }
+
+    default_primary_scanout_output_compare(current_output, current_state, next_output, next_state)
+}
+
 impl Common {
     pub fn update_primary_output(
         &self,
@@ -662,7 +675,7 @@ impl Common {
                 output,
                 states,
                 render_element_states,
-                default_primary_scanout_output_compare,
+                primary_scanout_output_compare,
             );
             if let Some(output) = primary_scanout_output {
                 with_fractional_scale(states, |fraction_scale| {

--- a/src/wayland/protocols/output_configuration/mod.rs
+++ b/src/wayland/protocols/output_configuration/mod.rs
@@ -27,6 +27,13 @@ use std::{convert::TryFrom, sync::Mutex};
 
 mod handlers;
 
+pub fn head_is_enabled(output: &Output) -> bool {
+    output
+        .user_data()
+        .get::<OutputState>()
+        .map_or(false, |inner| inner.lock().unwrap().enabled)
+}
+
 #[derive(Debug)]
 pub struct OutputConfigurationState<D> {
     outputs: Vec<Output>,


### PR DESCRIPTION
`Output` in Smithay doesn't track if the output still exists, other than based on whether or not it has strong references. Which doesn't seem to be working correctly.

There may be leaked strong references to `Output`s somewhere, and maybe Smithay should track if an output is still valid, generally when it is exposed as a Wayland global
(https://github.com/Smithay/smithay/issues/1584). But a check like this works for now.

Addresses https://github.com/pop-os/cosmic-comp/issues/985.