### PR TITLE
fix: Remove unnecessary scaling of borders

### DIFF
--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -190,7 +190,6 @@ impl IndicatorShader {
         key: impl Into<Key>,
         mut element_geo: Rectangle<i32, Local>,
         thickness: u8,
-        scale: f64,
         alpha: f32,
         active_window_hint: [f32; 3],
     ) -> PixelShaderElement {
@@ -205,7 +204,6 @@ impl IndicatorShader {
             thickness,
             thickness * 2,
             alpha,
-            scale,
             active_window_hint,
         )
     }
@@ -217,12 +215,8 @@ impl IndicatorShader {
         thickness: u8,
         radius: u8,
         alpha: f32,
-        scale: f64,
         color: [f32; 3],
     ) -> PixelShaderElement {
-        let thickness = (thickness as f64 * scale).round() as u8;
-        let radius = (radius as f64 * scale).round() as u8;
-
         let settings = IndicatorSettings {
             thickness,
             radius,

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -125,7 +125,6 @@ impl MoveGrabState {
                     )
                     .as_local(),
                     self.indicator_thickness,
-                    output_scale.x,
                     alpha,
                     [
                         active_window_hint.red,
@@ -159,7 +158,6 @@ impl MoveGrabState {
                         thickness,
                         theme.radius_s()[0] as u8, // TODO: Fix once shaders support 4 corner radii customization
                         1.0,
-                        output_scale.x,
                         [
                             active_window_hint.red,
                             active_window_hint.green,

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1576,7 +1576,6 @@ impl FloatingLayout {
                         Key::Window(Usage::FocusIndicator, elem.key()),
                         geometry,
                         indicator_thickness,
-                        output_scale,
                         alpha,
                         [
                             active_window_hint.red,

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -3346,7 +3346,6 @@ impl TilingLayout {
                 None,
                 1.0,
                 overview.alpha().unwrap(),
-                1.0,
                 placeholder_id,
                 Some(None),
                 None,
@@ -4002,7 +4001,6 @@ impl TilingLayout {
                     // but for that we have to associate focus with a tree (and animate focus changes properly)
                     1.0 - transition,
                     transition,
-                    output_scale,
                     &self.placeholder_id,
                     is_mouse_tiling,
                     swap_desc.clone(),
@@ -4040,7 +4038,6 @@ impl TilingLayout {
                 seat,
                 transition,
                 transition,
-                output_scale,
                 &self.placeholder_id,
                 is_mouse_tiling,
                 swap_desc.clone(),
@@ -4153,7 +4150,6 @@ impl TilingLayout {
                     // but for that we have to associate focus with a tree (and animate focus changes properly)
                     1.0 - transition,
                     transition,
-                    output_scale,
                     &self.placeholder_id,
                     is_mouse_tiling,
                     swap_desc.clone(),
@@ -4189,7 +4185,6 @@ impl TilingLayout {
                 seat,
                 transition,
                 transition,
-                output_scale,
                 &self.placeholder_id,
                 is_mouse_tiling,
                 swap_desc.clone(),
@@ -4264,7 +4259,6 @@ fn geometries_for_groupview<'a, R>(
     seat: Option<&Seat<State>>,
     alpha: f32,
     transition: f32,
-    output_scale: f64,
     placeholder_id: &Id,
     mouse_tiling: Option<Option<&TargetZone>>,
     swap_desc: Option<NodeDesc>,
@@ -4465,7 +4459,6 @@ where
                                     4,
                                     if render_active_child { 16 } else { 8 },
                                     alpha * if render_potential_group { 0.40 } else { 1.0 },
-                                    output_scale,
                                     group_color,
                                 )
                                 .into(),
@@ -4483,7 +4476,6 @@ where
                                     4,
                                     8,
                                     alpha * 0.40,
-                                    output_scale,
                                     group_color,
                                 )
                                 .into(),
@@ -4547,7 +4539,6 @@ where
                                         4,
                                         8,
                                         alpha * 0.15,
-                                        output_scale,
                                         group_color,
                                     )
                                     .into(),
@@ -4784,7 +4775,6 @@ where
                                     4,
                                     8,
                                     alpha * 0.40,
-                                    output_scale,
                                     group_color,
                                 )
                                 .into(),
@@ -5008,7 +4998,6 @@ where
                         Key::Window(Usage::FocusIndicator, mapped.clone().key()),
                         geo,
                         indicator_thickness,
-                        output_scale,
                         alpha,
                         [window_hint.red, window_hint.green, window_hint.blue],
                     ),
@@ -5276,7 +5265,6 @@ where
                 Key::Static(swapping_stack_surface_id.clone()),
                 swap_geo,
                 4,
-                output_scale,
                 transition.unwrap_or(1.0),
                 [window_hint.red, window_hint.green, window_hint.blue],
             ),
@@ -5369,7 +5357,6 @@ where
                             } else {
                                 indicator_thickness
                             },
-                            output_scale,
                             alpha,
                             [window_hint.red, window_hint.green, window_hint.blue],
                         ));


### PR DESCRIPTION
I noticed that the active window hint scales more than the rest of the UI, so I tried removing the seemingly special treatment given to border scaling:
```rust
let thickness = (thickness as f64 * scale).round() as u8;
let radius = (radius as f64 * scale).round() as u8;
```
And now it scales in line with everything else. 