### PR TITLE
Fixes for transformed outputs with mirroring

### DIFF
--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1112,7 +1112,8 @@ impl SurfaceThreadState {
                 None,
                 Kind::Unspecified,
             );
-            let texture_geometry = texture_elem.geometry(1.0.into());
+            let texture_geometry =
+                texture_elem.geometry(self.output.current_scale().fractional_scale().into());
             elements = constrain_render_elements(
                 std::iter::once(texture_elem),
                 (0, 0),


### PR DESCRIPTION
Also applicable to https://github.com/pop-os/cosmic-comp/pull/1058.

Looks like damage tracking for mirroring with output transforms isn't quite right either (before or after this) so some more fixes are needed.