### PR TITLE
Make numlock state on boot configurable

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -7,6 +7,20 @@ use std::collections::HashMap;
 pub mod input;
 pub mod workspace;
 
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct KeyboardConfig {
+    /// Boot state for numlock
+    pub numlock_state: NumlockState,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum NumlockState {
+    BootOn,
+    #[default]
+    BootOff,
+    LastBoot,
+}
+
 #[derive(Clone, Debug, PartialEq, CosmicConfigEntry)]
 #[version = 1]
 pub struct CosmicCompConfig {
@@ -15,6 +29,7 @@ pub struct CosmicCompConfig {
     pub input_touchpad: input::InputConfig,
     pub input_devices: HashMap<String, input::InputConfig>,
     pub xkb_config: XkbConfig,
+    pub keyboard_config: KeyboardConfig,
     /// Autotiling enabled
     pub autotile: bool,
     /// Determines the behavior of the autotile variable
@@ -53,6 +68,7 @@ impl Default for CosmicCompConfig {
             },
             input_devices: Default::default(),
             xkb_config: Default::default(),
+            keyboard_config: Default::default(),
             autotile: Default::default(),
             autotile_behavior: Default::default(),
             active_hint: true,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,8 @@ use cosmic_config::{ConfigGet, CosmicConfigEntry};
 use cosmic_settings_config::window_rules::ApplicationException;
 use cosmic_settings_config::{shortcuts, window_rules, Shortcuts};
 use serde::{Deserialize, Serialize};
+use smithay::utils::{Clock, Monotonic};
+use smithay::wayland::xdg_activation::XdgActivationState;
 pub use smithay::{
     backend::input::KeyState,
     input::keyboard::{keysyms as KeySyms, Keysym, ModifiersState},
@@ -24,10 +26,6 @@ pub use smithay::{
         },
     },
     utils::{Logical, Physical, Point, Size, Transform},
-};
-use smithay::{
-    utils::{Clock, Monotonic},
-    wayland::xdg_activation::XdgActivationState,
 };
 use std::{
     cell::RefCell,
@@ -45,7 +43,8 @@ mod types;
 pub use self::types::*;
 use cosmic::config::CosmicTk;
 use cosmic_comp_config::{
-    input::InputConfig, workspace::WorkspaceConfig, CosmicCompConfig, TileBehavior, XkbConfig,
+    input::InputConfig, workspace::WorkspaceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior,
+    XkbConfig,
 };
 
 #[derive(Debug)]
@@ -67,6 +66,7 @@ pub struct Config {
 #[derive(Debug)]
 pub struct DynamicConfig {
     outputs: (Option<PathBuf>, OutputsConfig),
+    numlock: (Option<PathBuf>, NumlockStateConfig),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -90,6 +90,11 @@ impl From<Output> for OutputInfo {
             model: physical.model,
         }
     }
+}
+
+#[derive(Default, Debug, Deserialize, Serialize)]
+pub struct NumlockStateConfig {
+    pub last_state: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -322,9 +327,13 @@ impl Config {
         let output_path =
             xdg.and_then(|base| base.place_state_file("cosmic-comp/outputs.ron").ok());
         let outputs = Self::load_outputs(&output_path);
+        let numlock_path =
+            xdg.and_then(|base| base.place_state_file("cosmic-comp/numlock.ron").ok());
+        let numlock = Self::load_numlock(&numlock_path);
 
         DynamicConfig {
             outputs: (output_path, outputs),
+            numlock: (numlock_path, numlock),
         }
     }
 
@@ -370,6 +379,24 @@ impl Config {
         OutputsConfig {
             config: HashMap::new(),
         }
+    }
+
+    fn load_numlock(path: &Option<PathBuf>) -> NumlockStateConfig {
+        path.as_deref()
+            .filter(|path| path.exists())
+            .and_then(|path| {
+                ron::de::from_reader::<_, NumlockStateConfig>(
+                    OpenOptions::new().read(true).open(path).unwrap(),
+                )
+                .map_err(|err| {
+                    warn!(?err, "Failed to read numlock.ron, resetting..");
+                    if let Err(err) = std::fs::remove_file(path) {
+                        error!(?err, "Failed to remove numlock.ron.");
+                    }
+                })
+                .ok()
+            })
+            .unwrap_or_default()
     }
 
     pub fn shortcut_for_action(&self, action: &shortcuts::Action) -> Option<String> {
@@ -627,6 +654,14 @@ impl DynamicConfig {
     pub fn outputs_mut(&mut self) -> PersistenceGuard<'_, OutputsConfig> {
         PersistenceGuard(self.outputs.0.clone(), &mut self.outputs.1)
     }
+
+    pub fn numlock(&self) -> &NumlockStateConfig {
+        &self.numlock.1
+    }
+
+    pub fn numlock_mut(&mut self) -> PersistenceGuard<'_, NumlockStateConfig> {
+        PersistenceGuard(self.numlock.0.clone(), &mut self.numlock.1)
+    }
 }
 
 fn get_config<T: Default + serde::de::DeserializeOwned>(
@@ -675,6 +710,14 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                 }
                 state.common.atspi_ei.update_keymap(value.clone());
                 state.common.config.cosmic_conf.xkb_config = value;
+            }
+            "keyboard_config" => {
+                let value = get_config::<KeyboardConfig>(&config, "keyboard_config");
+                state.common.config.cosmic_conf.keyboard_config = value;
+                let shell = state.common.shell.read().unwrap();
+                let seat = shell.seats.last_active();
+                state.common.config.dynamic_conf.numlock_mut().last_state =
+                    seat.get_keyboard().unwrap().modifier_state().num_lock;
             }
             "input_default" => {
                 let value = get_config::<InputConfig>(&config, "input_default");

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -241,6 +241,22 @@ impl State {
                         }
                         self.handle_action(action, &seat, serial, time, pattern, None, true)
                     }
+
+                    // If we want to track numlock state so it can be reused on the next boot...
+                    if let NumlockState::LastBoot =
+                        self.common.config.cosmic_conf.keyboard_config.numlock_state
+                    {
+                        // .. and the state has been updated ...
+                        if self.common.config.dynamic_conf.numlock().last_state
+                            != keyboard.modifier_state().num_lock
+                        {
+                            // ... then record the updated state.
+                            // The call to `numlock_mut` will generate a `PersistenceGuard`. The
+                            // `PersistenceGuard` will write to a file when it's dropped here.
+                            self.common.config.dynamic_conf.numlock_mut().last_state =
+                                keyboard.modifier_state().num_lock;
+                        }
+                    }
                 }
             }
 
@@ -1454,19 +1470,6 @@ impl State {
             event.state(),
             event.time() as u64 * 1000,
         );
-
-        // If the numlock key is pressed ...
-        if event.key_code() == Keycode::new(77) && event.state() == KeyState::Pressed {
-            // ... and we want to track numlock state so it can be reused on the next boot...
-            if let NumlockState::LastBoot =
-                self.common.config.cosmic_conf.keyboard_config.numlock_state
-            {
-                // ... then record the updated config.
-                // The call to `numlock_mut` will generate a `PersistenceGuard`. The
-                // `PersistenceGuard` will write to a file when it's dropped here.
-                self.common.config.dynamic_conf.numlock_mut().last_state = modifiers.num_lock;
-            }
-        }
 
         // Leave move overview mode, if any modifier was released
         if let Some(Trigger::KeyboardMove(action_modifiers)) =

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -33,7 +33,7 @@ use calloop::{
     timer::{TimeoutAction, Timer},
     RegistrationToken,
 };
-use cosmic_comp_config::workspace::WorkspaceLayout;
+use cosmic_comp_config::{workspace::WorkspaceLayout, NumlockState};
 use cosmic_settings_config::shortcuts;
 use cosmic_settings_config::shortcuts::action::{Direction, ResizeDirection};
 use smithay::{
@@ -1454,6 +1454,19 @@ impl State {
             event.state(),
             event.time() as u64 * 1000,
         );
+
+        // If the numlock key is pressed ...
+        if event.key_code() == Keycode::new(77) && event.state() == KeyState::Pressed {
+            // ... and we want to track numlock state so it can be reused on the next boot...
+            if let NumlockState::LastBoot =
+                self.common.config.cosmic_conf.keyboard_config.numlock_state
+            {
+                // ... then record the updated config.
+                // The call to `numlock_mut` will generate a `PersistenceGuard`. The
+                // `PersistenceGuard` will write to a file when it's dropped here.
+                self.common.config.dynamic_conf.numlock_mut().last_state = modifiers.num_lock;
+            }
+        }
 
         // Leave move overview mode, if any modifier was released
         if let Some(Trigger::KeyboardMove(action_modifiers)) =

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -12,7 +12,7 @@ use smithay::{
     backend::input::{Device, DeviceCapability},
     desktop::utils::bbox_from_surface_tree,
     input::{
-        keyboard::{LedState, XkbConfig},
+        keyboard::{KeyboardHandle, LedState, XkbConfig},
         pointer::{CursorImageAttributes, CursorImageStatus},
         Seat, SeatState,
     },
@@ -178,7 +178,7 @@ pub fn create_seat(
     output: &Output,
     config: &Config,
     name: String,
-) -> Seat<State> {
+) -> (Seat<State>, KeyboardHandle<State>) {
     let mut seat = seat_state.new_wl_seat(dh, name);
     let userdata = seat.user_data();
     userdata.insert_if_missing_threadsafe(SeatId::default);
@@ -203,26 +203,28 @@ pub fn create_seat(
     // So instead of doing the right thing (and initialize these capabilities as matching
     // devices appear), we have to surrender to reality and just always expose a keyboard and pointer.
     let conf = config.xkb_config();
-    if let Err(err) = seat.add_keyboard(
-        xkb_config_to_wl(&conf),
-        (conf.repeat_delay as i32).abs(),
-        (conf.repeat_rate as i32).abs(),
-    ) {
-        warn!(
-            ?err,
-            "Failed to load provided xkb config. Trying default...",
-        );
-        seat.add_keyboard(
-            XkbConfig::default(),
+    let keyboard = seat
+        .add_keyboard(
+            xkb_config_to_wl(&conf),
             (conf.repeat_delay as i32).abs(),
             (conf.repeat_rate as i32).abs(),
         )
+        .or_else(|err| {
+            warn!(
+                ?err,
+                "Failed to load provided xkb config. Trying default...",
+            );
+            seat.add_keyboard(
+                XkbConfig::default(),
+                (conf.repeat_delay as i32).abs(),
+                (conf.repeat_rate as i32).abs(),
+            )
+        })
         .expect("Failed to load xkb configuration files");
-    }
     seat.add_pointer();
     seat.add_touch();
 
-    seat
+    (seat, keyboard)
 }
 
 pub trait SeatExt {

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -12,7 +12,7 @@ use smithay::{
     backend::input::{Device, DeviceCapability},
     desktop::utils::bbox_from_surface_tree,
     input::{
-        keyboard::{KeyboardHandle, LedState, XkbConfig},
+        keyboard::{LedState, XkbConfig},
         pointer::{CursorImageAttributes, CursorImageStatus},
         Seat, SeatState,
     },


### PR DESCRIPTION
This will expose 3 settings for numlock behavior:
1. Numlock is off on boot (this is the current default behavior)
2. Numlock is on on boot
3. Numlock will restore the state from the last boot

Fixes #369