### PR TITLE
Update leds when devices are added

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -171,7 +171,8 @@ impl State {
             InputEvent::DeviceAdded { device } => {
                 let shell = self.common.shell.read().unwrap();
                 let seat = shell.seats.last_active();
-                seat.devices().add_device(&device);
+                let led_state = seat.get_keyboard().unwrap().led_state();
+                seat.devices().add_device(&device, led_state);
                 if device.has_capability(DeviceCapability::TabletTool) {
                     seat.tablet_seat().add_tablet::<Self>(
                         &self.common.display_handle,

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -83,7 +83,11 @@ impl Seats {
 }
 
 impl Devices {
-    pub fn add_device<D: Device + 'static>(&self, device: &D) -> Vec<DeviceCapability> {
+    pub fn add_device<D: Device + 'static>(
+        &self,
+        device: &D,
+        led_state: LedState,
+    ) -> Vec<DeviceCapability> {
         let id = device.id();
         let mut map = self.capabilities.borrow_mut();
         let caps = [
@@ -104,7 +108,9 @@ impl Devices {
 
         if device.has_capability(DeviceCapability::Keyboard) {
             if let Some(device) = <dyn Any>::downcast_ref::<InputDevice>(device) {
-                self.keyboards.borrow_mut().push(device.clone());
+                let mut device = device.clone();
+                device.led_update(led_state.into());
+                self.keyboards.borrow_mut().push(device);
             }
         }
 


### PR DESCRIPTION
This fixes #1104

LEDs on keyboard will now update to match the compositor state when they're plugged in.