### PR TITLE
refactor(shell/element): refactor how decorations height is accessed

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -94,9 +94,6 @@ struct Sticky(AtomicBool);
 #[derive(Default)]
 struct GlobalGeometry(Mutex<Option<Rectangle<i32, Global>>>);
 
-pub const SSD_HEIGHT: i32 = 36;
-pub const RESIZE_BORDER: i32 = 10;
-
 impl CosmicSurface {
     pub fn title(&self) -> String {
         match self.0.underlying_surface() {
@@ -451,7 +448,7 @@ impl CosmicSurface {
         }
     }
 
-    pub fn min_size(&self) -> Option<Size<i32, Logical>> {
+    pub fn min_size_without_ssd(&self) -> Option<Size<i32, Logical>> {
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
                 Some(with_states(toplevel.wl_surface(), |states| {
@@ -465,16 +462,9 @@ impl CosmicSurface {
             }
             WindowSurface::X11(surface) => surface.min_size(),
         }
-        .map(|size| {
-            if self.is_decorated(false) {
-                size
-            } else {
-                size + (0, SSD_HEIGHT).into()
-            }
-        })
     }
 
-    pub fn max_size(&self) -> Option<Size<i32, Logical>> {
+    pub fn max_size_without_ssd(&self) -> Option<Size<i32, Logical>> {
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
                 Some(with_states(toplevel.wl_surface(), |states| {
@@ -488,13 +478,6 @@ impl CosmicSurface {
             }
             WindowSurface::X11(surface) => surface.max_size(),
         }
-        .map(|size| {
-            if self.is_decorated(false) {
-                size
-            } else {
-                size + (0, SSD_HEIGHT).into()
-            }
-        })
     }
 
     pub fn serial_acked(&self, serial: &Serial) -> bool {

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -55,10 +55,10 @@ use std::{
 };
 use wayland_backend::server::ObjectId;
 
-use super::{
-    surface::{RESIZE_BORDER, SSD_HEIGHT},
-    CosmicSurface,
-};
+use super::CosmicSurface;
+
+pub const SSD_HEIGHT: i32 = 36;
+pub const RESIZE_BORDER: i32 = 10;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CosmicWindow(pub(super) IcedElement<CosmicWindowInternal>);
@@ -385,6 +385,29 @@ impl CosmicWindow {
 
     pub(crate) fn force_redraw(&self) {
         self.0.force_redraw();
+    }
+
+    pub fn min_size(&self) -> Option<Size<i32, Logical>> {
+        self.0
+            .with_program(|p| p.window.min_size_without_ssd())
+            .map(|size| {
+                if self.0.with_program(|p| !p.window.is_decorated(false)) {
+                    size + (0, SSD_HEIGHT).into()
+                } else {
+                    size
+                }
+            })
+    }
+    pub fn max_size(&self) -> Option<Size<i32, Logical>> {
+        self.0
+            .with_program(|p| p.window.max_size_without_ssd())
+            .map(|size| {
+                if self.0.with_program(|p| !p.window.is_decorated(false)) {
+                    size + (0, SSD_HEIGHT).into()
+                } else {
+                    size
+                }
+            })
     }
 }
 

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -44,8 +44,8 @@ pub fn is_dialog(window: &CosmicSurface) -> bool {
     };
 
     // Check if sizing suggest dialog
-    let max_size = window.max_size();
-    let min_size = window.min_size();
+    let max_size = window.max_size_without_ssd();
+    let min_size = window.min_size_without_ssd();
 
     if min_size.is_some() && min_size == max_size {
         return true;

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -2,10 +2,7 @@ use std::{ffi::OsString, os::unix::io::OwnedFd, process::Stdio};
 
 use crate::{
     backend::render::cursor::{load_cursor_theme, Cursor},
-    shell::{
-        element::surface::SSD_HEIGHT, focus::target::KeyboardFocusTarget, grabs::ReleaseMode,
-        CosmicSurface, Shell,
-    },
+    shell::{focus::target::KeyboardFocusTarget, grabs::ReleaseMode, CosmicSurface, Shell},
     state::State,
     utils::prelude::*,
     wayland::handlers::{
@@ -473,7 +470,7 @@ impl XwmHandler for State {
             };
 
             if let Some(current_geo) = current_geo {
-                let ssd_height = if window.is_decorated() { 0 } else { SSD_HEIGHT };
+                let ssd_height = mapped.ssd_height(false).unwrap_or(0);
                 mapped.set_geometry(Rectangle::from_loc_and_size(
                     current_geo.loc,
                     (


### PR DESCRIPTION
This fixes several things:
- The xwayland code previously incorrectly used the SSD_HEIGHT (for Windows) even when the X11 surface was in a stack
- The SSD_HEIGHT was defined in surface.rs, even though rendering serverside decorations is done in the window/stack

Rename (min|max)_size to (min|max)_size_without_ssd in CosmicSurface and make it act accordingly
Add a new (min|max)_size() in CosmicWindow and CosmicStack, which takes the surface's (min|max)_size and adds the decorations.
Change all callers to use (min|max)_size() from the window or stack respectively, except is_dialog() where it does not matter.