### PR TITLE
Derive Eq for NumlockState

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -13,7 +13,7 @@ pub struct KeyboardConfig {
     pub numlock_state: NumlockState,
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NumlockState {
     BootOn,
     #[default]


### PR DESCRIPTION
This will allow NumlockState to be used as a radio value in cosmic-settings.