### PR TITLE
Reactivate after output switch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,49 +6,65 @@ name = "cosmic-comp"
 version = "0.1.0"
 
 [workspace]
-members = [
-  "cosmic-comp-config",
-]
+members = ["cosmic-comp-config"]
 
 [dependencies]
-anyhow = {version = "1.0.51", features = ["backtrace"]}
+anyhow = { version = "1.0.51", features = ["backtrace"] }
 bitflags = "2.4"
 bytemuck = "1.12"
-calloop = {version = "0.14.1", features = ["executor"]}
-cosmic-comp-config = {path = "cosmic-comp-config"}
-cosmic-config = {git = "https://github.com/pop-os/libcosmic/", features = ["calloop", "macro"]}
-cosmic-protocols = {git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = ["server"]}
+calloop = { version = "0.14.1", features = ["executor"] }
+cosmic-comp-config = { path = "cosmic-comp-config" }
+cosmic-config = { git = "https://github.com/pop-os/libcosmic/", features = [
+  "calloop",
+  "macro",
+] }
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = [
+  "server",
+] }
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
-edid-rs = {version = "0.1"}
-egui = {version = "0.29.0", optional = true}
-egui_plot = {version = "0.29.0", optional = true}
+edid-rs = { version = "0.1" }
+egui = { version = "0.29.0", optional = true }
+egui_plot = { version = "0.29.0", optional = true }
 glow = "0.12.0"
-i18n-embed = {version = "0.14", features = ["fluent-system", "desktop-requester"]}
+i18n-embed = { version = "0.14", features = [
+  "fluent-system",
+  "desktop-requester",
+] }
 i18n-embed-fl = "0.8"
-iced_tiny_skia = {git = "https://github.com/pop-os/libcosmic/"}
+iced_tiny_skia = { git = "https://github.com/pop-os/libcosmic/" }
 indexmap = "2.0"
 keyframe = "1.1.1"
 lazy_static = "1.4.0"
 libc = "0.2.149"
-libcosmic = {git = "https://github.com/pop-os/libcosmic/", default-features = false}
-libsystemd = {version = "0.7", optional = true}
-log-panics = {version = "2", features = ["with-backtrace"]}
+libcosmic = { git = "https://github.com/pop-os/libcosmic/", default-features = false }
+libsystemd = { version = "0.7", optional = true }
+log-panics = { version = "2", features = ["with-backtrace"] }
 once_cell = "1.18.0"
 ordered-float = "4.0"
 png = "0.17.5"
 regex = "1"
 ron = "0.8"
-rust-embed = {version = "8.0", features = ["debug-embed"]}
+rust-embed = { version = "8.0", features = ["debug-embed"] }
 sanitize-filename = "0.5.0"
 sendfd = "0.4.1"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0.26"
-time = {version = "0.3.30", features = ["macros", "formatting", "local-offset"]}
+time = { version = "0.3.30", features = [
+  "macros",
+  "formatting",
+  "local-offset",
+] }
 tiny-skia = "0.11"
-tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
+tracing = { version = "0.1.37", features = [
+  "max_level_debug",
+  "release_max_level_info",
+] }
 tracing-journald = "0.3.0"
-tracing-subscriber = {version = "0.3.16", features = ["env-filter", "tracing-log"]}
+tracing-subscriber = { version = "0.3.16", features = [
+  "env-filter",
+  "tracing-log",
+] }
 wayland-backend = "0.3.3"
 wayland-scanner = "0.31.1"
 xcursor = "0.3.3"
@@ -116,7 +132,7 @@ debug = true
 inherits = "release"
 
 [profile.release]
-lto = "fat"
+opt-level = 2
 
 [patch."https://github.com/Smithay/smithay.git"]
 smithay = { git = "https://github.com/smithay//smithay", rev = "bc1d732" }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -403,6 +403,7 @@ impl State {
                         &mut self.common.workspace_state.update(),
                     );
                     seat.set_active_output(&next_output);
+                    shell.swapped_output = true;
 
                     if let Ok(Some(new_pos)) = res {
                         let new_target = shell
@@ -490,6 +491,7 @@ impl State {
                         &mut self.common.workspace_state.update(),
                     );
                     seat.set_active_output(&next_output);
+                    shell.swapped_output = true;
 
                     if let Ok(Some(new_pos)) = res {
                         let new_target = shell
@@ -549,6 +551,7 @@ impl State {
                         &mut self.common.workspace_state.update(),
                     );
                     seat.set_active_output(&prev_output);
+                    shell.swapped_output = true;
 
                     if let Ok(Some(new_pos)) = res {
                         let new_target = shell

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -507,6 +507,7 @@ impl State {
                             session.set_cursor_pos(None);
                         }
                         seat.set_active_output(&output);
+                        shell.swapped_output = true;
                     }
 
                     for session in cursor_sessions_for_output(&shell, &output) {

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -203,7 +203,7 @@ impl Shell {
                 m.window.configure();
             }
 
-            let workspace = self.workspaces.active_mut(&output);
+            let workspace = &mut set.workspaces[set.active];
             for focused in focused_windows.iter() {
                 raise_with_children(&mut workspace.floating_layer, focused);
             }
@@ -214,6 +214,16 @@ impl Shell {
             for m in workspace.minimized_windows.iter() {
                 m.window.set_activated(false);
                 m.window.configure();
+            }
+
+            for (i, workspace) in set.workspaces.iter().enumerate() {
+                if i == set.active {
+                    continue;
+                }
+                for window in workspace.mapped() {
+                    window.set_activated(false);
+                    window.configure();
+                }   
             }
         }
     }

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -59,14 +59,17 @@ impl ToplevelManagementHandler for State {
                     WorkspaceDelta::new_shortcut(),
                     &mut self.common.workspace_state.update(),
                 );
-                std::mem::drop(shell);
 
                 if seat.active_output() != *output {
                     match res {
                         Ok(Some(new_pos)) => {
                             seat.set_active_output(&output);
+                            shell.swapped_output = true;
+                            std::mem::drop(shell);
+
                             if let Some(ptr) = seat.get_pointer() {
                                 let serial = SERIAL_COUNTER.next_serial();
+
                                 ptr.motion(
                                     self,
                                     None,
@@ -81,9 +84,15 @@ impl ToplevelManagementHandler for State {
                         }
                         Ok(None) => {
                             seat.set_active_output(&output);
+                            shell.swapped_output = true;
+                            std::mem::drop(shell);
                         }
-                        _ => {}
+                        _ => {
+                            std::mem::drop(shell);
+                        }
                     }
+                } else {
+                    std::mem::drop(shell);
                 }
 
                 mapped.focus_window(window);


### PR DESCRIPTION
Alt tab relies on changes to the activated state, but if there is a single window on each output, they are always activated. This forces activation state changes so that the events are sent to indicate the focus change if an output changes and the newly focused window is already activated. This should work properly with https://github.com/pop-os/cosmic-launcher/pull/225 & https://github.com/pop-os/launcher/pull/249. 

I think there is a cleaner way of doing this if toplevel's also had a focused state, which could only ever set for one window at a time. but this works if we want to avoid adding something like that.