### PR TITLE
When removing output global, use `disable_global`, remove with timer

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -499,7 +499,8 @@ impl State {
         let fractional_scale_state = FractionalScaleManagerState::new::<State>(dh);
         let keyboard_shortcuts_inhibit_state = KeyboardShortcutsInhibitState::new::<Self>(dh);
         let output_state = OutputManagerState::new_with_xdg_output::<Self>(dh);
-        let output_configuration_state = OutputConfigurationState::new(dh, client_is_privileged);
+        let output_configuration_state =
+            OutputConfigurationState::new(dh, handle.clone(), client_is_privileged);
         let output_power_state = OutputPowerState::new::<Self, _>(dh, client_is_privileged);
         let overlap_notify_state =
             OverlapNotifyState::new::<Self, _>(dh, client_has_no_security_context);


### PR DESCRIPTION
This should fix an issue where output hotplug can sometimes cause clients (including XWayland) to crash with a protocol error trying to bind the output.

Using a timer doesn't seem ideal, but seems to be the correct way to do this at present. Wlroots `wlr_global_destroy_safe` is basically the same as this.

Adding a `LoopHandle` argument to `OutputConfigurationState::new` seems awkward, but maybe better than a handler method for removing globals. (`IdleNotifierState::new` also takes a `LoopHandle`). Perhaps Smithay could provide some kind of helper for this.