### PR TITLE
fix: activation of an element outside the current workspace

### DIFF
--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -152,7 +152,7 @@ impl XdgActivationHandler for State {
                             }
                         }
 
-                        if workspace == &current_workspace.handle || in_current_workspace {
+                        if in_current_workspace {
                             let target = element.into();
 
                             std::mem::drop(shell);


### PR DESCRIPTION
If the activated element is outside the current workspace, its workspace should be set to urgent