### PR TITLE
WIP: Postprocess shader support

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -2,7 +2,7 @@
 
 use cosmic_config::{cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 pub mod input;
 pub mod workspace;
@@ -48,6 +48,8 @@ pub struct CosmicCompConfig {
     pub descale_xwayland: bool,
     /// The threshold before windows snap themselves to output edges
     pub edge_snap_threshold: u32,
+    /// Path to postprocess shader applied to whole screen
+    pub postprocess_shader_path: Option<PathBuf>,
 }
 
 impl Default for CosmicCompConfig {
@@ -79,6 +81,7 @@ impl Default for CosmicCompConfig {
             focus_follows_cursor_delay: 250,
             descale_xwayland: false,
             edge_snap_threshold: 0,
+            postprocess_shader_path: None,
         }
     }
 }

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -266,6 +266,7 @@ impl State {
 
         {
             for (conn, maybe_crtc) in connectors {
+                let postprocess_shader = self.backend.kms().postprocess_shader.clone();
                 match device.connector_added(
                     self.backend.kms().primary_node.as_ref(),
                     conn,
@@ -274,6 +275,7 @@ impl State {
                     &self.common.event_loop_handle,
                     self.common.shell.clone(),
                     self.common.startup_done.clone(),
+                    postprocess_shader,
                 ) {
                     Ok((output, should_expose)) => {
                         if should_expose {
@@ -359,6 +361,7 @@ impl State {
                 }
 
                 for (conn, maybe_crtc) in changes.added {
+                    let postprocess_shader = backend.postprocess_shader.clone();
                     match device.connector_added(
                         backend.primary_node.as_ref(),
                         conn,
@@ -367,6 +370,7 @@ impl State {
                         &self.common.event_loop_handle,
                         self.common.shell.clone(),
                         self.common.startup_done.clone(),
+                        postprocess_shader,
                     ) {
                         Ok((output, should_expose)) => {
                             if should_expose {
@@ -518,6 +522,7 @@ impl Device {
         evlh: &LoopHandle<'static, State>,
         shell: Arc<RwLock<Shell>>,
         startup_done: Arc<AtomicBool>,
+        postprocess_shader: Option<String>,
     ) -> Result<(Output, bool)> {
         let output = self
             .outputs
@@ -582,7 +587,8 @@ impl Device {
                     shell,
                     startup_done,
                 ) {
-                    Ok(data) => {
+                    Ok(mut data) => {
+                        data.set_postprocess_shader(postprocess_shader);
                         self.surfaces.insert(crtc, data);
                         true
                     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -96,6 +96,25 @@ pub fn init_backend_auto(
             const NUMLOCK_SCANCODE: u32 = 69;
             crate::config::change_modifier_state(&keyboard, NUMLOCK_SCANCODE, state);
         }
+
+        // TODO
+        if let Some(shader_path) = state
+            .common
+            .config
+            .cosmic_conf
+            .postprocess_shader_path
+            .as_ref()
+        {
+            match std::fs::read_to_string(shader_path) {
+                Ok(shader) => {
+                    state.backend.update_postprocess_shader(Some(&shader));
+                }
+                Err(_) => {
+                    tracing::error!("failed to read shader at path: {}", shader_path.display());
+                }
+            }
+        }
+
         {
             {
                 state

--- a/src/backend/render/element.rs
+++ b/src/backend/render/element.rs
@@ -203,35 +203,29 @@ where
                 RenderElement::<R>::draw(elem, frame, src, dst, damage, opaque_regions)
             }
             CosmicElement::Mirror(elem) => {
-                let elem = {
-                    let glow_frame = R::glow_frame_mut(frame);
-                    RenderElement::<GlowRenderer>::draw(
-                        elem,
-                        glow_frame,
-                        src,
-                        dst,
-                        damage,
-                        opaque_regions,
-                    )
-                    .map_err(FromGlesError::from_gles_error)
-                };
-                elem
+                let glow_frame = R::glow_frame_mut(frame);
+                RenderElement::<GlowRenderer>::draw(
+                    elem,
+                    glow_frame,
+                    src,
+                    dst,
+                    damage,
+                    opaque_regions,
+                )
+                .map_err(FromGlesError::from_gles_error)
             }
             #[cfg(feature = "debug")]
             CosmicElement::Egui(elem) => {
-                let elem = {
-                    let glow_frame = R::glow_frame_mut(frame);
-                    RenderElement::<GlowRenderer>::draw(
-                        elem,
-                        glow_frame,
-                        src,
-                        dst,
-                        damage,
-                        opaque_regions,
-                    )
-                    .map_err(FromGlesError::from_gles_error)
-                };
-                elem
+                let glow_frame = R::glow_frame_mut(frame);
+                RenderElement::<GlowRenderer>::draw(
+                    elem,
+                    glow_frame,
+                    src,
+                    dst,
+                    damage,
+                    opaque_regions,
+                )
+                .map_err(FromGlesError::from_gles_error)
             }
         }
     }
@@ -245,22 +239,12 @@ where
             CosmicElement::AdditionalDamage(elem) => elem.underlying_storage(renderer),
             CosmicElement::Mirror(elem) => {
                 let glow_renderer = renderer.glow_renderer_mut();
-                match elem.underlying_storage(glow_renderer) {
-                    Some(UnderlyingStorage::Wayland(buffer)) => {
-                        Some(UnderlyingStorage::Wayland(buffer))
-                    }
-                    _ => None,
-                }
+                elem.underlying_storage(glow_renderer)
             }
             #[cfg(feature = "debug")]
             CosmicElement::Egui(elem) => {
                 let glow_renderer = renderer.glow_renderer_mut();
-                match elem.underlying_storage(glow_renderer) {
-                    Some(UnderlyingStorage::Wayland(buffer)) => {
-                        Some(UnderlyingStorage::Wayland(buffer))
-                    }
-                    _ => None,
-                }
+                elem.underlying_storage(glow_renderer)
             }
         }
     }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -34,7 +34,7 @@ use smithay::{
 use std::{borrow::BorrowMut, cell::RefCell, time::Duration};
 use tracing::{error, info, warn};
 
-use super::render::{init_shaders, CursorMode};
+use super::render::{init_shaders, update_postprocess_shader, CursorMode};
 
 #[derive(Debug)]
 pub struct WinitState {
@@ -124,6 +124,10 @@ impl WinitState {
         } else {
             Ok(vec![self.output.clone()])
         }
+    }
+
+    pub fn update_postprocess_shader(&mut self, shader: Option<&str>) {
+        update_postprocess_shader(self.backend.renderer().borrow_mut(), shader)
     }
 }
 

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -41,7 +41,7 @@ use smithay::{
 use std::{borrow::BorrowMut, cell::RefCell, os::unix::io::OwnedFd, time::Duration};
 use tracing::{debug, error, info, warn};
 
-use super::render::init_shaders;
+use super::render::{init_shaders, update_postprocess_shader};
 
 #[derive(Debug)]
 enum Allocator {
@@ -186,6 +186,10 @@ impl X11State {
         } else {
             Ok(vec![surface.output.clone()])
         }
+    }
+
+    pub fn update_postprocess_shader(&mut self, shader: Option<&str>) {
+        update_postprocess_shader(self.renderer.borrow_mut(), shader)
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -852,6 +852,22 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                     state.common.config.cosmic_conf.edge_snap_threshold = new;
                 }
             }
+            "postprocess_shader_path" => {
+                let new = get_config::<Option<PathBuf>>(&config, "postprocess_shader_path");
+                if new != state.common.config.cosmic_conf.postprocess_shader_path {
+                    let shader =
+                        new.as_ref()
+                            .and_then(|path| match std::fs::read_to_string(path) {
+                                Ok(shader) => Some(shader),
+                                Err(_) => {
+                                    error!("failed to read shader at path: {}", path.display());
+                                    None
+                                }
+                            });
+                    state.backend.update_postprocess_shader(shader.as_deref());
+                    state.common.config.cosmic_conf.postprocess_shader_path = new;
+                }
+            }
             _ => {}
         }
     }

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -1366,12 +1366,7 @@ where
             #[cfg(feature = "debug")]
             CosmicMappedRenderElement::Egui(elem) => {
                 let glow_renderer = renderer.glow_renderer_mut();
-                match elem.underlying_storage(glow_renderer) {
-                    Some(UnderlyingStorage::Wayland(buffer)) => {
-                        Some(UnderlyingStorage::Wayland(buffer))
-                    }
-                    _ => None,
-                }
+                elem.underlying_storage(glow_renderer)
             }
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -441,6 +441,16 @@ impl BackendData {
             _ => unreachable!("No backend set when getting offscreen renderer"),
         }
     }
+
+    /// Set the GLES texture shader used for postprocessing
+    pub fn update_postprocess_shader(&mut self, shader: Option<&str>) {
+        match self {
+            BackendData::Kms(kms) => kms.update_postprocess_shader(shader),
+            BackendData::Winit(winit) => winit.update_postprocess_shader(shader),
+            BackendData::X11(x11) => x11.update_postprocess_shader(shader),
+            _ => unreachable!("No backend was initialized"),
+        }
+    }
 }
 
 pub struct KmsNodes {


### PR DESCRIPTION
This renames `MirroringState` to `OffscreenState`, which is now used for mirroring (with a different size) and/or postprocessing.

Currently a shader can be set by manually putting a shader path in `~/.config/cosmic/com.system76.CosmicComp/v1/postprocess_shader_path`. This can be modified from https://github.com/Smithay/smithay/blob/master/src/backend/renderer/gles/shaders/implicit/texture.frag.

This is handy for testing. It may be better to have an enum of default shaders for supported features. But it would be nice for development, debugging, and creative applications to be able to set a shader path, or store the shader directly in cosmic-config.

It seems that GL shaders can be shared between EGL contexts, but state like uniforms is part of the program, so only one thread should be using it at a time. So it seems we need to compile the program once per render device, per kms surface thread.

Getting this to work in the X11 and Winit backends is not hugely important, but I still need to try doing that. Shouldn't be too hard.

I wanted to refactor`SurfaceThreadState::redraw` into a couple parts, though when I tried that earlier, a couple things I tried ran into lifetime issues (some of which seem to be borrow checker bugs). I may try something else, but this doesn't complicate that function too much more in this version.

### Example uses

#### Invert color

We want to add an option for this in accessibility settings.
```glsl
color.rgb = 1.0 - color.rgb;
```

#### Greyscale

```glsl
float value = (color.r + color.g + color.b) / 3.0;
color = vec4(value, value, value, color.a);
```

More advanced methods of colorblindness simulation can be done with a process called "daltonization" based on the LMS color space, apparently. I haven't look into the exact formulate for different types of color blindness.

#### Color temperature

A hacky example just using an arbitrary hard-coded value from https://gitlab.com/chinstrap/gammastep/-/blob/master/src/colorramp.c:

```glsl
color.rgb *= vec3(1.00000000,  0.86860704,  0.73688797);
```

### Shader format

Instead of duplicating everything in `smithay/backend/renderer/gles/shaders/implicit/texture.frag`, we could accept shaders that are just a function mapping a color value to a color value. If that's all we need to support.

I guess `DEBUG_FLAGS` and `tint` shouldn't be used in a postprocess shader; only for normal rendering.

If we have multiple features that use postprocess shaders that should be possible to use simultaneously, we may need to combine them as one parameterized shader. Possibly we could also generate shader text chaining multiple separate functions in series. We definitely don't want to actually do multiple postprocess passes.

Some types of shaders (like color temperature) might benefit from a way to add custom uniforms. Not sure how we'd want to manage that.