### PR TITLE
shell: Handle maximize requests before commit

### DIFF
--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -277,11 +277,11 @@ impl State {
     fn send_initial_configure_and_map(&mut self, surface: &WlSurface) -> bool {
         let mut shell = self.common.shell.write().unwrap();
 
-        if let Some((window, _, _)) = shell
+        if let Some(window) = shell
             .pending_windows
             .iter()
-            .find(|(window, _, _)| window.wl_surface().as_deref() == Some(surface))
-            .cloned()
+            .find(|pending| pending.surface.wl_surface().as_deref() == Some(surface))
+            .map(|pending| pending.surface.clone())
         {
             if let Some(toplevel) = window.0.toplevel() {
                 if toplevel_ensure_initial_configure(&toplevel)
@@ -305,11 +305,11 @@ impl State {
             }
         }
 
-        if let Some((layer_surface, _, _)) = shell
+        if let Some(layer_surface) = shell
             .pending_layers
             .iter()
-            .find(|(layer_surface, _, _)| layer_surface.wl_surface() == surface)
-            .cloned()
+            .find(|pending| pending.surface.wl_surface() == surface)
+            .map(|pending| pending.surface.clone())
         {
             if !layer_surface_check_inital_configure(&layer_surface) {
                 // compute initial dimensions by mapping

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::utils::prelude::*;
+use crate::{shell::PendingLayer, utils::prelude::*};
 use smithay::{
     delegate_layer_shell,
     desktop::{layer_map_for_output, LayerSurface, PopupKind, WindowSurfaceType},
@@ -32,9 +32,11 @@ impl WlrLayerShellHandler for State {
             .as_ref()
             .and_then(Output::from_resource)
             .unwrap_or_else(|| seat.active_output());
-        shell
-            .pending_layers
-            .push((LayerSurface::new(surface, namespace), output, seat));
+        shell.pending_layers.push(PendingLayer {
+            surface: LayerSurface::new(surface, namespace),
+            output,
+            seat,
+        });
     }
 
     fn new_popup(&mut self, _parent: WlrLayerSurface, popup: PopupSurface) {


### PR DESCRIPTION
Similar to how we handle fullscreen-requests for unmapped windows.

While I am at it, this also refactors pending windows and layers a bit to make handling nicer. It also allows to unset the fullscreen state on pending windows again, which should be legal according to the protocol, but wasn't handled correctly previously.