### PR TITLE
Remove `CosmicMapped::stack_ref_mut`

### DIFF
--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -542,13 +542,6 @@ impl CosmicMapped {
         }
     }
 
-    pub fn stack_ref_mut(&mut self) -> Option<&mut CosmicStack> {
-        match &mut self.element {
-            CosmicMappedInternal::Stack(stack) => Some(stack),
-            _ => None,
-        }
-    }
-
     pub fn convert_to_stack(
         &mut self,
         (output, overlap): (&Output, Rectangle<i32, Logical>),

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -103,10 +103,10 @@ pub fn tab_items(
 
     vec![
         Item::new(fl!("window-menu-unstack"), move |handle| {
-            let mut mapped = unstack_clone_stack.clone();
+            let mapped = unstack_clone_stack.clone();
             let surface = unstack_clone_tab.clone();
             let _ = handle.insert_idle(move |state| {
-                mapped.stack_ref_mut().unwrap().remove_window(&surface);
+                mapped.stack_ref().unwrap().remove_window(&surface);
                 let mapped: CosmicMapped = CosmicWindow::new(
                     surface,
                     state.common.event_loop_handle.clone(),

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -1665,11 +1665,11 @@ impl TilingLayout {
                         .unwrap();
 
                     let stack_data = tree.get_mut(&next_child_id).unwrap().data_mut();
-                    let mut mapped = match stack_data {
+                    let mapped = match stack_data {
                         Data::Mapped { mapped, .. } => mapped.clone(),
                         _ => unreachable!(),
                     };
-                    let stack = mapped.stack_ref_mut().unwrap();
+                    let stack = mapped.stack_ref().unwrap();
 
                     let surface = match node.data() {
                         Data::Mapped { mapped, .. } => mapped.active_window(),
@@ -2744,7 +2744,7 @@ impl TilingLayout {
                 match tree.get_mut(window_id).unwrap().data_mut() {
                     Data::Mapped { mapped, .. } => {
                         mapped.convert_to_stack((&self.output, mapped.bbox()), self.theme.clone());
-                        let Some(stack) = mapped.stack_ref_mut() else {
+                        let Some(stack) = mapped.stack_ref() else {
                             unreachable!()
                         };
                         for surface in window.windows().map(|s| s.0) {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2274,9 +2274,9 @@ impl Shell {
                     .position(|(s, _)| &s == surface)
                     .map(|idx| (idx, m.clone()))
             });
-            let surface = if let Some((idx, mut mapped)) = sticky_res {
+            let surface = if let Some((idx, mapped)) = sticky_res {
                 if mapped.is_stack() {
-                    mapped.stack_ref_mut().unwrap().remove_idx(idx)
+                    mapped.stack_ref().unwrap().remove_idx(idx)
                 } else {
                     set.sticky_layer.unmap(&mapped);
                     Some(mapped.active_window())
@@ -2289,19 +2289,19 @@ impl Shell {
             {
                 if set.minimized_windows.get(idx).unwrap().window.is_stack() {
                     let window = &mut set.minimized_windows.get_mut(idx).unwrap().window;
-                    let stack = window.stack_ref_mut().unwrap();
+                    let stack = window.stack_ref().unwrap();
                     let idx = stack.surfaces().position(|s| &s == surface);
                     idx.and_then(|idx| stack.remove_idx(idx))
                 } else {
                     Some(set.minimized_windows.remove(idx).window.active_window())
                 }
-            } else if let Some((workspace, mut elem)) = set.workspaces.iter_mut().find_map(|w| {
+            } else if let Some((workspace, elem)) = set.workspaces.iter_mut().find_map(|w| {
                 w.element_for_surface(&surface)
                     .cloned()
                     .map(|elem| (w, elem))
             }) {
                 if elem.is_stack() {
-                    let stack = elem.stack_ref_mut().unwrap();
+                    let stack = elem.stack_ref().unwrap();
                     let idx = stack.surfaces().position(|s| &s == surface);
                     idx.and_then(|idx| stack.remove_idx(idx))
                 } else {
@@ -2676,7 +2676,7 @@ impl Shell {
         let serial = serial.into();
 
         let mut start_data = check_grab_preconditions(&seat, surface, serial, client_initiated)?;
-        let mut old_mapped = self.element_for_surface(surface).cloned()?;
+        let old_mapped = self.element_for_surface(surface).cloned()?;
         if old_mapped.is_minimized() {
             return None;
         }
@@ -2840,7 +2840,7 @@ impl Shell {
         toplevel_leave_output(&window, &cursor_output);
 
         if move_out_of_stack {
-            old_mapped.stack_ref_mut().unwrap().remove_window(&window);
+            old_mapped.stack_ref().unwrap().remove_window(&window);
             self.workspaces
                 .space_for_handle_mut(&workspace_handle)
                 .unwrap()

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -213,9 +213,9 @@ impl CompositorHandler for State {
                         })
                         .then(|| state.element())
                 });
-            if let Some(mut window) = moved_window {
+            if let Some(window) = moved_window {
                 if window.is_stack() {
-                    let stack = window.stack_ref_mut().unwrap();
+                    let stack = window.stack_ref().unwrap();
                     if let Some(i) = stack.surfaces().position(|s| {
                         s.wl_surface()
                             .as_deref()

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -221,11 +221,11 @@ impl ToplevelManagementHandler for State {
 
     fn unminimize(&mut self, _dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {
         let mut shell = self.common.shell.write().unwrap();
-        if let Some(mut mapped) = shell.element_for_surface(window).cloned() {
+        if let Some(mapped) = shell.element_for_surface(window).cloned() {
             let seat = shell.seats.last_active().clone();
             shell.unminimize_request(&mapped, &seat);
             if mapped.is_stack() {
-                mapped.stack_ref_mut().unwrap().set_active(window);
+                mapped.stack_ref().unwrap().set_active(window);
             }
         }
     }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -627,13 +627,13 @@ impl XwmHandler for State {
 
     fn unminimize_request(&mut self, _xwm: XwmId, window: X11Surface) {
         let mut shell = self.common.shell.write().unwrap();
-        if let Some(mut mapped) = shell.element_for_surface(&window).cloned() {
+        if let Some(mapped) = shell.element_for_surface(&window).cloned() {
             let seat = shell.seats.last_active().clone();
             shell.unminimize_request(&mapped, &seat);
             if mapped.is_stack() {
                 let maybe_surface = mapped.windows().find(|(w, _)| w.is_window(&window));
                 if let Some((surface, _)) = maybe_surface {
-                    mapped.stack_ref_mut().unwrap().set_active(&surface);
+                    mapped.stack_ref().unwrap().set_active(&surface);
                 }
             }
         }


### PR DESCRIPTION
The methods of `CosmicStack` take `&self`, so this isn't actually needed for anything.