### PR TITLE
Throttle refresh routines

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -119,7 +119,7 @@ use std::{
     ffi::OsString,
     process::Child,
     sync::{atomic::AtomicBool, Arc, Mutex, Once, RwLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 #[derive(RustEmbed)]
@@ -172,10 +172,18 @@ pub fn advertised_node_for_surface(w: &WlSurface, dh: &DisplayHandle) -> Option<
 }
 
 #[derive(Debug)]
+pub enum LastRefresh {
+    None,
+    At(Instant),
+    Scheduled(RegistrationToken),
+}
+
+#[derive(Debug)]
 pub struct State {
     pub backend: BackendData,
     pub common: Common,
     pub ready: Once,
+    pub last_refresh: LastRefresh,
 }
 
 #[derive(Debug)]
@@ -655,6 +663,7 @@ impl State {
             },
             backend: BackendData::Unset,
             ready: Once::new(),
+            last_refresh: LastRefresh::None,
         }
     }
 


### PR DESCRIPTION
(Re-opened due to branch naming CI stuff.)

Fixes https://github.com/pop-os/cosmic-comp/issues/883.
Supersedes https://github.com/pop-os/cosmic-comp/pull/1279.

Profiling with [samply](https://github.com/mstange/samply) shows a very significant drop in `refresh` calls as well in the overall cpu usage.

Notably this only fixes the cosmic-comp side to some degree. Some clients consuming toplevel-info like `cosmic-files-applet` are still using a lot of cpu, as is `cosmic-term`, during resizing for testing this. But that warrants a separate issue in the respective projects.