### PR TITLE
WIP match output by edid, falling back to connector name

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,7 +29,7 @@ pub use smithay::{
 };
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fs::OpenOptions,
     io::Write,
     path::PathBuf,
@@ -73,7 +73,7 @@ pub struct DynamicConfig {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct OutputsConfig {
-    pub config: HashMap<Vec<OutputInfo>, Vec<OutputConfig>>,
+    pub config: HashMap<BTreeSet<OutputInfo>, Vec<OutputConfig>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -459,12 +459,11 @@ impl Config {
         clock: &Clock<Monotonic>,
     ) {
         let outputs = output_state.outputs().collect::<Vec<_>>();
-        let mut infos = outputs
+        let infos = outputs
             .iter()
             .cloned()
             .map(Into::<crate::config::OutputInfo>::into)
-            .collect::<Vec<_>>();
-        infos.sort();
+            .collect::<BTreeSet<_>>();
         if let Some(configs) = self.dynamic_conf.outputs().config.get(&infos).cloned() {
             let known_good_configs = outputs
                 .iter()

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -84,6 +84,7 @@ pub struct Workspace {
     pub handle: WorkspaceHandle,
     pub focus_stack: FocusStacks,
     pub screencopy: ScreencopySessions,
+    // TODO edid info
     pub output_stack: VecDeque<String>,
     pub pending_tokens: HashSet<XdgActivationToken>,
     pub(super) backdrop_id: Id,

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -9,7 +9,7 @@ pub use crate::shell::{SeatExt, Shell, Workspace};
 pub use crate::state::{Common, State};
 pub use crate::wayland::handlers::xdg_shell::popup::update_reactive_popups;
 use crate::{
-    config::{AdaptiveSync, OutputConfig, OutputState},
+    config::{AdaptiveSync, EdidProduct, OutputConfig, OutputState},
     shell::zoom::OutputZoomState,
 };
 
@@ -35,6 +35,8 @@ pub trait OutputExt {
     fn is_enabled(&self) -> bool;
     fn config(&self) -> Ref<'_, OutputConfig>;
     fn config_mut(&self) -> RefMut<'_, OutputConfig>;
+
+    fn edid(&self) -> Option<EdidProduct>;
 }
 
 struct Vrr(AtomicU8);
@@ -157,5 +159,9 @@ impl OutputExt for Output {
             .get::<RefCell<OutputConfig>>()
             .unwrap()
             .borrow_mut()
+    }
+
+    fn edid(&self) -> Option<EdidProduct> {
+        self.user_data().get().copied()
     }
 }


### PR DESCRIPTION
Matching by connector name may work well for some uses, but is pretty inconsistent with display controllers that dynamically add DRM connectors, with variable numbering.

My idea is to only match outputs with the same edid vendor/product information (which should be the same physical display), and fallback to connectors if two somehow are identical. I think that would general match expected behavior?

I'm not sure this is working correctly, and I need to update the `output_stack` too. If persisted state ends up with display information in multiple places, it could make sense to track in just one place somehow...

This should also be used for persisted pinned workspaces (not sure if we want to persist a whole `output_stack`, or only the last output it was explicitly placed on?)