### PR TITLE
fix: add missing libdisplay-info library into flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
               fontconfig
               stdenv.cc.cc.lib
               pixman
+              libdisplay-info
             ];
 
             runtimeDependencies = with pkgs; [


### PR DESCRIPTION
Trying to `cargo run --release` inside the flake.nix development shell (through `nix develop `command) yielded this error:
```
❯ cargo run --release
   Compiling tiny-xlib v0.2.3
   Compiling libudev-sys v0.1.4
   Compiling libseat-sys v0.1.7
   Compiling x11-dl v2.21.0
   Compiling libdisplay-info-sys v0.2.0
   Compiling smithay v0.3.0 (https://github.com/smithay//smithay?rev=9fbc9fb#9fbc9fbb)
   Compiling cosmic-comp v0.1.0 (/home/cenk/cosmic-comp)
error: failed to run custom build command for `libdisplay-info-sys v0.2.0`
```

It was fixed by adding the missing `libdisplay-info` library into the flake buildInputs.