### PR TITLE
shell: Handle maximize requests before commit

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2219,7 +2219,7 @@ impl Shell {
         }
 
         if !should_be_fullscreen && should_be_maximized {
-            self.maximize_request(&mapped, &seat);
+            self.maximize_request(&mapped, &seat, false);
         }
 
         let new_target = if (workspace_output == seat.active_output()
@@ -3239,7 +3239,7 @@ impl Shell {
             if window.is_fullscreen(true) {
                 return;
             }
-            self.maximize_request(window, seat);
+            self.maximize_request(window, seat, true);
         }
     }
 
@@ -3310,7 +3310,7 @@ impl Shell {
         }
     }
 
-    pub fn maximize_request(&mut self, mapped: &CosmicMapped, seat: &Seat<State>) {
+    pub fn maximize_request(&mut self, mapped: &CosmicMapped, seat: &Seat<State>, animate: bool) {
         self.unminimize_request(mapped, seat);
         let (original_layer, floating_layer, original_geometry) = if let Some(set) = self
             .workspaces
@@ -3339,7 +3339,7 @@ impl Shell {
                 original_layer,
             });
             std::mem::drop(state);
-            floating_layer.map_maximized(mapped.clone(), original_geometry, true);
+            floating_layer.map_maximized(mapped.clone(), original_geometry, animate);
         }
     }
 
@@ -3568,7 +3568,7 @@ impl Shell {
 
             if was_maximized {
                 if let Some(KeyboardFocusTarget::Element(mapped)) = res.as_ref() {
-                    self.maximize_request(mapped, seat);
+                    self.maximize_request(mapped, seat, false);
                 }
             }
 

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -277,11 +277,11 @@ impl State {
     fn send_initial_configure_and_map(&mut self, surface: &WlSurface) -> bool {
         let mut shell = self.common.shell.write().unwrap();
 
-        if let Some((window, _, _)) = shell
+        if let Some(window) = shell
             .pending_windows
             .iter()
-            .find(|(window, _, _)| window.wl_surface().as_deref() == Some(surface))
-            .cloned()
+            .find(|pending| pending.surface.wl_surface().as_deref() == Some(surface))
+            .map(|pending| pending.surface.clone())
         {
             if let Some(toplevel) = window.0.toplevel() {
                 if toplevel_ensure_initial_configure(&toplevel)
@@ -305,11 +305,11 @@ impl State {
             }
         }
 
-        if let Some((layer_surface, _, _)) = shell
+        if let Some(layer_surface) = shell
             .pending_layers
             .iter()
-            .find(|(layer_surface, _, _)| layer_surface.wl_surface() == surface)
-            .cloned()
+            .find(|pending| pending.surface.wl_surface() == surface)
+            .map(|pending| pending.surface.clone())
         {
             if !layer_surface_check_inital_configure(&layer_surface) {
                 // compute initial dimensions by mapping

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::utils::prelude::*;
+use crate::{shell::PendingLayer, utils::prelude::*};
 use smithay::{
     delegate_layer_shell,
     desktop::{layer_map_for_output, LayerSurface, PopupKind, WindowSurfaceType},
@@ -32,9 +32,11 @@ impl WlrLayerShellHandler for State {
             .as_ref()
             .and_then(Output::from_resource)
             .unwrap_or_else(|| seat.active_output());
-        shell
-            .pending_layers
-            .push((LayerSurface::new(surface, namespace), output, seat));
+        shell.pending_layers.push(PendingLayer {
+            surface: LayerSurface::new(surface, namespace),
+            output,
+            seat,
+        });
     }
 
     fn new_popup(&mut self, _parent: WlrLayerSurface, popup: PopupSurface) {

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -210,7 +210,7 @@ impl ToplevelManagementHandler for State {
         let mut shell = self.common.shell.write().unwrap();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             let seat = shell.seats.last_active().clone();
-            shell.maximize_request(&mapped, &seat);
+            shell.maximize_request(&mapped, &seat, true);
         }
     }
 

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -226,7 +226,7 @@ impl XdgShellHandler for State {
         let mut shell = self.common.shell.write().unwrap();
         if let Some(mapped) = shell.element_for_surface(surface.wl_surface()).cloned() {
             let seat = shell.seats.last_active().clone();
-            shell.maximize_request(&mapped, &seat)
+            shell.maximize_request(&mapped, &seat, true)
         } else if let Some(pending) = shell
             .pending_windows
             .iter_mut()

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -612,7 +612,7 @@ impl XwmHandler for State {
         let mut shell = self.common.shell.write().unwrap();
         if let Some(mapped) = shell.element_for_surface(&window).cloned() {
             let seat = shell.seats.last_active().clone();
-            shell.maximize_request(&mapped, &seat);
+            shell.maximize_request(&mapped, &seat, true);
         } else if let Some(pending) = shell
             .pending_windows
             .iter_mut()


### PR DESCRIPTION
Similar to how we handle fullscreen-requests for unmapped windows.

While I am at it, this also refactors pending windows and layers a bit to make handling nicer. It also allows to unset the fullscreen state on pending windows again, which should be legal according to the protocol, but wasn't handled correctly previously.
