### PR TITLE
Throttle refresh routines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use calloop::timer::{TimeoutAction, Timer};
 use smithay::{
     reexports::{
         calloop::{generic::Generic, EventLoop, Interest, Mode, PostAction},
@@ -9,8 +10,15 @@ use smithay::{
 };
 
 use anyhow::{Context, Result};
-use state::State;
-use std::{env, ffi::OsString, os::unix::process::CommandExt, process, sync::Arc};
+use state::{LastRefresh, State};
+use std::{
+    env,
+    ffi::OsString,
+    os::unix::process::CommandExt,
+    process,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tracing::{error, info, warn};
 use wayland::protocols::overlap_notify::OverlapNotifyState;
 
@@ -134,10 +142,8 @@ fn main() -> Result<()> {
                 client_compositor_state(&client).blocker_cleared(state, &dh);
             }
         }
-        state.common.refresh();
-        state::Common::refresh_focus(state);
-        OverlapNotifyState::refresh(state);
-        state.common.update_x11_stacking_order();
+
+        refresh(state);
 
         {
             let shell = state.common.shell.read().unwrap();
@@ -229,4 +235,33 @@ fn init_wayland_display(
         .with_context(|| "Failed to init the wayland event source.")?;
 
     Ok((handle, socket_name))
+}
+
+fn refresh(state: &mut State) {
+    if !matches!(state.last_refresh, LastRefresh::None)
+        && !matches!(state.last_refresh, LastRefresh::At(instant) if Instant::now().duration_since(instant) >= Duration::from_millis(100))
+    {
+        if let LastRefresh::Scheduled(token) = &state.last_refresh {
+            state.common.event_loop_handle.remove(token.clone());
+        }
+
+        if let Ok(token) = state.common.event_loop_handle.insert_source(
+            Timer::from_duration(Duration::from_millis(100)),
+            |_, _, state| {
+                state.last_refresh = LastRefresh::None;
+                TimeoutAction::Drop
+            },
+        ) {
+            state.last_refresh = LastRefresh::Scheduled(token);
+            return;
+        } else {
+            warn!("Failed to schedule refresh");
+        }
+    }
+
+    state.common.refresh();
+    state::Common::refresh_focus(state);
+    OverlapNotifyState::refresh(state);
+    state.common.update_x11_stacking_order();
+    state.last_refresh = LastRefresh::At(Instant::now());
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,7 +119,7 @@ use std::{
     ffi::OsString,
     process::Child,
     sync::{atomic::AtomicBool, Arc, Mutex, Once, RwLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 #[derive(RustEmbed)]
@@ -172,10 +172,18 @@ pub fn advertised_node_for_surface(w: &WlSurface, dh: &DisplayHandle) -> Option<
 }
 
 #[derive(Debug)]
+pub enum LastRefresh {
+    None,
+    At(Instant),
+    Scheduled(RegistrationToken),
+}
+
+#[derive(Debug)]
 pub struct State {
     pub backend: BackendData,
     pub common: Common,
     pub ready: Once,
+    pub last_refresh: LastRefresh,
 }
 
 #[derive(Debug)]
@@ -655,6 +663,7 @@ impl State {
             },
             backend: BackendData::Unset,
             ready: Once::new(),
+            last_refresh: LastRefresh::None,
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/883.
Supersedes https://github.com/pop-os/cosmic-comp/pull/1279.

Profiling with [samply](https://github.com/mstange/samply) shows a very significant drop in `refresh` calls as well in the overall cpu usage.

Notably this only fixes the cosmic-comp side to some degree. Some clients consuming toplevel-info like `cosmic-files-applet` are still using a lot of cpu, as is `cosmic-term`, during resizing for testing this. But that warrants a separate issue in the respective projects.