### PR TITLE
Reactivated num/caps-lock upon keyboard layour change

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -94,23 +94,7 @@ pub fn init_backend_auto(
         if toggle_numlock {
             /// Linux scancode for numlock key.
             const NUMLOCK_SCANCODE: u32 = 69;
-            /// Offset used to convert Linux scancode to X11 keycode.
-            const X11_KEYCODE_OFFSET: u32 = 8;
-
-            let mut input = |key_state| {
-                let time = state.common.clock.now().as_millis();
-                let _ = keyboard.input(
-                    state,
-                    smithay_input::Keycode::new(NUMLOCK_SCANCODE + X11_KEYCODE_OFFSET),
-                    key_state,
-                    SERIAL_COUNTER.next_serial(),
-                    time,
-                    |_, _, _| smithay::input::keyboard::FilterResult::<()>::Forward,
-                );
-            };
-            // Press and release the numlock key to update modifiers.
-            input(smithay_input::KeyState::Pressed);
-            input(smithay_input::KeyState::Released);
+            crate::config::change_modifier_state(&keyboard, NUMLOCK_SCANCODE, state);
         }
         {
             {


### PR DESCRIPTION
When changing keyboard layout, modifier state of keyboard resets to default. This happens here  `keyboard.set_xkb_config(..)`. In turn this call leads to `KeyboardHandle::update_xkb_state` call, which in turn executes such code
```
let mut state = xkb::State::new(&keymap);
for key in &internal.pressed_keys {
    state.update_key(*key, xkb::KeyDirection::Down);
}
```

To make sure, that numlock/capslock state is not modified, we read old state, and if needed active those modifiers again.
