### PR TITLE
Address some visible jank from refresh throttling

### DIFF
--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -371,6 +371,7 @@ impl FloatingLayout {
         }
         self.space
             .map_element(mapped, geometry.loc.as_logical(), true);
+        self.space.refresh();
     }
 
     pub(in crate::shell) fn map_internal(
@@ -585,6 +586,7 @@ impl FloatingLayout {
             );
         }
         self.space.map_element(mapped, position.as_logical(), false);
+        self.space.refresh();
     }
 
     pub fn remap_minimized(
@@ -612,6 +614,7 @@ impl FloatingLayout {
         mapped.set_minimized(false);
         self.space
             .map_element(mapped.clone(), position.as_logical(), true);
+        self.space.refresh();
         let target_geometry = self.space.element_geometry(&mapped).unwrap().as_local();
 
         self.animations.insert(
@@ -1062,6 +1065,7 @@ impl FloatingLayout {
                 self.map(window, None);
             }
             self.space.map_element(mapped.clone(), location, false);
+            self.space.refresh();
 
             for elem in new_elements.into_iter().rev() {
                 focus_stack.append(&elem);

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -842,6 +842,8 @@ impl<P: Program + Send + 'static> SpaceElement for IcedElement<P> {
         });
 
         internal.outputs.insert(output.clone());
+        std::mem::drop(internal);
+        self.refresh();
     }
 
     fn output_leave(&self, output: &Output) {


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/1287

`smithay::desktop::Space` used in our floating layout, only sends out `output_enter` events grouped on `refresh`. This is somewhat problematic with our new throttling, as it can cause entire server-side widgets to not show up until after the next refresh.

We barely map a larger count of windows at once anyway, so lets just make sure to force a refresh of the space (only) after mapping.

Additionally our iced integration also (de-)allocates buffers on refresh, which is why `output_leave` already called that, but `output_enter` didn't. Lets fix that, so we immediately get new contents on `output_enter` without having to make sure that we also call `refresh` on each and every server-side rendered widget. A second refresh call will not allocate a new buffer anyway.