### PR TITLE
feat: Snap Window Edges to Close Output Edges

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -47,7 +47,7 @@ pub struct CosmicCompConfig {
     /// Let X11 applications scale themselves
     pub descale_xwayland: bool,
     /// The threshold before windows snap themselves to output edges
-    pub window_snap_threshold: u32,
+    pub edge_snap_threshold: u32,
 }
 
 impl Default for CosmicCompConfig {
@@ -78,7 +78,7 @@ impl Default for CosmicCompConfig {
             cursor_follows_focus: false,
             focus_follows_cursor_delay: 250,
             descale_xwayland: false,
-            window_snap_threshold: 0,
+            edge_snap_threshold: 0,
         }
     }
 }

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -46,6 +46,8 @@ pub struct CosmicCompConfig {
     pub focus_follows_cursor_delay: u64,
     /// Let X11 applications scale themselves
     pub descale_xwayland: bool,
+    /// The threshold before windows snap themselves to output edges
+    pub window_snap_threshold: u32,
 }
 
 impl Default for CosmicCompConfig {
@@ -76,6 +78,7 @@ impl Default for CosmicCompConfig {
             cursor_follows_focus: false,
             focus_follows_cursor_delay: 250,
             descale_xwayland: false,
+            window_snap_threshold: 0,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -846,10 +846,10 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                     state.common.config.cosmic_conf.focus_follows_cursor_delay = new;
                 }
             }
-            "window_snap_threshold" => {
-                let new = get_config::<u32>(&config, "window_snap_threshold");
-                if new != state.common.config.cosmic_conf.window_snap_threshold {
-                    state.common.config.cosmic_conf.window_snap_threshold = new;
+            "edge_snap_threshold" => {
+                let new = get_config::<u32>(&config, "edge_snap_threshold");
+                if new != state.common.config.cosmic_conf.edge_snap_threshold {
+                    state.common.config.cosmic_conf.edge_snap_threshold = new;
                 }
             }
             _ => {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -846,6 +846,12 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                     state.common.config.cosmic_conf.focus_follows_cursor_delay = new;
                 }
             }
+            "window_snap_threshold" => {
+                let new = get_config::<u32>(&config, "window_snap_threshold");
+                if new != state.common.config.cosmic_conf.window_snap_threshold {
+                    state.common.config.cosmic_conf.window_snap_threshold = new;
+                }
+            }
             _ => {}
         }
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -756,11 +756,15 @@ impl State {
                                                             }
                                                         };
                                                         let res = shell.resize_request(
-                                                            &state.common.config,
                                                             &surface,
                                                             &seat_clone,
                                                             serial,
                                                             edge,
+                                                            state
+                                                                .common
+                                                                .config
+                                                                .cosmic_conf
+                                                                .edge_snap_threshold,
                                                             false,
                                                         );
                                                         drop(shell);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -756,6 +756,7 @@ impl State {
                                                             }
                                                         };
                                                         let res = shell.resize_request(
+                                                            &state.common.config,
                                                             &surface,
                                                             &seat_clone,
                                                             serial,

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -1355,6 +1355,7 @@ impl PointerTarget<State> for CosmicStack {
                 };
                 self.0.loop_handle().insert_idle(move |state| {
                     let res = state.common.shell.write().unwrap().resize_request(
+                        &state.common.config,
                         &surface,
                         &seat,
                         serial,

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -1355,7 +1355,6 @@ impl PointerTarget<State> for CosmicStack {
                 };
                 self.0.loop_handle().insert_idle(move |state| {
                     let res = state.common.shell.write().unwrap().resize_request(
-                        &state.common.config,
                         &surface,
                         &seat,
                         serial,
@@ -1370,6 +1369,7 @@ impl PointerTarget<State> for CosmicStack {
                             Focus::ResizeRight => ResizeEdge::RIGHT,
                             Focus::Header => unreachable!(),
                         },
+                        state.common.config.cosmic_conf.edge_snap_threshold,
                         false,
                     );
                     if let Some((grab, focus)) = res {

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -745,7 +745,6 @@ impl PointerTarget<State> for CosmicWindow {
                 };
                 self.0.loop_handle().insert_idle(move |state| {
                     let res = state.common.shell.write().unwrap().resize_request(
-                        &state.common.config,
                         &surface,
                         &seat,
                         serial,
@@ -760,6 +759,7 @@ impl PointerTarget<State> for CosmicWindow {
                             Focus::ResizeRight => ResizeEdge::RIGHT,
                             Focus::Header => unreachable!(),
                         },
+                        state.common.config.cosmic_conf.edge_snap_threshold,
                         false,
                     );
 

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -745,6 +745,7 @@ impl PointerTarget<State> for CosmicWindow {
                 };
                 self.0.loop_handle().insert_idle(move |state| {
                     let res = state.common.shell.write().unwrap().resize_request(
+                        &state.common.config,
                         &surface,
                         &seat,
                         serial,

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -288,7 +288,12 @@ pub fn window_items(
                     let _ = handle.insert_idle(move |state| {
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
-                        let res = shell.menu_resize_request(&resize_clone, &seat, ResizeEdge::TOP);
+                        let res = shell.menu_resize_request(
+                            &state.common.config,
+                            &resize_clone,
+                            &seat,
+                            ResizeEdge::TOP,
+                        );
 
                         std::mem::drop(shell);
                         if let Some(((target, loc), (grab, focus))) = res {
@@ -318,7 +323,12 @@ pub fn window_items(
                     let _ = handle.insert_idle(move |state| {
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
-                        let res = shell.menu_resize_request(&resize_clone, &seat, ResizeEdge::LEFT);
+                        let res = shell.menu_resize_request(
+                            &state.common.config,
+                            &resize_clone,
+                            &seat,
+                            ResizeEdge::LEFT,
+                        );
 
                         std::mem::drop(shell);
                         if let Some(((target, loc), (grab, focus))) = res {
@@ -348,8 +358,12 @@ pub fn window_items(
                     let _ = handle.insert_idle(move |state| {
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
-                        let res =
-                            shell.menu_resize_request(&resize_clone, &seat, ResizeEdge::RIGHT);
+                        let res = shell.menu_resize_request(
+                            &state.common.config,
+                            &resize_clone,
+                            &seat,
+                            ResizeEdge::RIGHT,
+                        );
 
                         std::mem::drop(shell);
                         if let Some(((target, loc), (grab, focus))) = res {
@@ -379,8 +393,12 @@ pub fn window_items(
                     let _ = handle.insert_idle(move |state| {
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
-                        let res =
-                            shell.menu_resize_request(&resize_clone, &seat, ResizeEdge::BOTTOM);
+                        let res = shell.menu_resize_request(
+                            &state.common.config,
+                            &resize_clone,
+                            &seat,
+                            ResizeEdge::BOTTOM,
+                        );
 
                         std::mem::drop(shell);
                         if let Some(((target, loc), (grab, focus))) = res {

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -289,10 +289,10 @@ pub fn window_items(
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
-                            &state.common.config,
                             &resize_clone,
                             &seat,
                             ResizeEdge::TOP,
+                            state.common.config.cosmic_conf.edge_snap_threshold,
                         );
 
                         std::mem::drop(shell);
@@ -324,10 +324,10 @@ pub fn window_items(
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
-                            &state.common.config,
                             &resize_clone,
                             &seat,
                             ResizeEdge::LEFT,
+                            state.common.config.cosmic_conf.edge_snap_threshold,
                         );
 
                         std::mem::drop(shell);
@@ -359,10 +359,10 @@ pub fn window_items(
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
-                            &state.common.config,
                             &resize_clone,
                             &seat,
                             ResizeEdge::RIGHT,
+                            state.common.config.cosmic_conf.edge_snap_threshold,
                         );
 
                         std::mem::drop(shell);
@@ -394,10 +394,10 @@ pub fn window_items(
                         let mut shell = state.common.shell.write().unwrap();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
-                            &state.common.config,
                             &resize_clone,
                             &seat,
                             ResizeEdge::BOTTOM,
+                            state.common.config.cosmic_conf.edge_snap_threshold,
                         );
 
                         std::mem::drop(shell);

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -342,6 +342,7 @@ pub struct MoveGrab {
     window_outputs: HashSet<Output>,
     previous: ManagedLayer,
     release: ReleaseMode,
+    window_snap_threshold: f64,
     // SAFETY: This is only used on drop which will always be on the main thread
     evlh: NotSend<LoopHandle<'static, State>>,
 }
@@ -395,16 +396,22 @@ impl MoveGrab {
                 let output_loc = output_geom.loc;
                 let output_size = output_geom.size;
 
-                grab_state.location.x = if (loc.x - output_loc.x).abs() < 10.0 {
+                grab_state.location.x = if (loc.x - output_loc.x).abs() < self.window_snap_threshold
+                {
                     output_loc.x - grab_state.window_offset.x as f64
-                } else if ((loc.x + size.w) - (output_loc.x + output_size.w)).abs() < 10.0 {
+                } else if ((loc.x + size.w) - (output_loc.x + output_size.w)).abs()
+                    < self.window_snap_threshold
+                {
                     output_loc.x + output_size.w - grab_state.window_offset.x as f64 - size.w
                 } else {
                     grab_state.location.x
                 };
-                grab_state.location.y = if (loc.y - output_loc.y).abs() < 10.0 {
+                grab_state.location.y = if (loc.y - output_loc.y).abs() < self.window_snap_threshold
+                {
                     output_loc.y - grab_state.window_offset.y as f64
-                } else if ((loc.y + size.h) - (output_loc.y + output_size.h)).abs() < 10.0 {
+                } else if ((loc.y + size.h) - (output_loc.y + output_size.h)).abs()
+                    < self.window_snap_threshold
+                {
                     output_loc.y + output_size.h - grab_state.window_offset.y as f64 - size.h
                 } else {
                     grab_state.location.y
@@ -709,6 +716,7 @@ impl MoveGrab {
         initial_window_location: Point<i32, Global>,
         cursor_output: Output,
         indicator_thickness: u8,
+        window_snap_threshold: f64,
         previous_layer: ManagedLayer,
         release: ReleaseMode,
         evlh: LoopHandle<'static, State>,
@@ -748,10 +756,11 @@ impl MoveGrab {
             window,
             start_data,
             seat: seat.clone(),
-            window_outputs: outputs,
             cursor_output,
+            window_outputs: outputs,
             previous: previous_layer,
             release,
+            window_snap_threshold,
             evlh: NotSend(evlh),
         }
     }

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -409,7 +409,6 @@ impl MoveGrab {
                 } else {
                     grab_state.location.y
                 };
-                dbg!(grab_state.location);
             }
 
             for output in shell.outputs() {

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -58,7 +58,7 @@ pub struct ResizeSurfaceGrab {
     window: CosmicMapped,
     edges: ResizeEdge,
     output: Output,
-    window_snap_threshold: i32,
+    edge_snap_threshold: u32,
     initial_window_location: Point<i32, Local>,
     initial_window_size: Size<i32, Logical>,
     last_window_size: Size<i32, Logical>,
@@ -97,18 +97,18 @@ impl ResizeSurfaceGrab {
             // If the resizing vertical edge is close to our output's edge in the same direction, snap to it.
             let output_geom = self.output.geometry().to_local(&self.output);
             if self.edges.intersects(ResizeEdge::LEFT) {
-                if (self.initial_window_location.x - dx as i32 - output_geom.loc.x).abs()
-                    < self.window_snap_threshold
+                if ((self.initial_window_location.x - dx as i32 - output_geom.loc.x).abs() as u32)
+                    < self.edge_snap_threshold
                 {
                     new_window_width = self.initial_window_size.w - output_geom.loc.x
                         + self.initial_window_location.x;
                 }
             } else {
-                if (self.initial_window_location.x + self.initial_window_size.w + dx as i32
+                if ((self.initial_window_location.x + self.initial_window_size.w + dx as i32
                     - output_geom.loc.x
                     - output_geom.size.w)
-                    .abs()
-                    < self.window_snap_threshold
+                    .abs() as u32)
+                    < self.edge_snap_threshold
                 {
                     new_window_width =
                         output_geom.loc.x - self.initial_window_location.x + output_geom.size.w;
@@ -126,18 +126,18 @@ impl ResizeSurfaceGrab {
             // If the resizing horizontal edge is close to our output's edge in the same direction, snap to it.
             let output_geom = self.output.geometry().to_local(&self.output);
             if self.edges.intersects(ResizeEdge::TOP) {
-                if (self.initial_window_location.y - dy as i32 - output_geom.loc.y).abs()
-                    < self.window_snap_threshold
+                if ((self.initial_window_location.y - dy as i32 - output_geom.loc.y).abs() as u32)
+                    < self.edge_snap_threshold
                 {
                     new_window_height = self.initial_window_size.h - output_geom.loc.y
                         + self.initial_window_location.y;
                 }
             } else {
-                if (self.initial_window_location.y + self.initial_window_size.h + dy as i32
+                if ((self.initial_window_location.y + self.initial_window_size.h + dy as i32
                     - output_geom.loc.y
                     - output_geom.size.h)
-                    .abs()
-                    < self.window_snap_threshold
+                    .abs() as u32)
+                    < self.edge_snap_threshold
                 {
                     new_window_height =
                         output_geom.loc.y - self.initial_window_location.y + output_geom.size.h;
@@ -419,7 +419,7 @@ impl ResizeSurfaceGrab {
         mapped: CosmicMapped,
         edges: ResizeEdge,
         output: Output,
-        window_snap_threshold: i32,
+        edge_snap_threshold: u32,
         initial_window_location: Point<i32, Local>,
         initial_window_size: Size<i32, Logical>,
         seat: &Seat<State>,
@@ -463,7 +463,7 @@ impl ResizeSurfaceGrab {
             initial_window_size,
             last_window_size: initial_window_size,
             release,
-            window_snap_threshold,
+            edge_snap_threshold,
         }
     }
 

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -58,6 +58,7 @@ pub struct ResizeSurfaceGrab {
     window: CosmicMapped,
     edges: ResizeEdge,
     output: Output,
+    initial_window_location: Point<i32, Local>,
     initial_window_size: Size<i32, Logical>,
     last_window_size: Size<i32, Logical>,
     release: ReleaseMode,
@@ -91,6 +92,25 @@ impl ResizeSurfaceGrab {
             }
 
             new_window_width = (self.initial_window_size.w as f64 + dx) as i32;
+
+            // If the resizing vertical edge is close to our output's edge in the same direction, snap to it.
+            let output_geom = self.output.geometry().to_local(&self.output);
+            if self.edges.intersects(ResizeEdge::LEFT) {
+                if (self.initial_window_location.x - dx as i32 - output_geom.loc.x).abs() < 10 {
+                    new_window_width = self.initial_window_size.w - output_geom.loc.x
+                        + self.initial_window_location.x;
+                }
+            } else {
+                if (self.initial_window_location.x + self.initial_window_size.w + dx as i32
+                    - output_geom.loc.x
+                    - output_geom.size.w)
+                    .abs()
+                    < 10
+                {
+                    new_window_width =
+                        output_geom.loc.x - self.initial_window_location.x + output_geom.size.w;
+                }
+            }
         }
 
         if self.edges.intersects(top_bottom) {
@@ -99,6 +119,25 @@ impl ResizeSurfaceGrab {
             }
 
             new_window_height = (self.initial_window_size.h as f64 + dy) as i32;
+
+            // If the resizing horizontal edge is close to our output's edge in the same direction, snap to it.
+            let output_geom = self.output.geometry().to_local(&self.output);
+            if self.edges.intersects(ResizeEdge::TOP) {
+                if (self.initial_window_location.y - dy as i32 - output_geom.loc.y).abs() < 10 {
+                    new_window_height = self.initial_window_size.h - output_geom.loc.y
+                        + self.initial_window_location.y;
+                }
+            } else {
+                if (self.initial_window_location.y + self.initial_window_size.h + dy as i32
+                    - output_geom.loc.y
+                    - output_geom.size.h)
+                    .abs()
+                    < 10
+                {
+                    new_window_height =
+                        output_geom.loc.y - self.initial_window_location.y + output_geom.size.h;
+                }
+            }
         }
 
         let (min_size, max_size) = (self.window.min_size(), self.window.max_size());
@@ -414,6 +453,7 @@ impl ResizeSurfaceGrab {
             window: mapped,
             edges,
             output,
+            initial_window_location,
             initial_window_size,
             last_window_size: initial_window_size,
             release,

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -58,6 +58,7 @@ pub struct ResizeSurfaceGrab {
     window: CosmicMapped,
     edges: ResizeEdge,
     output: Output,
+    window_snap_threshold: i32,
     initial_window_location: Point<i32, Local>,
     initial_window_size: Size<i32, Logical>,
     last_window_size: Size<i32, Logical>,
@@ -96,7 +97,9 @@ impl ResizeSurfaceGrab {
             // If the resizing vertical edge is close to our output's edge in the same direction, snap to it.
             let output_geom = self.output.geometry().to_local(&self.output);
             if self.edges.intersects(ResizeEdge::LEFT) {
-                if (self.initial_window_location.x - dx as i32 - output_geom.loc.x).abs() < 10 {
+                if (self.initial_window_location.x - dx as i32 - output_geom.loc.x).abs()
+                    < self.window_snap_threshold
+                {
                     new_window_width = self.initial_window_size.w - output_geom.loc.x
                         + self.initial_window_location.x;
                 }
@@ -105,7 +108,7 @@ impl ResizeSurfaceGrab {
                     - output_geom.loc.x
                     - output_geom.size.w)
                     .abs()
-                    < 10
+                    < self.window_snap_threshold
                 {
                     new_window_width =
                         output_geom.loc.x - self.initial_window_location.x + output_geom.size.w;
@@ -123,7 +126,9 @@ impl ResizeSurfaceGrab {
             // If the resizing horizontal edge is close to our output's edge in the same direction, snap to it.
             let output_geom = self.output.geometry().to_local(&self.output);
             if self.edges.intersects(ResizeEdge::TOP) {
-                if (self.initial_window_location.y - dy as i32 - output_geom.loc.y).abs() < 10 {
+                if (self.initial_window_location.y - dy as i32 - output_geom.loc.y).abs()
+                    < self.window_snap_threshold
+                {
                     new_window_height = self.initial_window_size.h - output_geom.loc.y
                         + self.initial_window_location.y;
                 }
@@ -132,7 +137,7 @@ impl ResizeSurfaceGrab {
                     - output_geom.loc.y
                     - output_geom.size.h)
                     .abs()
-                    < 10
+                    < self.window_snap_threshold
                 {
                     new_window_height =
                         output_geom.loc.y - self.initial_window_location.y + output_geom.size.h;
@@ -414,6 +419,7 @@ impl ResizeSurfaceGrab {
         mapped: CosmicMapped,
         edges: ResizeEdge,
         output: Output,
+        window_snap_threshold: i32,
         initial_window_location: Point<i32, Local>,
         initial_window_size: Size<i32, Logical>,
         seat: &Seat<State>,
@@ -457,6 +463,7 @@ impl ResizeSurfaceGrab {
             initial_window_size,
             last_window_size: initial_window_size,
             release,
+            window_snap_threshold,
         }
     }
 

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -25,6 +25,7 @@ use smithay::{
 
 use crate::{
     backend::render::{element::AsGlowRenderer, IndicatorShader, Key, Usage},
+    config::Config,
     shell::{
         element::{
             resize_indicator::ResizeIndicator,
@@ -884,6 +885,7 @@ impl FloatingLayout {
 
     pub fn resize_request(
         &mut self,
+        config: &Config,
         mapped: &CosmicMapped,
         seat: &Seat<State>,
         start_data: GrabStartData,
@@ -900,6 +902,7 @@ impl FloatingLayout {
                 mapped.clone(),
                 edges,
                 self.space.outputs().next().cloned().unwrap(),
+                config.cosmic_conf.window_snap_threshold as i32,
                 location,
                 size,
                 seat,

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -25,7 +25,6 @@ use smithay::{
 
 use crate::{
     backend::render::{element::AsGlowRenderer, IndicatorShader, Key, Usage},
-    config::Config,
     shell::{
         element::{
             resize_indicator::ResizeIndicator,
@@ -885,11 +884,11 @@ impl FloatingLayout {
 
     pub fn resize_request(
         &mut self,
-        config: &Config,
         mapped: &CosmicMapped,
         seat: &Seat<State>,
         start_data: GrabStartData,
         edges: ResizeEdge,
+        edge_snap_threshold: u32,
         release: ReleaseMode,
     ) -> Option<ResizeSurfaceGrab> {
         if seat.get_pointer().is_some() {
@@ -902,7 +901,7 @@ impl FloatingLayout {
                 mapped.clone(),
                 edges,
                 self.space.outputs().next().cloned().unwrap(),
-                config.cosmic_conf.window_snap_threshold as i32,
+                edge_snap_threshold,
                 location,
                 size,
                 seat,

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2896,7 +2896,7 @@ impl Shell {
             initial_window_location,
             cursor_output,
             active_hint,
-            config.cosmic_conf.window_snap_threshold as f64,
+            config.cosmic_conf.edge_snap_threshold as f64,
             layer,
             release,
             evlh.clone(),
@@ -3148,10 +3148,10 @@ impl Shell {
 
     pub fn menu_resize_request(
         &mut self,
-        config: &Config,
         mapped: &CosmicMapped,
         seat: &Seat<State>,
         edge: ResizeEdge,
+        edge_snap_threshold: u32,
     ) -> Option<(
         (
             Option<(PointerFocusTarget, Point<f64, Logical>)>,
@@ -3215,11 +3215,11 @@ impl Shell {
         start_data.set_focus(focus.clone());
 
         let grab: ResizeGrab = if let Some(grab) = floating_layer.resize_request(
-            config,
             mapped,
             seat,
             start_data.clone(),
             edge,
+            edge_snap_threshold,
             ReleaseMode::Click,
         ) {
             grab.into()
@@ -3391,11 +3391,11 @@ impl Shell {
 
     pub fn resize_request(
         &mut self,
-        config: &Config,
         surface: &WlSurface,
         seat: &Seat<State>,
         serial: impl Into<Option<Serial>>,
         edges: ResizeEdge,
+        edge_snap_threshold: u32,
         client_initiated: bool,
     ) -> Option<(ResizeGrab, Focus)> {
         let serial = serial.into();
@@ -3419,11 +3419,11 @@ impl Shell {
         };
 
         let grab: ResizeGrab = if let Some(grab) = floating_layer.resize_request(
-            config,
             &mapped,
             seat,
             start_data.clone(),
             edges,
+            edge_snap_threshold,
             ReleaseMode::NoMouseButtons,
         ) {
             grab.into()

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2896,6 +2896,7 @@ impl Shell {
             initial_window_location,
             cursor_output,
             active_hint,
+            config.cosmic_conf.window_snap_threshold as f64,
             layer,
             release,
             evlh.clone(),
@@ -3147,6 +3148,7 @@ impl Shell {
 
     pub fn menu_resize_request(
         &mut self,
+        config: &Config,
         mapped: &CosmicMapped,
         seat: &Seat<State>,
         edge: ResizeEdge,
@@ -3213,6 +3215,7 @@ impl Shell {
         start_data.set_focus(focus.clone());
 
         let grab: ResizeGrab = if let Some(grab) = floating_layer.resize_request(
+            config,
             mapped,
             seat,
             start_data.clone(),
@@ -3388,6 +3391,7 @@ impl Shell {
 
     pub fn resize_request(
         &mut self,
+        config: &Config,
         surface: &WlSurface,
         seat: &Seat<State>,
         serial: impl Into<Option<Serial>>,
@@ -3415,6 +3419,7 @@ impl Shell {
         };
 
         let grab: ResizeGrab = if let Some(grab) = floating_layer.resize_request(
+            config,
             &mapped,
             seat,
             start_data.clone(),

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -197,9 +197,14 @@ impl XdgShellHandler for State {
     ) {
         let seat = Seat::from_resource(&seat).unwrap();
         let mut shell = self.common.shell.write().unwrap();
-        if let Some((grab, focus)) =
-            shell.resize_request(surface.wl_surface(), &seat, serial, edges.into(), true)
-        {
+        if let Some((grab, focus)) = shell.resize_request(
+            &self.common.config,
+            surface.wl_surface(),
+            &seat,
+            serial,
+            edges.into(),
+            true,
+        ) {
             std::mem::drop(shell);
             if grab.is_touch_grab() {
                 seat.get_touch().unwrap().set_grab(self, grab, serial)

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -198,11 +198,11 @@ impl XdgShellHandler for State {
         let seat = Seat::from_resource(&seat).unwrap();
         let mut shell = self.common.shell.write().unwrap();
         if let Some((grab, focus)) = shell.resize_request(
-            &self.common.config,
             surface.wl_surface(),
             &seat,
             serial,
             edges.into(),
+            self.common.config.cosmic_conf.edge_snap_threshold,
             true,
         ) {
             std::mem::drop(shell);

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -557,11 +557,11 @@ impl XwmHandler for State {
             let mut shell = self.common.shell.write().unwrap();
             let seat = shell.seats.last_active().clone();
             if let Some((grab, focus)) = shell.resize_request(
-                &self.common.config,
                 &wl_surface,
                 &seat,
                 None,
                 resize_edge.into(),
+                self.common.config.cosmic_conf.edge_snap_threshold,
                 true,
             ) {
                 std::mem::drop(shell);

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -556,9 +556,14 @@ impl XwmHandler for State {
         if let Some(wl_surface) = window.wl_surface() {
             let mut shell = self.common.shell.write().unwrap();
             let seat = shell.seats.last_active().clone();
-            if let Some((grab, focus)) =
-                shell.resize_request(&wl_surface, &seat, None, resize_edge.into(), true)
-            {
+            if let Some((grab, focus)) = shell.resize_request(
+                &self.common.config,
+                &wl_surface,
+                &seat,
+                None,
+                resize_edge.into(),
+                true,
+            ) {
                 std::mem::drop(shell);
                 if grab.is_touch_grab() {
                     seat.get_touch()


### PR DESCRIPTION
This is a feature that KDE has called "Snap Zones" which I find to be very useful for organizing floating layouts (especially small widgets like the Spotify miniplayer, demonstrated in the video).

When resizing or moving a floating/sticky window, any edge that gets too close to one of the currently active output's edges will be snapped into the output's edge, mitigating any pixel-perfect movements you would have to do otherwise to get window edges to align properly.

https://github.com/user-attachments/assets/9ea74bf9-af80-4e3c-a210-8e610c73a50e