### PR TITLE
Improve window positioning when toggling tiling on

### DIFF
--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -974,7 +974,7 @@ impl Workspace {
     pub fn set_tiling(
         &mut self,
         tiling: bool,
-        seat: &Seat<State>,
+        _seat: &Seat<State>,
         workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
     ) {
         let mut maximized_windows = Vec::new();
@@ -990,12 +990,10 @@ impl Workspace {
                 maximized_windows.push((window.clone(), ManagedLayer::Tiling, original_geometry));
             }
 
-            let focus_stack = self.focus_stack.get(seat);
-            for window in floating_windows.into_iter() {
+            for window in floating_windows.clone().into_iter() {
                 self.floating_layer.unmap(&window);
-                self.tiling_layer
-                    .map(window, Some(focus_stack.iter()), None)
             }
+            self.tiling_layer.map_from_floating_windows(floating_windows.clone());
             workspace_state.set_workspace_tiling_state(&self.handle, TilingState::TilingEnabled);
             self.tiling_enabled = true;
         } else {
@@ -1006,6 +1004,7 @@ impl Workspace {
                 .collect::<Vec<_>>()
                 .into_iter()
             {
+
                 if window.is_maximized(false) {
                     let original_geometry = {
                         let state = window.maximized_state.lock().unwrap();


### PR DESCRIPTION
Hi folks! This is a quality of life change I've been working on. I frequently switch back and forth between using tiling and floating windows, and thought it would be nice to be able to position windows in floating mode and preserve those positions when turning on tiling.

This change updates the tiling layout code to attempt to preserve relative window positioning and sizes as much as possible when turning on toggling.

At a high level, the algorithm for this is to iteratively:
* Find candidate positions to "split" the screen based on window geometry
* Determine which candidate positions best minimize overlap with windows
* Assign windows to either side of the split - if a side has one window, insert a `Mapped` leaf into the tree, otherwise create a `Group` and placeholders for the windows to be solved.
* Repeat this process until all placeholder leafs have been solved.

Here's a small demo video: [Demo](https://www.youtube.com/watch?v=QcZlskcIC7Y)

This is the first time I've written a significant amount of Rust, so any feedback on anything non-idiomatic would be appreciated. Cheers!