### PR TITLE
Initial support for workspace pinning and moving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,10 +40,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?rev=67df697#67df697105486fa4c9dd6ce00889c8b0526c9bb4"
+source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#bc4af9183e0967802d7fbe91ba811a29ca6a3b67"
 dependencies = [
  "bitflags 2.8.0",
  "cosmic-protocols",
@@ -840,7 +840,7 @@ dependencies = [
  "ordered-float",
  "png",
  "profiling",
- "rand",
+ "rand 0.9.0",
  "regex",
  "reis",
  "ron",
@@ -874,6 +874,7 @@ version = "0.1.0"
 dependencies = [
  "cosmic-config",
  "input",
+ "libdisplay-info",
  "serde",
 ]
 
@@ -921,7 +922,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?rev=67df697#67df697105486fa4c9dd6ce00889c8b0526c9bb4"
+source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#bc4af9183e0967802d7fbe91ba811a29ca6a3b67"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -1907,7 +1908,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3248,7 +3261,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -3872,7 +3885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4010,7 +4023,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4113,14 +4126,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4130,7 +4160,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4139,7 +4179,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -4209,7 +4258,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -4714,7 +4763,7 @@ dependencies = [
  "pixman",
  "pkg-config",
  "profiling",
- "rand",
+ "rand 0.8.5",
  "rustix",
  "scopeguard",
  "smallvec",
@@ -4999,7 +5048,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",
@@ -5581,6 +5630,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6357,6 +6415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6548,7 +6615,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -6599,7 +6666,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -6607,6 +6683,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = {version = "1.0.51", features = ["backtrace"]}
 bitflags = "2.4"
 bytemuck = "1.12"
 calloop = {version = "0.14.1", features = ["executor"]}
-cosmic-comp-config = {path = "cosmic-comp-config"}
+cosmic-comp-config = {path = "cosmic-comp-config", features = ["libdisplay-info"]}
 cosmic-config = {git = "https://github.com/pop-os/libcosmic/", features = ["calloop", "macro"]}
 cosmic-protocols = {git = "https://github.com/pop-os/cosmic-protocols", rev = "e706814", default-features = false, features = ["server"]}
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
@@ -59,7 +59,7 @@ zbus = "4.4.0"
 profiling = { version = "1.0" }
 rustix = { version = "0.38.32", features = ["process"] }
 smallvec = "1.13.2"
-rand = "0.8.5"
+rand = "0.9.0"
 reis = { version = "0.4", features = ["calloop"] }
 # CLI arguments
 clap_lex = "0.7"
@@ -119,8 +119,8 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/pop-os/cosmic-protocols"]
-cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", rev = "67df697" }
-cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", rev = "67df697" }
+cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
+cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch."https://github.com/smithay/smithay"]
 smithay = { git = "https://github.com/smithay/smithay//", rev = "ce61c9b" }

--- a/cosmic-comp-config/Cargo.toml
+++ b/cosmic-comp-config/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 cosmic-config = { git = "https://github.com/pop-os/libcosmic/" }
 input = "0.9.0"
+libdisplay-info = { version = "0.2.0", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub mod input;
+pub mod output;
 pub mod workspace;
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -25,6 +26,7 @@ pub enum NumlockState {
 #[version = 1]
 pub struct CosmicCompConfig {
     pub workspaces: workspace::WorkspaceConfig,
+    pub pinned_workspaces: Vec<workspace::PinnedWorkspace>,
     pub input_default: input::InputConfig,
     pub input_touchpad: input::InputConfig,
     pub input_devices: HashMap<String, input::InputConfig>,
@@ -57,6 +59,7 @@ impl Default for CosmicCompConfig {
     fn default() -> Self {
         Self {
             workspaces: Default::default(),
+            pinned_workspaces: Vec::new(),
             input_default: Default::default(),
             // By default, enable tap-to-click and disable-while-typing.
             input_touchpad: input::InputConfig {

--- a/cosmic-comp-config/src/output.rs
+++ b/cosmic-comp-config/src/output.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EdidProduct {
+    pub manufacturer: [char; 3],
+    pub product: u16,
+    pub serial: Option<u32>,
+    pub manufacture_week: i32,
+    pub manufacture_year: i32,
+    pub model_year: Option<i32>,
+}
+
+#[cfg(feature = "libdisplay-info")]
+impl From<libdisplay_info::edid::VendorProduct> for EdidProduct {
+    fn from(vp: libdisplay_info::edid::VendorProduct) -> Self {
+        Self {
+            manufacturer: vp.manufacturer,
+            product: vp.product,
+            serial: vp.serial,
+            manufacture_week: vp.manufacture_week,
+            manufacture_year: vp.manufacture_year,
+            model_year: vp.model_year,
+        }
+    }
+}

--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::output::EdidProduct;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
     pub workspace_mode: WorkspaceMode,
@@ -29,4 +31,17 @@ pub enum WorkspaceLayout {
     #[default]
     Vertical,
     Horizontal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutputMatch {
+    pub name: String,
+    pub edid: Option<EdidProduct>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PinnedWorkspace {
+    pub output: OutputMatch,
+    pub tiling_enabled: bool,
+    // TODO: name, id
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,6 +43,7 @@ pub use key_bindings::{Action, PrivateAction};
 mod types;
 pub use self::types::*;
 use cosmic::config::CosmicTk;
+pub use cosmic_comp_config::output::EdidProduct;
 use cosmic_comp_config::{
     input::InputConfig, workspace::WorkspaceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior,
     XkbConfig, XwaylandDescaling, XwaylandEavesdropping, ZoomConfig,
@@ -90,29 +91,6 @@ impl From<Output> for OutputInfo {
             connector: o.name(),
             make: physical.make,
             model: physical.model,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EdidProduct {
-    pub manufacturer: [char; 3],
-    pub product: u16,
-    pub serial: Option<u32>,
-    pub manufacture_week: i32,
-    pub manufacture_year: i32,
-    pub model_year: Option<i32>,
-}
-
-impl From<libdisplay_info::edid::VendorProduct> for EdidProduct {
-    fn from(vp: libdisplay_info::edid::VendorProduct) -> Self {
-        Self {
-            manufacturer: vp.manufacturer,
-            product: vp.product,
-            serial: vp.serial,
-            manufacture_week: vp.manufacture_week,
-            manufacture_year: vp.manufacture_year,
-            model_year: vp.model_year,
         }
     }
 }

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -1,12 +1,12 @@
 use crate::{shell::ActivationKey, state::ClientState, utils::prelude::*};
-use crate::{state::State, wayland::protocols::workspace::WorkspaceHandle};
+use crate::{
+    state::State,
+    wayland::protocols::workspace::{State as WState, WorkspaceHandle},
+};
 use smithay::{
     delegate_xdg_activation,
     input::Seat,
-    reexports::{
-        wayland_protocols::ext::workspace::v1::server::ext_workspace_handle_v1::State as WState,
-        wayland_server::protocol::wl_surface::WlSurface,
-    },
+    reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::xdg_activation::{
         XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
     },

--- a/src/wayland/protocols/workspace/ext.rs
+++ b/src/wayland/protocols/workspace/ext.rs
@@ -20,7 +20,7 @@ use smithay::{
 use std::{collections::HashSet, sync::Mutex};
 
 use super::{
-    Request, Workspace, WorkspaceCapabilities, WorkspaceGlobalData, WorkspaceGroup,
+    Request, State, Workspace, WorkspaceCapabilities, WorkspaceGlobalData, WorkspaceGroup,
     WorkspaceGroupHandle, WorkspaceHandler, WorkspaceState,
 };
 
@@ -469,12 +469,23 @@ where
         changed = true;
     }
 
-    if handle_state.states != Some(workspace.states) {
-        instance.state(workspace.states);
-        handle_state.states = Some(workspace.states.clone());
+    let states = workspace
+        .states
+        .iter()
+        .filter_map(|state| match state {
+            State::Active => Some(ext_workspace_handle_v1::State::Active),
+            State::Urgent => Some(ext_workspace_handle_v1::State::Urgent),
+            State::Hidden => Some(ext_workspace_handle_v1::State::Hidden),
+            _ => None,
+        })
+        .collect();
+    if handle_state.states != Some(states) {
+        instance.state(states);
+        handle_state.states = Some(states);
         changed = true;
     }
     // TODO ext_workspace_handle_v1::id
+    // TODO send id if pinned
 
     if let Some(cosmic_v2_handle) = handle_state
         .cosmic_v2_handle


### PR DESCRIPTION
Initial compositor-side prototype for https://github.com/pop-os/cosmic-workspaces-epoch/issues/108, using https://github.com/pop-os/cosmic-protocols/pull/48.

This adds a pinned flag for workspaces, which prevents the workspace from being removed automatically when empty, and allows a new workspace after it.

This does not yet persist pinned workspaces. Or allow re-ordering workspaces. We probably want to persist pinned workspaces by monitor and order, with names.