### PR TITLE
Migrate away from `Rectangle::from_loc_and_size`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,7 +4688,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay//smithay?rev=14c7e43#14c7e43255968e2d979a19e1fd9bd694e5a9726e"
+source = "git+https://github.com/smithay//smithay?rev=9fbc9fb#9fbc9fbbfe04c94e6716b89080145d061f66031f"
 dependencies = [
  "appendlist",
  "ash",
@@ -4711,7 +4711,6 @@ dependencies = [
  "libc",
  "libloading",
  "libseat",
- "once_cell",
  "pixman",
  "pkg-config",
  "profiling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,4 +119,4 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/Smithay/smithay.git"]
-smithay = { git = "https://github.com/smithay//smithay", rev = "14c7e43" }
+smithay = { git = "https://github.com/smithay//smithay", rev = "9fbc9fb" }

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -165,7 +165,7 @@ impl MirroringState {
             .unwrap_or_default()
             .to_logical(1)
             .to_buffer(1, Transform::Normal);
-        let opaque_regions = vec![Rectangle::from_loc_and_size((0, 0), size)];
+        let opaque_regions = vec![Rectangle::from_size(size)];
 
         let texture = Offscreen::<GlesTexture>::create_buffer(renderer, format, size)?;
         let transform = output.current_transform();
@@ -512,10 +512,8 @@ fn surface_thread(
 
     #[cfg(feature = "debug")]
     let egui = {
-        let state = smithay_egui::EguiState::new(smithay::utils::Rectangle::from_loc_and_size(
-            (0, 0),
-            (400, 800),
-        ));
+        let state =
+            smithay_egui::EguiState::new(smithay::utils::Rectangle::from_size((400, 800).into()));
         let mut visuals: egui::style::Visuals = Default::default();
         visuals.window_shadow = egui::Shadow::NONE;
         state.context().set_visuals(visuals);
@@ -1114,8 +1112,7 @@ impl SurfaceThreadState {
             elements = constrain_render_elements(
                 std::iter::once(texture_elem),
                 (0, 0),
-                Rectangle::from_loc_and_size(
-                    (0, 0),
+                Rectangle::from_size(
                     self.output
                         .geometry()
                         .size

--- a/src/backend/render/element.rs
+++ b/src/backend/render/element.rs
@@ -379,7 +379,7 @@ impl Element for DamageElement {
     }
 
     fn src(&self) -> Rectangle<f64, BufferCoords> {
-        Rectangle::from_loc_and_size((0.0, 0.0), (1.0, 1.0))
+        Rectangle::from_size((1.0, 1.0).into())
     }
 
     fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
@@ -391,10 +391,7 @@ impl Element for DamageElement {
         scale: Scale<f64>,
         _commit: Option<CommitCounter>,
     ) -> DamageSet<i32, Physical> {
-        DamageSet::from_slice(&[Rectangle::from_loc_and_size(
-            (0, 0),
-            self.geometry(scale).size,
-        )])
+        DamageSet::from_slice(&[Rectangle::from_size(self.geometry(scale).size).into()])
     }
 }
 

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -678,11 +678,7 @@ where
         .as_logical()
         .to_physical_precise_round(scale);
     let crop_to_output = |element: WorkspaceRenderElement<R>| {
-        CropRenderElement::from_element(
-            element.into(),
-            scale,
-            Rectangle::from_loc_and_size((0, 0), output_size),
-        )
+        CropRenderElement::from_element(element.into(), scale, Rectangle::from_size(output_size))
     };
 
     render_input_order(

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1955,7 +1955,7 @@ impl State {
                         let location = global_pos + offset.as_global().to_f64();
                         let output = workspace.output();
                         let output_geo = output.geometry().to_local(output);
-                        if Rectangle::from_loc_and_size(offset.as_local(), output_geo.size)
+                        if Rectangle::new(offset.as_local(), output_geo.size)
                             .intersection(output_geo)
                             .is_some_and(|geometry| {
                                 geometry.contains(global_pos.to_local(output).to_i32_round())
@@ -1970,7 +1970,7 @@ impl State {
                         let location = global_pos + offset.as_global().to_f64();
                         let output = workspace.output();
                         let output_geo = output.geometry().to_local(output);
-                        if Rectangle::from_loc_and_size(offset.as_local(), output_geo.size)
+                        if Rectangle::new(offset.as_local(), output_geo.size)
                             .intersection(output_geo)
                             .is_some_and(|geometry| {
                                 geometry.contains(global_pos.to_local(output).to_i32_round())

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -226,12 +226,12 @@ impl CosmicMapped {
                 let win = stack.active();
                 let location = stack.offset();
                 let size = win.geometry().size;
-                Rectangle::from_loc_and_size(location, size)
+                Rectangle::new(location, size)
             }
             CosmicMappedInternal::Window(win) => {
                 let location = win.offset();
                 let size = win.geometry().size;
-                Rectangle::from_loc_and_size(location, size)
+                Rectangle::new(location, size)
             }
             _ => unreachable!(),
         }
@@ -601,9 +601,9 @@ impl CosmicMapped {
     pub fn set_debug(&self, flag: bool) {
         let mut debug = self.debug.lock().unwrap();
         if flag {
-            *debug = Some(smithay_egui::EguiState::new(Rectangle::from_loc_and_size(
-                (10, 10),
-                (100, 100),
+            *debug = Some(smithay_egui::EguiState::new(Rectangle::new(
+                (10, 10).into(),
+                (100, 100).into(),
             )));
         } else {
             debug.take();
@@ -662,7 +662,7 @@ impl CosmicMapped {
                 window.geometry().size,
             );
 
-            let area = Rectangle::<i32, Logical>::from_loc_and_size(
+            let area = Rectangle::<i32, Logical>::new(
                 location.to_f64().to_logical(scale).to_i32_round(),
                 self.bbox().size,
             );

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -491,7 +491,7 @@ impl CosmicStack {
             let loc = (geo.loc.x, geo.loc.y + TAB_HEIGHT);
             let size = (geo.size.w, geo.size.h - TAB_HEIGHT);
 
-            let win_geo = Rectangle::from_loc_and_size(loc, size);
+            let win_geo = Rectangle::new(loc.into(), size.into());
             for window in p.windows.lock().unwrap().iter() {
                 window.set_geometry(win_geo, TAB_HEIGHT as u32);
             }
@@ -1045,9 +1045,9 @@ impl Program for CosmicStackInternal {
         theme: &Theme,
     ) {
         if self.group_focused.load(Ordering::SeqCst) {
-            let border = Rectangle::from_loc_and_size(
-                (0, ((TAB_HEIGHT as f32 * scale) - scale).floor() as i32),
-                (pixels.width() as i32, scale.ceil() as i32),
+            let border = Rectangle::new(
+                (0, ((TAB_HEIGHT as f32 * scale) - scale).floor() as i32).into(),
+                (pixels.width() as i32, scale.ceil() as i32).into(),
             );
 
             let mut paint = tiny_skia::Paint::default();

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -214,7 +214,7 @@ impl CosmicWindow {
             let loc = (geo.loc.x, geo.loc.y + ssd_height);
             let size = (geo.size.w, std::cmp::max(geo.size.h - ssd_height, 0));
             p.window
-                .set_geometry(Rectangle::from_loc_and_size(loc, size), ssd_height as u32);
+                .set_geometry(Rectangle::new(loc.into(), size.into()), ssd_height as u32);
         });
     }
 

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -249,7 +249,7 @@ impl Program for ContextMenu {
                             let output = seat.active_output();
                             let position = [
                                 // to the right -> down
-                                Rectangle::from_loc_and_size(
+                                Rectangle::new(
                                     position
                                         + Point::from((
                                             bounds.width.ceil() as i32,
@@ -258,7 +258,7 @@ impl Program for ContextMenu {
                                     min_size.as_global(),
                                 ),
                                 // to the right -> up
-                                Rectangle::from_loc_and_size(
+                                Rectangle::new(
                                     position
                                         + Point::from((
                                             bounds.width.ceil() as i32,
@@ -268,12 +268,12 @@ impl Program for ContextMenu {
                                     min_size.as_global(),
                                 ),
                                 // to the left -> down
-                                Rectangle::from_loc_and_size(
+                                Rectangle::new(
                                     position + Point::from((-min_size.w, bounds.y.ceil() as i32)),
                                     min_size.as_global(),
                                 ),
                                 // to the left -> up
-                                Rectangle::from_loc_and_size(
+                                Rectangle::new(
                                     position
                                         + Point::from((
                                             -min_size.w,
@@ -669,16 +669,16 @@ impl MenuGrab {
 
         let output = seat.active_output();
         let position = [
-            Rectangle::from_loc_and_size(position, min_size.as_global()), // normal
-            Rectangle::from_loc_and_size(
+            Rectangle::new(position, min_size.as_global()), // normal
+            Rectangle::new(
                 position - Point::from((min_size.w, 0)),
                 min_size.as_global(),
             ), // flipped left
-            Rectangle::from_loc_and_size(
+            Rectangle::new(
                 position - Point::from((0, min_size.h)),
                 min_size.as_global(),
             ), // flipped up
-            Rectangle::from_loc_and_size(
+            Rectangle::new(
                 position - Point::from((min_size.w, min_size.h)),
                 min_size.as_global(),
             ), // flipped left & up

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -114,7 +114,7 @@ impl MoveGrabState {
                 CosmicMappedRenderElement::from(IndicatorShader::focus_element(
                     renderer,
                     Key::Window(Usage::MoveGrabIndicator, self.window.key()),
-                    Rectangle::from_loc_and_size(
+                    Rectangle::new(
                         render_location,
                         self.window
                             .geometry()
@@ -350,15 +350,15 @@ impl MoveGrab {
     fn update_location(&mut self, state: &mut State, location: Point<f64, Logical>) {
         let mut shell = state.common.shell.write().unwrap();
 
-        let Some(current_output) =
-            shell
-                .outputs()
-                .find(|output| {
-                    output.geometry().as_logical().overlaps_or_touches(
-                        Rectangle::from_loc_and_size(location.to_i32_floor(), (0, 0)),
-                    )
-                })
-                .cloned()
+        let Some(current_output) = shell
+            .outputs()
+            .find(|output| {
+                output
+                    .geometry()
+                    .as_logical()
+                    .overlaps_or_touches(Rectangle::new(location.to_i32_floor(), (0, 0).into()))
+            })
+            .cloned()
         else {
             return;
         };
@@ -412,10 +412,7 @@ impl MoveGrab {
                     for output in &self.window_outputs {
                         element.output_enter(
                             output,
-                            Rectangle::from_loc_and_size(
-                                (0, 0),
-                                output.geometry().size.as_logical(),
-                            ),
+                            Rectangle::from_size(output.geometry().size.as_logical()),
                         );
                     }
                     (element, geo.loc.as_logical())
@@ -778,7 +775,7 @@ impl Drop for MoveGrab {
 
                     match previous {
                         ManagedLayer::Sticky => {
-                            grab_state.window.set_geometry(Rectangle::from_loc_and_size(
+                            grab_state.window.set_geometry(Rectangle::new(
                                 window_location,
                                 grab_state.window.geometry().size.as_global(),
                             ));
@@ -800,7 +797,7 @@ impl Drop for MoveGrab {
                             Some((window, location.to_global(&output)))
                         }
                         _ => {
-                            grab_state.window.set_geometry(Rectangle::from_loc_and_size(
+                            grab_state.window.set_geometry(Rectangle::new(
                                 window_location,
                                 grab_state.window.geometry().size.as_global(),
                             ));

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -112,7 +112,7 @@ impl ResizeSurfaceGrab {
         self.last_window_size = (new_window_width, new_window_height).into();
 
         self.window.set_resizing(true);
-        self.window.set_geometry(Rectangle::from_loc_and_size(
+        self.window.set_geometry(Rectangle::new(
             if let Some(s) = self.window.active_window().x11_surface() {
                 s.geometry().loc.as_global()
             } else {
@@ -523,7 +523,7 @@ impl ResizeSurfaceGrab {
         }
 
         self.window.set_resizing(false);
-        self.window.set_geometry(Rectangle::from_loc_and_size(
+        self.window.set_geometry(Rectangle::new(
             if let Some(x11_surface) = self.window.active_window().x11_surface() {
                 x11_surface.geometry().loc.as_global()
             } else {

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -257,7 +257,7 @@ impl TiledCorners {
             ),
         };
 
-        Rectangle::from_loc_and_size(loc, size).as_local()
+        Rectangle::new(loc, size).as_local()
     }
 }
 
@@ -463,9 +463,9 @@ impl FloatingLayout {
                             && output_geometry.contains_rect(*geo)
                     })
                     .map(|geometry| {
-                        let mut geometry: Rectangle<u32, Logical> = Rectangle::from_loc_and_size(
-                            (geometry.loc.x as u32, geometry.loc.y as u32),
-                            (geometry.size.w as u32, geometry.size.h as u32),
+                        let mut geometry: Rectangle<u32, Logical> = Rectangle::new(
+                            (geometry.loc.x as u32, geometry.loc.y as u32).into(),
+                            (geometry.size.w as u32, geometry.size.h as u32).into(),
                         );
 
                         // move down
@@ -572,8 +572,7 @@ impl FloatingLayout {
             });
 
         mapped.set_tiled(false);
-        mapped
-            .set_geometry(Rectangle::from_loc_and_size(position, win_geo.size).to_global(&output));
+        mapped.set_geometry(Rectangle::new(position, win_geo.size).to_global(&output));
         mapped.configure();
 
         if let Some(previous_geometry) = prev.or(already_mapped) {
@@ -604,7 +603,7 @@ impl FloatingLayout {
             mapped.set_geometry(geometry.to_global(&output));
             mapped.configure();
         } else {
-            mapped.set_geometry(Rectangle::from_loc_and_size(
+            mapped.set_geometry(Rectangle::new(
                 position.to_global(&output),
                 window_size.as_global(),
             ));
@@ -633,7 +632,7 @@ impl FloatingLayout {
                 if let Some(location) = self.space.element_location(window) {
                     window.set_tiled(false);
                     window.set_geometry(
-                        Rectangle::from_loc_and_size(location, last_size.as_logical())
+                        Rectangle::new(location, last_size.as_logical())
                             .as_local()
                             .to_global(self.space.outputs().next().unwrap()),
                     );
@@ -644,7 +643,7 @@ impl FloatingLayout {
         } else if !window.is_maximized(true) && !window.is_fullscreen(true) {
             if let Some(location) = self.space.element_location(window) {
                 *window.last_geometry.lock().unwrap() = Some(
-                    Rectangle::from_loc_and_size(
+                    Rectangle::new(
                         location,
                         window
                             .pending_size()

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -476,7 +476,7 @@ impl TilingLayout {
                     *current_sizes = sizes;
                     let new_node = Node::new(Data::Mapped {
                         mapped: window.clone(),
-                        last_geometry: Rectangle::from_loc_and_size((0, 0), (100, 100)),
+                        last_geometry: Rectangle::from_size((100, 100).into()),
                         minimize_rect: Some(from),
                     });
                     let new_id = tree
@@ -499,7 +499,7 @@ impl TilingLayout {
                 let sibling_id = sibling.unwrap();
                 let new_node = Node::new(Data::Mapped {
                     mapped: window.clone(),
-                    last_geometry: Rectangle::from_loc_and_size((0, 0), (100, 100)),
+                    last_geometry: Rectangle::from_size((100, 100).into()),
                     minimize_rect: Some(from),
                 });
 
@@ -546,7 +546,7 @@ impl TilingLayout {
         let window = window.into();
         let new_window = Node::new(Data::Mapped {
             mapped: window.clone(),
-            last_geometry: Rectangle::from_loc_and_size((0, 0), (100, 100)),
+            last_geometry: Rectangle::from_size((100, 100).into()),
             minimize_rect,
         });
 
@@ -1511,7 +1511,7 @@ impl TilingLayout {
 
                     let new_node = Node::new(Data::Mapped {
                         mapped: mapped.clone(),
-                        last_geometry: Rectangle::from_loc_and_size((0, 0), (100, 100)),
+                        last_geometry: Rectangle::from_size((100, 100).into()),
                         minimize_rect: None,
                     });
                     let new_id = tree.insert(new_node, InsertBehavior::AsRoot).unwrap();
@@ -2651,7 +2651,7 @@ impl TilingLayout {
                     .insert(
                         Node::new(Data::Mapped {
                             mapped: window.clone(),
-                            last_geometry: Rectangle::from_loc_and_size((0, 0), (100, 100)),
+                            last_geometry: Rectangle::from_size((100, 100).into()),
                             minimize_rect: None,
                         }),
                         InsertBehavior::UnderNode(group_id),
@@ -2687,7 +2687,7 @@ impl TilingLayout {
                     .insert(
                         Node::new(Data::Mapped {
                             mapped: window.clone(),
-                            last_geometry: Rectangle::from_loc_and_size((0, 0), (100, 100)),
+                            last_geometry: Rectangle::from_size((100, 100).into()),
                             minimize_rect: None,
                         }),
                         InsertBehavior::UnderNode(group_id),
@@ -2720,7 +2720,7 @@ impl TilingLayout {
                     .insert(
                         Node::new(Data::Mapped {
                             mapped: window.clone(),
-                            last_geometry: Rectangle::from_loc_and_size((0, 0), (100, 100)),
+                            last_geometry: Rectangle::from_size((100, 100).into()),
                             minimize_rect: None,
                         }),
                         InsertBehavior::UnderNode(&window_id),
@@ -2861,7 +2861,7 @@ impl TilingLayout {
     ) -> Result<NodeId, NodeIdError> {
         let new_group = Node::new(Data::new_group(
             orientation,
-            Rectangle::from_loc_and_size((0, 0), (100, 100)),
+            Rectangle::from_size((100, 100).into()),
         ));
         let old = tree.get(old_id)?;
         let parent_id = old.parent().cloned();
@@ -3059,9 +3059,9 @@ impl TilingLayout {
                                 let mut previous: i32 = sizes.iter().sum();
                                 for size in sizes.iter().rev() {
                                     previous -= *size;
-                                    stack.push(Rectangle::from_loc_and_size(
-                                        (geo.loc.x, geo.loc.y + previous),
-                                        (geo.size.w, *size),
+                                    stack.push(Rectangle::new(
+                                        (geo.loc.x, geo.loc.y + previous).into(),
+                                        (geo.size.w, *size).into(),
                                     ));
                                 }
                             }
@@ -3069,9 +3069,9 @@ impl TilingLayout {
                                 let mut previous: i32 = sizes.iter().sum();
                                 for size in sizes.iter().rev() {
                                     previous -= *size;
-                                    stack.push(Rectangle::from_loc_and_size(
-                                        (geo.loc.x + previous, geo.loc.y),
-                                        (*size, geo.size.h),
+                                    stack.push(Rectangle::new(
+                                        (geo.loc.x + previous, geo.loc.y).into(),
+                                        (*size, geo.size.h).into(),
                                     ));
                                 }
                             }
@@ -3422,18 +3422,18 @@ impl TilingLayout {
                             Some((_, TargetZone::GroupEdge(id, Direction::Left)))
                                 if *id == res_id =>
                             {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     last_geometry.loc,
-                                    (80, last_geometry.size.h),
+                                    (80, last_geometry.size.h).into(),
                                 );
                                 last_geometry.loc.x += 80;
                                 last_geometry.size.w -= 80;
                                 zone
                             }
                             _ => {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     last_geometry.loc,
-                                    (32, last_geometry.size.h),
+                                    (32, last_geometry.size.h).into(),
                                 );
                                 last_geometry.loc.x += 32;
                                 last_geometry.size.w -= 32;
@@ -3444,18 +3444,18 @@ impl TilingLayout {
                             Some((_, TargetZone::GroupEdge(id, Direction::Up)))
                                 if *id == res_id =>
                             {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     last_geometry.loc,
-                                    (last_geometry.size.w, 80),
+                                    (last_geometry.size.w, 80).into(),
                                 );
                                 last_geometry.loc.y += 80;
                                 last_geometry.size.h -= 80;
                                 zone
                             }
                             _ => {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     last_geometry.loc,
-                                    (last_geometry.size.w, 32),
+                                    (last_geometry.size.w, 32).into(),
                                 );
                                 last_geometry.loc.y += 32;
                                 last_geometry.size.h -= 32;
@@ -3466,23 +3466,25 @@ impl TilingLayout {
                             Some((_, TargetZone::GroupEdge(id, Direction::Right)))
                                 if *id == res_id =>
                             {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     (
                                         last_geometry.loc.x + last_geometry.size.w - 80,
                                         last_geometry.loc.y,
-                                    ),
-                                    (80, last_geometry.size.h),
+                                    )
+                                        .into(),
+                                    (80, last_geometry.size.h).into(),
                                 );
                                 last_geometry.size.w -= 80;
                                 zone
                             }
                             _ => {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     (
                                         last_geometry.loc.x + last_geometry.size.w - 32,
                                         last_geometry.loc.y,
-                                    ),
-                                    (32, last_geometry.size.h),
+                                    )
+                                        .into(),
+                                    (32, last_geometry.size.h).into(),
                                 );
                                 last_geometry.size.w -= 32;
                                 zone
@@ -3492,23 +3494,25 @@ impl TilingLayout {
                             Some((_, TargetZone::GroupEdge(id, Direction::Down)))
                                 if *id == res_id =>
                             {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     (
                                         last_geometry.loc.x,
                                         last_geometry.loc.y + last_geometry.size.h - 80,
-                                    ),
-                                    (last_geometry.size.w, 80),
+                                    )
+                                        .into(),
+                                    (last_geometry.size.w, 80).into(),
                                 );
                                 last_geometry.size.h -= 80;
                                 zone
                             }
                             _ => {
-                                let zone = Rectangle::from_loc_and_size(
+                                let zone = Rectangle::new(
                                     (
                                         last_geometry.loc.x,
                                         last_geometry.loc.y + last_geometry.size.h - 32,
-                                    ),
-                                    (last_geometry.size.w, 32),
+                                    )
+                                        .into(),
+                                    (last_geometry.size.w, 32).into(),
                                 );
                                 last_geometry.size.h -= 32;
                                 zone
@@ -3722,9 +3726,8 @@ impl TilingLayout {
                                     let id = tree
                                         .insert(
                                             Node::new(Data::Placeholder {
-                                                last_geometry: Rectangle::from_loc_and_size(
-                                                    (0, 0),
-                                                    (100, 100),
+                                                last_geometry: Rectangle::from_size(
+                                                    (100, 100).into(),
                                                 ),
                                                 initial_placeholder: false,
                                             }),
@@ -4244,7 +4247,7 @@ fn swap_geometry(
         relative_to.loc.y,
     ));
 
-    Rectangle::from_loc_and_size(loc, new_size)
+    Rectangle::new(loc, new_size)
 }
 
 fn geometries_for_groupview<'a, R>(
@@ -4284,7 +4287,7 @@ where
     let mut stack = Vec::new();
     if swap_tree.is_some() {
         // push bogos value, that will get ignored anyway
-        stack.push((Rectangle::from_loc_and_size((0, 0), (320, 240)), 0));
+        stack.push((Rectangle::from_size((320, 240).into()), 0));
     }
     if root.is_some() {
         stack.push((non_exclusive_zone, 0));
@@ -4553,44 +4556,38 @@ where
                         if let Some(PillIndicator::Outer(direction)) = pill_indicator {
                             let (pill_geo, remaining_geo) = match direction {
                                 Direction::Left => (
-                                    Rectangle::from_loc_and_size(
-                                        (geo.loc.x, geo.loc.y),
-                                        (16, geo.size.h),
+                                    Rectangle::new(
+                                        (geo.loc.x, geo.loc.y).into(),
+                                        (16, geo.size.h).into(),
                                     ),
-                                    Rectangle::from_loc_and_size(
-                                        (geo.loc.x + 48, geo.loc.y),
-                                        (geo.size.w - 48, geo.size.h),
+                                    Rectangle::new(
+                                        (geo.loc.x + 48, geo.loc.y).into(),
+                                        (geo.size.w - 48, geo.size.h).into(),
                                     ),
                                 ),
                                 Direction::Up => (
-                                    Rectangle::from_loc_and_size(
-                                        (geo.loc.x, geo.loc.y),
-                                        (geo.size.w, 16),
+                                    Rectangle::new(
+                                        (geo.loc.x, geo.loc.y).into(),
+                                        (geo.size.w, 16).into(),
                                     ),
-                                    Rectangle::from_loc_and_size(
-                                        (geo.loc.x, geo.loc.y + 48),
-                                        (geo.size.w, geo.size.h - 48),
+                                    Rectangle::new(
+                                        (geo.loc.x, geo.loc.y + 48).into(),
+                                        (geo.size.w, geo.size.h - 48).into(),
                                     ),
                                 ),
                                 Direction::Right => (
-                                    Rectangle::from_loc_and_size(
-                                        (geo.loc.x + geo.size.w - 16, geo.loc.y),
-                                        (16, geo.size.h),
+                                    Rectangle::new(
+                                        (geo.loc.x + geo.size.w - 16, geo.loc.y).into(),
+                                        (16, geo.size.h).into(),
                                     ),
-                                    Rectangle::from_loc_and_size(
-                                        geo.loc,
-                                        (geo.size.w - 48, geo.size.h),
-                                    ),
+                                    Rectangle::new(geo.loc, (geo.size.w - 48, geo.size.h).into()),
                                 ),
                                 Direction::Down => (
-                                    Rectangle::from_loc_and_size(
-                                        (geo.loc.x, geo.loc.y + geo.size.h - 16),
-                                        (geo.size.w, 16),
+                                    Rectangle::new(
+                                        (geo.loc.x, geo.loc.y + geo.size.h - 16).into(),
+                                        (geo.size.w, 16).into(),
                                     ),
-                                    Rectangle::from_loc_and_size(
-                                        geo.loc,
-                                        (geo.size.w, geo.size.h - 48),
-                                    ),
+                                    Rectangle::new(geo.loc, (geo.size.w, geo.size.h - 48).into()),
                                 ),
                             };
 
@@ -4683,9 +4680,9 @@ where
                             let mut previous: i32 = sizes.iter().sum();
                             for (idx, size) in sizes.iter().enumerate().rev() {
                                 previous -= *size;
-                                let mut geo = Rectangle::from_loc_and_size(
-                                    (geo.loc.x, geo.loc.y + previous),
-                                    (geo.size.w, *size),
+                                let mut geo = Rectangle::new(
+                                    (geo.loc.x, geo.loc.y + previous).into(),
+                                    (geo.size.w, *size).into(),
                                 );
                                 if mouse_tiling.is_some() {
                                     if let Some(PillIndicator::Inner(pill_idx)) = pill_indicator {
@@ -4702,9 +4699,9 @@ where
                                                     BackdropShader::element(
                                                         *renderer,
                                                         placeholder_id.clone(),
-                                                        Rectangle::from_loc_and_size(
-                                                            (geo.loc.x, geo.loc.y - 8),
-                                                            (geo.size.w, 16),
+                                                        Rectangle::new(
+                                                            (geo.loc.x, geo.loc.y - 8).into(),
+                                                            (geo.size.w, 16).into(),
                                                         ),
                                                         8.,
                                                         alpha * 0.4,
@@ -4725,9 +4722,9 @@ where
                             let mut previous: i32 = sizes.iter().sum();
                             for (idx, size) in sizes.iter().enumerate().rev() {
                                 previous -= *size;
-                                let mut geo = Rectangle::from_loc_and_size(
-                                    (geo.loc.x + previous, geo.loc.y),
-                                    (*size, geo.size.h),
+                                let mut geo = Rectangle::new(
+                                    (geo.loc.x + previous, geo.loc.y).into(),
+                                    (*size, geo.size.h).into(),
                                 );
                                 if mouse_tiling.is_some() {
                                     if let Some(PillIndicator::Inner(pill_idx)) = pill_indicator {
@@ -4744,9 +4741,9 @@ where
                                                     BackdropShader::element(
                                                         *renderer,
                                                         placeholder_id.clone(),
-                                                        Rectangle::from_loc_and_size(
-                                                            (geo.loc.x - 8, geo.loc.y),
-                                                            (16, geo.size.h),
+                                                        Rectangle::new(
+                                                            (geo.loc.x - 8, geo.loc.y).into(),
+                                                            (16, geo.size.h).into(),
                                                         ),
                                                         8.,
                                                         alpha * 0.4,
@@ -5076,12 +5073,13 @@ fn render_old_tree(
                     .unwrap_or_else(|| (1.0.into(), (0, 0).into()));
                 let geo = scaled_geo
                     .map(|adapted_geo| {
-                        Rectangle::from_loc_and_size(
+                        Rectangle::new(
                             adapted_geo.loc + offset,
                             (
                                 (original_geo.size.w as f64 * scale).round() as i32,
                                 (original_geo.size.h as f64 * scale).round() as i32,
-                            ),
+                            )
+                                .into(),
                         )
                     })
                     .unwrap_or(*original_geo);
@@ -5643,12 +5641,13 @@ fn render_new_tree(
                     old_scaled_geo
                         .unwrap()
                         .map(|adapted_geo| {
-                            Rectangle::from_loc_and_size(
+                            Rectangle::new(
                                 adapted_geo.loc + offset,
                                 (
                                     (original_geo.size.w as f64 * scale).round() as i32,
                                     (original_geo.size.h as f64 * scale).round() as i32,
-                                ),
+                                )
+                                    .into(),
                             )
                         })
                         .unwrap_or(*original_geo),
@@ -5672,12 +5671,13 @@ fn render_new_tree(
                 .unwrap_or_else(|| (1.0.into(), (0, 0).into()));
             let new_geo = scaled_geo
                 .map(|adapted_geo| {
-                    Rectangle::from_loc_and_size(
+                    Rectangle::new(
                         adapted_geo.loc + offset,
                         (
                             (original_geo.size.w as f64 * scale).round() as i32,
                             (original_geo.size.h as f64 * scale).round() as i32,
-                        ),
+                        )
+                            .into(),
                     )
                 })
                 .unwrap_or(*original_geo);

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -5075,11 +5075,7 @@ fn render_old_tree(
                     .map(|adapted_geo| {
                         Rectangle::new(
                             adapted_geo.loc + offset,
-                            (
-                                (original_geo.size.w as f64 * scale).round() as i32,
-                                (original_geo.size.h as f64 * scale).round() as i32,
-                            )
-                                .into(),
+                            (original_geo.size.to_f64() * scale).to_i32_round(),
                         )
                     })
                     .unwrap_or(*original_geo);
@@ -5643,11 +5639,7 @@ fn render_new_tree(
                         .map(|adapted_geo| {
                             Rectangle::new(
                                 adapted_geo.loc + offset,
-                                (
-                                    (original_geo.size.w as f64 * scale).round() as i32,
-                                    (original_geo.size.h as f64 * scale).round() as i32,
-                                )
-                                    .into(),
+                                (original_geo.size.to_f64() * scale).to_i32_round(),
                             )
                         })
                         .unwrap_or(*original_geo),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2714,14 +2714,18 @@ impl Shell {
         let pointer = seat.get_pointer().unwrap();
         let pos = pointer.current_location().as_global();
 
-        let cursor_output = if let Some(output) =
-            self.outputs()
-                .find(|output| {
-                    output.geometry().as_logical().overlaps_or_touches(
-                        Rectangle::from_loc_and_size(start_data.location().to_i32_floor(), (0, 0)),
-                    )
-                })
-                .cloned()
+        let cursor_output = if let Some(output) = self
+            .outputs()
+            .find(|output| {
+                output
+                    .geometry()
+                    .as_logical()
+                    .overlaps_or_touches(Rectangle::new(
+                        start_data.location().to_i32_floor(),
+                        (0, 0).into(),
+                    ))
+            })
+            .cloned()
         {
             output
         } else {

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -347,8 +347,8 @@ impl SeatExt for Seat<State> {
                         .hotspot
                 });
                 let geo = bbox_from_surface_tree(&surface, (location.x, location.y));
-                let buffer_geo = Rectangle::from_loc_and_size(
-                    (geo.loc.x, geo.loc.y),
+                let buffer_geo = Rectangle::new(
+                    (geo.loc.x, geo.loc.y).into(),
                     geo.size.to_buffer(1, Transform::Normal),
                 );
                 Some((buffer_geo, (hotspot.x, hotspot.y).into()))
@@ -364,10 +364,7 @@ impl SeatExt for Seat<State> {
                     .get_image(1, time.as_millis());
 
                 Some((
-                    Rectangle::from_loc_and_size(
-                        location,
-                        (frame.width as i32, frame.height as i32),
-                    ),
+                    Rectangle::new(location, (frame.width as i32, frame.height as i32).into()),
                     (frame.xhot as i32, frame.yhot as i32).into(),
                 ))
             }

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -438,8 +438,7 @@ impl Workspace {
         self.fullscreen.as_ref().map(|fullscreen| {
             let bbox = fullscreen.surface.bbox().as_local();
 
-            let mut full_geo =
-                Rectangle::from_loc_and_size((0, 0), self.output.geometry().size.as_local());
+            let mut full_geo = Rectangle::from_size(self.output.geometry().size.as_local());
             if bbox != full_geo {
                 if bbox.size.w < full_geo.size.w {
                     full_geo.loc.x += (full_geo.size.w - bbox.size.w) / 2;
@@ -1175,7 +1174,7 @@ impl Workspace {
         if let Some(fullscreen) = self.fullscreen.as_ref() {
             // fullscreen window
             let bbox = fullscreen.surface.bbox().as_local();
-            let element_geo = Rectangle::from_loc_and_size(
+            let element_geo = Rectangle::new(
                 self.element_for_surface(&fullscreen.surface)
                     .and_then(|elem| {
                         self.floating_layer
@@ -1191,8 +1190,7 @@ impl Workspace {
                 fullscreen.original_geometry.size.as_local(),
             );
 
-            let mut full_geo =
-                Rectangle::from_loc_and_size((0, 0), self.output.geometry().size.as_local());
+            let mut full_geo = Rectangle::from_size(self.output.geometry().size.as_local());
             if fullscreen.start_at.is_none() {
                 if bbox != full_geo {
                     if bbox.size.w < full_geo.size.w {
@@ -1339,10 +1337,7 @@ impl Workspace {
                     Into::<CosmicMappedRenderElement<R>>::into(BackdropShader::element(
                         renderer,
                         self.backdrop_id.clone(),
-                        Rectangle::from_loc_and_size(
-                            (0, 0),
-                            self.output.geometry().size.as_local(),
-                        ),
+                        Rectangle::from_size(self.output.geometry().size.as_local()),
                         0.,
                         alpha * 0.85,
                         [0.0, 0.0, 0.0],
@@ -1382,7 +1377,7 @@ impl Workspace {
         if let Some(fullscreen) = self.fullscreen.as_ref() {
             // fullscreen window
             let bbox = fullscreen.surface.bbox().as_local();
-            let element_geo = Rectangle::from_loc_and_size(
+            let element_geo = Rectangle::new(
                 self.element_for_surface(&fullscreen.surface)
                     .and_then(|elem| {
                         self.floating_layer
@@ -1398,8 +1393,7 @@ impl Workspace {
                 fullscreen.original_geometry.size.as_local(),
             );
 
-            let mut full_geo =
-                Rectangle::from_loc_and_size((0, 0), self.output.geometry().size.as_local());
+            let mut full_geo = Rectangle::from_size(self.output.geometry().size.as_local());
             if fullscreen.start_at.is_none() {
                 if bbox != full_geo {
                     if bbox.size.w < full_geo.size.w {

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -120,30 +120,33 @@ impl<C: Coordinate> SizeExt<C> for Size<C, Logical> {
 
 impl<C: Coordinate> RectExt<C> for Rectangle<C, Logical> {
     fn as_global(self) -> Rectangle<C, Global> {
-        Rectangle::from_loc_and_size(self.loc.as_global(), (self.size.w, self.size.h))
+        Rectangle::new(self.loc.as_global(), (self.size.w, self.size.h).into())
     }
 
     fn as_local(self) -> Rectangle<C, Local> {
-        Rectangle::from_loc_and_size(self.loc.as_local(), (self.size.w, self.size.h))
+        Rectangle::new(self.loc.as_local(), (self.size.w, self.size.h).into())
     }
 }
 
 impl<C: Coordinate> RectGlobalExt<C> for Rectangle<C, Global> {
     fn to_local(self, output: &Output) -> Rectangle<C, Local> {
-        Rectangle::from_loc_and_size(self.loc.to_local(output), (self.size.w, self.size.h))
+        Rectangle::new(self.loc.to_local(output), (self.size.w, self.size.h).into())
     }
 
     fn as_logical(self) -> Rectangle<C, Logical> {
-        Rectangle::from_loc_and_size(self.loc.as_logical(), self.size.as_logical())
+        Rectangle::new(self.loc.as_logical(), self.size.as_logical())
     }
 }
 
 impl<C: Coordinate> RectLocalExt<C> for Rectangle<C, Local> {
     fn to_global(self, output: &Output) -> Rectangle<C, Global> {
-        Rectangle::from_loc_and_size(self.loc.to_global(output), (self.size.w, self.size.h))
+        Rectangle::new(
+            self.loc.to_global(output),
+            (self.size.w, self.size.h).into(),
+        )
     }
 
     fn as_logical(self) -> Rectangle<C, Logical> {
-        Rectangle::from_loc_and_size(self.loc.as_logical(), self.size.as_logical())
+        Rectangle::new(self.loc.as_logical(), self.size.as_logical())
     }
 }

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -734,7 +734,7 @@ impl<P: Program + Send + 'static> IsAlive for IcedElement<P> {
 
 impl<P: Program + Send + 'static> SpaceElement for IcedElement<P> {
     fn bbox(&self) -> Rectangle<i32, Logical> {
-        Rectangle::from_loc_and_size((0, 0), self.0.lock().unwrap().size)
+        Rectangle::from_size(self.0.lock().unwrap().size)
     }
 
     fn is_in_input_region(&self, _point: &Point<f64, Logical>) -> bool {
@@ -928,9 +928,9 @@ where
                         .map(|d| d * scale_x)
                         .filter_map(|x| x.snap())
                         .map(|damage_rect| {
-                            Rectangle::from_loc_and_size(
-                                (damage_rect.x as i32, damage_rect.y as i32),
-                                (damage_rect.width as i32, damage_rect.height as i32),
+                            Rectangle::new(
+                                (damage_rect.x as i32, damage_rect.y as i32).into(),
+                                (damage_rect.width as i32, damage_rect.height as i32).into(),
                             )
                         })
                         .collect::<Vec<_>>();
@@ -948,8 +948,7 @@ where
                 location.to_f64(),
                 &buffer,
                 Some(alpha),
-                Some(Rectangle::from_loc_and_size(
-                    (0., 0.),
+                Some(Rectangle::from_size(
                     size.to_f64()
                         .to_logical(1., Transform::Normal)
                         .to_i32_round(),

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -38,7 +38,7 @@ struct Mirroring(Mutex<Option<WeakOutput>>);
 
 impl OutputExt for Output {
     fn geometry(&self) -> Rectangle<i32, Global> {
-        Rectangle::from_loc_and_size(self.current_location(), {
+        Rectangle::new(self.current_location(), {
             Transform::from(self.current_transform())
                 .transform_size(
                     self.current_mode()

--- a/src/utils/tween.rs
+++ b/src/utils/tween.rs
@@ -23,7 +23,7 @@ impl<N: Coordinate, Kind> CanTween for EaseSize<N, Kind> {
 
 impl<N: Coordinate, Kind> CanTween for EaseRectangle<N, Kind> {
     fn ease(from: Self, to: Self, time: impl Float) -> Self {
-        EaseRectangle(Rectangle::from_loc_and_size(
+        EaseRectangle(Rectangle::new(
             CanTween::ease(EasePoint(from.0.loc), EasePoint(to.0.loc), time).unwrap(),
             CanTween::ease(EaseSize(from.0.size), EaseSize(to.0.size), time).unwrap(),
         ))

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -98,8 +98,7 @@ where
             renderer.wait(&sync)?;
 
             let format = get_transparent(format).unwrap_or(format);
-            let mapping = renderer
-                .copy_framebuffer(Rectangle::from_loc_and_size((0, 0), buffer_size), format)?;
+            let mapping = renderer.copy_framebuffer(Rectangle::from_size(buffer_size), format)?;
             let gl_data = renderer.map_texture(&mapping)?;
             assert!((width * height * pixelsize) as usize <= gl_data.len());
 
@@ -496,7 +495,7 @@ pub fn render_window_to_buffer(
                         Transform::Normal,
                         &geometry.size.to_buffer(1, Transform::Normal),
                     );
-                    logical_rect.intersection(Rectangle::from_loc_and_size((0, 0), geometry.size))
+                    logical_rect.intersection(Rectangle::from_size(geometry.size))
                 })
                 .map(DamageElement::new)
                 .map(Into::<WindowCaptureElement<R>>::into),
@@ -733,7 +732,7 @@ pub fn render_cursor_to_buffer(
                 .into_iter()
                 .filter_map(|rect| {
                     let logical_rect = rect.to_logical(1, Transform::Normal, &Size::from((64, 64)));
-                    logical_rect.intersection(Rectangle::from_loc_and_size((0, 0), (64, 64)))
+                    logical_rect.intersection(Rectangle::from_size((64, 64).into()))
                 })
                 .map(DamageElement::new)
                 .map(Into::<WindowCaptureElement<R>>::into),

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -271,7 +271,7 @@ pub fn minimize_rectangle(output: &Output, window: &CosmicSurface) -> Rectangle<
             let map = layer_map_for_output(output);
             let layer = map.layer_for_surface(&surface, WindowSurfaceType::ALL);
             layer.and_then(|s| map.layer_geometry(s)).map(|local| {
-                Rectangle::from_loc_and_size(
+                Rectangle::new(
                     Point::from((local.loc.x + relative.loc.x, local.loc.y + relative.loc.y)),
                     relative.size,
                 )
@@ -279,7 +279,7 @@ pub fn minimize_rectangle(output: &Output, window: &CosmicSurface) -> Rectangle<
         })
         .unwrap_or_else(|| {
             let output_size = output.geometry().size;
-            Rectangle::from_loc_and_size(
+            Rectangle::new(
                 Point::from((
                     (output_size.w / 2) - 100,
                     output_size.h - (output_size.h / 3) - 50,

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -166,7 +166,7 @@ fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surfac
     let layer_geo = map.layer_geometry(layer_surface).unwrap();
 
     // the output_rect represented relative to the parents coordinate system
-    let mut relative = Rectangle::from_loc_and_size((0, 0), output.geometry().size).as_logical();
+    let mut relative = Rectangle::from_size(output.geometry().size).as_logical();
     relative.loc -= layer_geo.loc;
     let toplevel_offset = get_popup_toplevel_coords(surface);
     let mut geometry = surface.with_pending_state(|state| state.positioner.get_geometry());

--- a/src/wayland/protocols/overlap_notify.rs
+++ b/src/wayland/protocols/overlap_notify.rs
@@ -124,7 +124,7 @@ impl OverlapNotifyState {
                             if let Some(window_geo) = window.global_geometry() {
                                 if let Some(intersection) = layer_geo.intersection(window_geo) {
                                     // relative to layer location
-                                    let region = Rectangle::from_loc_and_size(
+                                    let region = Rectangle::new(
                                         intersection.loc - layer_geo.loc,
                                         intersection.size,
                                     )
@@ -145,7 +145,7 @@ impl OverlapNotifyState {
                                 .to_global(&output);
                             if let Some(intersection) = layer_geo.intersection(other_geo) {
                                 // relative to layer location
-                                let region = Rectangle::from_loc_and_size(
+                                let region = Rectangle::new(
                                     intersection.loc - layer_geo.loc,
                                     intersection.size,
                                 )

--- a/src/wayland/protocols/screencopy.rs
+++ b/src/wayland/protocols/screencopy.rs
@@ -870,7 +870,7 @@ where
 
                 inner
                     .damage
-                    .push(Rectangle::from_loc_and_size((x, y), (width, height)));
+                    .push(Rectangle::new((x, y).into(), (width, height).into()));
             }
             zcosmic_screencopy_frame_v2::Request::Capture => {
                 let mut inner = data.inner.lock().unwrap();

--- a/src/wayland/protocols/toplevel_management.rs
+++ b/src/wayland/protocols/toplevel_management.rs
@@ -244,7 +244,7 @@ where
                     } else {
                         toplevel_state.rectangles.push((
                             surface.downgrade(),
-                            Rectangle::from_loc_and_size((x, y), (width, height)),
+                            Rectangle::new((x, y).into(), (width, height).into()),
                         ));
                     }
                 }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -471,13 +471,14 @@ impl XwmHandler for State {
 
             if let Some(current_geo) = current_geo {
                 let ssd_height = mapped.ssd_height(false).unwrap_or(0);
-                mapped.set_geometry(Rectangle::from_loc_and_size(
+                mapped.set_geometry(Rectangle::new(
                     current_geo.loc,
                     (
                         w.map(|w| w as i32).unwrap_or(current_geo.size.w),
                         h.map(|h| h as i32 + ssd_height)
                             .unwrap_or(current_geo.size.h),
-                    ),
+                    )
+                        .into(),
                 ))
             } else {
                 let _ = window.configure(None); // ack and force old state


### PR DESCRIPTION
Depends on https://github.com/Smithay/smithay/pull/1621.

Annoying to update, but overall a little bit better.

Some of these `Rectangle::new` calls should probably be written in a way that doesn't construct new `Point`/`Size` instances from scalars and uses higher-level operations that preserve coordinate space, but this doesn't change that for now. (If we can move Smithay to `euclid` that should have a few more useful methods to clean up things like that too.)