### PR TITLE
chore: smithay update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2934,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "libseat"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a0adf8d8607a73a5b74cbe4132f57cb349e4bf860103cd089461bbcbc9907e"
+checksum = "c23a245bbd5790c690791c4fe6eefafe4c75851226288a71cb657601135aa00c"
 dependencies = [
  "errno",
  "libseat-sys",
@@ -2945,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "libseat-sys"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3671cb5e03871f1d6bf0b3b5daa9275549e348fa6359e0f9adb910ca163d4c34"
+checksum = "134621e50557e8698a96ccff3eadbc6f4b449d5d12f8aa48fcef8d40b4b02725"
 dependencies = [
  "pkg-config",
 ]
@@ -4386,7 +4386,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4671,9 +4671,10 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay"
-version = "0.4.0"
-source = "git+https://github.com/smithay/smithay.git?rev=f93476c#f93476cebab3d47f6729354805b3e184f6878ef2"
+version = "0.5.0"
+source = "git+https://github.com/smithay/smithay?rev=a503d98#a503d981d1be9a54b286ab5e160e4b9edddb500f"
 dependencies = [
+ "aliasable",
  "appendlist",
  "ash",
  "bitflags 2.8.0",
@@ -4760,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "smithay-egui"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay-egui.git?rev=e9411da#e9411da9932316d6770661788c348f4b5a9be184"
+source = "git+https://github.com/Smithay/smithay-egui.git?rev=e720136#e7201366b88e4fb20d0c6618a6cac9acc6299e07"
 dependencies = [
  "cgmath",
  "egui",
@@ -4986,7 +4987,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5691,9 +5692,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.7"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
+checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
 dependencies = [
  "rustix",
  "wayland-client",
@@ -5702,9 +5703,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-egl"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3cb8b84ff95310fe59ce6c61f1fa344ec22f4c240c369a2b20f15caebfede4"
+checksum = "504838241a10e271f48ffd429ac4033e0ac468b399fe7c2e2840f5c3a82d9902"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -5725,9 +5726,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-misc"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2e42969764e469a115d4bb1c16e9588ef8b75b127ba7a2c9ddf1e140b25ca7"
+checksum = "feb7ee1810026d1bb15d47086d03a7e5c68651c707e305ba1e8cc796fcbf5a54"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -5751,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
+checksum = "248a02e6f595aad796561fa82d25601bd2c8c3b145b1c7453fc8f94c1a58f8b2"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -5959,7 +5960,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,13 +84,14 @@ features = [
   "wayland_frontend",
   "xwayland",
 ]
-version = "0.4"
+git = "https://github.com/smithay/smithay"
+rev = "a503d98"
 
 [dependencies.smithay-egui]
 features = ["svg"]
 git = "https://github.com/Smithay/smithay-egui.git"
 optional = true
-rev = "e9411da"
+rev = "e720136"
 
 [features]
 debug = ["egui", "egui_plot", "smithay-egui", "anyhow/backtrace"]
@@ -113,9 +114,6 @@ inherits = "release"
 
 [profile.release]
 lto = "fat"
-
-[patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "f93476c" }
 
 [patch."https://github.com/pop-os/cosmic-protocols"]
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", rev = "e706814" }

--- a/src/backend/kms/render/gles.rs
+++ b/src/backend/kms/render/gles.rs
@@ -11,7 +11,7 @@ use smithay::backend::{
         gles::GlesError,
         glow::GlowRenderer,
         multigpu::{ApiDevice, Error as MultiError, GraphicsApi},
-        Renderer,
+        RendererSuper,
     },
     SwapBuffersError,
 };
@@ -182,7 +182,7 @@ impl ApiDevice for GbmGlowDevice {
 impl<T: GraphicsApi, A: AsFd + Clone + 'static> FromGlesError for MultiError<GbmGlowBackend<A>, T>
 where
     T::Error: 'static,
-    <<T::Device as ApiDevice>::Renderer as Renderer>::Error: 'static,
+    <<T::Device as ApiDevice>::Renderer as RendererSuper>::Error: 'static,
 {
     #[inline]
     fn from_gles_error(err: GlesError) -> MultiError<GbmGlowBackend<A>, T> {

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -131,7 +131,7 @@ pub fn draw_surface_cursor<R>(
 ) -> Vec<(CursorRenderElement<R>, Point<i32, BufferCoords>)>
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
 {
     let position = location.into();
     let scale = scale.into();
@@ -172,7 +172,7 @@ pub fn draw_dnd_icon<R>(
 ) -> Vec<WaylandSurfaceRenderElement<R>>
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
 {
     if get_role(&surface) != Some("dnd_icon") {
         warn!(
@@ -262,7 +262,7 @@ pub fn draw_cursor<R>(
 ) -> Vec<(CursorRenderElement<R>, Point<i32, BufferCoords>)>
 where
     R: Renderer + ImportMem + ImportAll,
-    <R as Renderer>::TextureId: Send + Clone + 'static,
+    R::TextureId: Send + Clone + 'static,
 {
     // draw the cursor as relevant
     // reset the cursor if the surface is no longer alive

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -202,14 +202,17 @@ pub struct Surface {
 
 impl Surface {
     pub fn render_output(&mut self, renderer: &mut GlowRenderer, state: &mut Common) -> Result<()> {
-        let (buffer, age) = self
+        let (mut buffer, age) = self
             .surface
             .buffer()
             .with_context(|| "Failed to allocate buffer")?;
-        match render::render_output::<_, _, GlesRenderbuffer>(
+        let mut fb = renderer
+            .bind(&mut buffer)
+            .with_context(|| "Failed to bind dmabuf")?;
+        match render::render_output::<_, GlesRenderbuffer>(
             None,
             renderer,
-            buffer.clone(),
+            &mut fb,
             &mut self.damage_tracker,
             age as usize,
             &state.shell,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::collections::HashMap;
-
 use crate::{
     backend::kms::Timings,
     shell::focus::target::{KeyboardFocusTarget, PointerFocusTarget, PointerFocusToplevel},
     State,
 };
-use egui::{load::SizedTexture, Color32, Vec2};
+use egui::Color32;
 use smithay::{
     backend::{
         drm::DrmNode,
@@ -97,33 +95,6 @@ pub fn fps_ui<'a>(
         })
         .unzip();
 
-    let vendors = HashMap::from([
-        (
-            "0x10de",
-            state
-                .with_image(renderer, "nvidia", |image, ctx| {
-                    (image.texture_id(ctx), image.size_vec2())
-                })
-                .expect("Logo images not loaded?"),
-        ),
-        (
-            "0x1002",
-            state
-                .with_image(renderer, "amd", |image, ctx| {
-                    (image.texture_id(ctx), image.size_vec2())
-                })
-                .expect("Logo images not loaded?"),
-        ),
-        (
-            "0x8086",
-            state
-                .with_image(renderer, "intel", |image, ctx| {
-                    (image.texture_id(ctx), image.size_vec2())
-                })
-                .expect("Logo images not loaded?"),
-        ),
-    ]);
-
     state.render(
         |ctx| {
             egui::Area::new("main".into())
@@ -152,11 +123,21 @@ pub fn fps_ui<'a>(
                                     "/sys/class/drm/renderD{}/device/vendor",
                                     gpu.minor()
                                 )) {
-                                    if let Some((texture_id, mut size)) = vendors.get(vendor.trim())
-                                    {
-                                        let factor = resp.rect.height() / size.y;
-                                        size = Vec2::from([size.x * factor, resp.rect.height()]);
-                                        ui.image(SizedTexture::new(*texture_id, size));
+                                    if let Some(img) = match vendor.trim() {
+                                        "0x10de" => Some(egui::include_image!(
+                                            "../resources/icons/nvidia.svg"
+                                        )),
+                                        "0x1002" => {
+                                            Some(egui::include_image!("../resources/icons/amd.svg"))
+                                        }
+                                        "0x8086" => Some(egui::include_image!(
+                                            "../resources/icons/intel.svg"
+                                        )),
+                                        _ => None,
+                                    } {
+                                        ui.add(
+                                            egui::Image::new(img).max_height(resp.rect.height()),
+                                        );
                                     }
                                 }
                             });

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -625,7 +625,7 @@ impl CosmicMapped {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         C: From<CosmicMappedRenderElement<R>>,
     {
@@ -654,7 +654,7 @@ impl CosmicMapped {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         C: From<CosmicMappedRenderElement<R>>,
     {
@@ -1046,7 +1046,7 @@ impl From<CosmicStack> for CosmicMapped {
 pub enum CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
 {
     Stack(self::stack::CosmicStackRenderElement<R>),
     Window(self::window::CosmicWindowRenderElement<R>),
@@ -1081,7 +1081,7 @@ where
 impl<R> Element for CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
 {
     fn id(&self) -> &smithay::backend::renderer::element::Id {
         match self {
@@ -1264,12 +1264,12 @@ where
 impl<R> RenderElement<R> for CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
-    <R as Renderer>::Error: FromGlesError,
+    R::TextureId: 'static,
+    R::Error: FromGlesError,
 {
     fn draw(
         &self,
-        frame: &mut R::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
@@ -1385,7 +1385,7 @@ where
 impl<R> From<stack::CosmicStackRenderElement<R>> for CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: stack::CosmicStackRenderElement<R>) -> Self {
@@ -1395,7 +1395,7 @@ where
 impl<R> From<window::CosmicWindowRenderElement<R>> for CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: window::CosmicWindowRenderElement<R>) -> Self {
@@ -1406,7 +1406,7 @@ where
 impl<R> From<PixelShaderElement> for CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: PixelShaderElement) -> Self {
@@ -1417,7 +1417,7 @@ where
 impl<R> From<MemoryRenderBufferRenderElement<R>> for CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: MemoryRenderBufferRenderElement<R>) -> Self {
@@ -1429,7 +1429,7 @@ where
 impl<R> From<TextureRenderElement<GlesTexture>> for CosmicMappedRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: TextureRenderElement<GlesTexture>) -> Self {

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -618,7 +618,7 @@ impl CosmicStack {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         C: From<CosmicStackRenderElement<R>>,
     {
         let window_loc = location + Point::from((0, (TAB_HEIGHT as f64 * scale.y) as i32));
@@ -645,7 +645,7 @@ impl CosmicStack {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         C: From<CosmicStackRenderElement<R>>,
     {
         let offset = self

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -660,7 +660,7 @@ impl CosmicSurface {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll,
-        <R as Renderer>::TextureId: Clone + 'static,
+        R::TextureId: Clone + 'static,
         C: From<WaylandSurfaceRenderElement<R>>,
     {
         match self.0.underlying_surface() {
@@ -695,7 +695,7 @@ impl CosmicSurface {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll,
-        <R as Renderer>::TextureId: Clone + 'static,
+        R::TextureId: Clone + 'static,
         C: From<WaylandSurfaceRenderElement<R>>,
     {
         match self.0.underlying_surface() {
@@ -848,7 +848,7 @@ impl X11Relatable for CosmicSurface {
 impl<R> AsRenderElements<R> for CosmicSurface
 where
     R: Renderer + ImportAll,
-    <R as Renderer>::TextureId: Clone + 'static,
+    R::TextureId: Clone + 'static,
 {
     type RenderElement = WaylandSurfaceRenderElement<R>;
 

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -312,7 +312,7 @@ impl CosmicWindow {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         C: From<CosmicWindowRenderElement<R>>,
     {
         let has_ssd = self.0.with_program(|p| p.has_ssd(false));
@@ -343,7 +343,7 @@ impl CosmicWindow {
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         C: From<CosmicWindowRenderElement<R>>,
     {
         let has_ssd = self.0.with_program(|p| p.has_ssd(false));

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -68,7 +68,7 @@ impl MenuGrabState {
     pub fn render<I, R>(&self, renderer: &mut R, output: &Output) -> Vec<I>
     where
         R: Renderer + ImportMem,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         I: From<MemoryRenderBufferRenderElement<R>>,
     {
         let scale = output.current_scale().fractional_scale();

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -71,7 +71,7 @@ impl MoveGrabState {
     pub fn render<I, R>(&self, renderer: &mut R, output: &Output, theme: &CosmicTheme) -> Vec<I>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         I: From<CosmicMappedRenderElement<R>>,
     {

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1390,7 +1390,7 @@ impl FloatingLayout {
     ) -> Vec<CosmicMappedRenderElement<R>>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         CosmicWindowRenderElement<R>: RenderElement<R>,
         CosmicStackRenderElement<R>: RenderElement<R>,
@@ -1441,7 +1441,7 @@ impl FloatingLayout {
     ) -> Vec<CosmicMappedRenderElement<R>>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         CosmicWindowRenderElement<R>: RenderElement<R>,
         CosmicStackRenderElement<R>: RenderElement<R>,

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -3565,7 +3565,7 @@ impl TilingLayout {
 
                         let third_width = (last_geometry.size.w as f64 / 3.0).round() as i32;
                         let third_height = (last_geometry.size.h as f64 / 3.0).round() as i32;
-                        let stack_region = Rectangle::from_extemities(
+                        let stack_region = Rectangle::from_extremities(
                             (
                                 last_geometry.loc.x + third_width,
                                 last_geometry.loc.y + third_height,
@@ -3942,7 +3942,7 @@ impl TilingLayout {
     ) -> Result<Vec<CosmicMappedRenderElement<R>>, OutputNotMapped>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         CosmicWindowRenderElement<R>: RenderElement<R>,
         CosmicStackRenderElement<R>: RenderElement<R>,
@@ -4102,7 +4102,7 @@ impl TilingLayout {
     ) -> Result<Vec<CosmicMappedRenderElement<R>>, OutputNotMapped>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         CosmicWindowRenderElement<R>: RenderElement<R>,
         CosmicStackRenderElement<R>: RenderElement<R>,
@@ -4276,7 +4276,7 @@ fn geometries_for_groupview<'a, R>(
 )
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer + 'a,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
     CosmicWindowRenderElement<R>: RenderElement<R>,
 {
@@ -4906,7 +4906,7 @@ fn render_old_tree_popups<R>(
 ) -> Vec<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: Send + Clone + 'static,
+    R::TextureId: Send + Clone + 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
     CosmicWindowRenderElement<R>: RenderElement<R>,
     CosmicStackRenderElement<R>: RenderElement<R>,
@@ -4949,7 +4949,7 @@ fn render_old_tree_windows<R>(
 ) -> Vec<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: Send + Clone + 'static,
+    R::TextureId: Send + Clone + 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
     CosmicWindowRenderElement<R>: RenderElement<R>,
     CosmicStackRenderElement<R>: RenderElement<R>,
@@ -5115,7 +5115,7 @@ fn render_new_tree_popups<R>(
 ) -> Vec<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: Send + Clone + 'static,
+    R::TextureId: Send + Clone + 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
     CosmicWindowRenderElement<R>: RenderElement<R>,
     CosmicStackRenderElement<R>: RenderElement<R>,
@@ -5181,7 +5181,7 @@ fn render_new_tree_windows<R>(
 ) -> Vec<CosmicMappedRenderElement<R>>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: Send + Clone + 'static,
+    R::TextureId: Send + Clone + 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
     CosmicWindowRenderElement<R>: RenderElement<R>,
     CosmicStackRenderElement<R>: RenderElement<R>,

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1160,7 +1160,7 @@ impl Workspace {
     ) -> Result<Vec<WorkspaceRenderElement<R>>, OutputNotMapped>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         CosmicWindowRenderElement<R>: RenderElement<R>,
         CosmicStackRenderElement<R>: RenderElement<R>,
@@ -1363,7 +1363,7 @@ impl Workspace {
     ) -> Result<Vec<WorkspaceRenderElement<R>>, OutputNotMapped>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
         CosmicWindowRenderElement<R>: RenderElement<R>,
         CosmicStackRenderElement<R>: RenderElement<R>,
@@ -1521,7 +1521,7 @@ pub struct OutputNotMapped;
 pub enum WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
 {
     OverrideRedirect(WaylandSurfaceRenderElement<R>),
     Fullscreen(RescaleRenderElement<CosmicWindowRenderElement<R>>),
@@ -1533,7 +1533,7 @@ where
 impl<R> Element for WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
 {
     fn id(&self) -> &smithay::backend::renderer::element::Id {
         match self {
@@ -1633,12 +1633,12 @@ where
 impl<R> RenderElement<R> for WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
-    <R as Renderer>::Error: FromGlesError,
+    R::TextureId: 'static,
+    R::Error: FromGlesError,
 {
     fn draw(
         &self,
-        frame: &mut R::Frame<'_>,
+        frame: &mut R::Frame<'_, '_>,
         src: Rectangle<f64, BufferCoords>,
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, smithay::utils::Physical>],
@@ -1688,7 +1688,7 @@ where
 impl<R> From<RescaleRenderElement<CosmicWindowRenderElement<R>>> for WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: RescaleRenderElement<CosmicWindowRenderElement<R>>) -> Self {
@@ -1699,7 +1699,7 @@ where
 impl<R> From<CosmicWindowRenderElement<R>> for WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: CosmicWindowRenderElement<R>) -> Self {
@@ -1710,7 +1710,7 @@ where
 impl<R> From<WaylandSurfaceRenderElement<R>> for WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: WaylandSurfaceRenderElement<R>) -> Self {
@@ -1721,7 +1721,7 @@ where
 impl<R> From<CosmicMappedRenderElement<R>> for WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: CosmicMappedRenderElement<R>) -> Self {
@@ -1732,7 +1732,7 @@ where
 impl<R> From<TextureRenderElement<GlesTexture>> for WorkspaceRenderElement<R>
 where
     R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
-    <R as Renderer>::TextureId: 'static,
+    R::TextureId: 'static,
     CosmicMappedRenderElement<R>: RenderElement<R>,
 {
     fn from(elem: TextureRenderElement<GlesTexture>) -> Self {

--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -170,7 +170,7 @@ impl OutputZoomState {
     where
         C: From<<IcedElement<ZoomProgram> as AsRenderElements<R>>::RenderElement>,
         R: Renderer + ImportMem,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
     {
         let size = self.element.current_size().to_f64();
         let output_geo = output.geometry().to_f64();
@@ -372,7 +372,7 @@ impl ZoomState {
     where
         C: From<<IcedElement<ZoomProgram> as AsRenderElements<R>>::RenderElement>,
         R: Renderer + ImportMem,
-        <R as Renderer>::TextureId: Send + Clone + 'static,
+        R::TextureId: Send + Clone + 'static,
     {
         let output_state = output.user_data().get::<Mutex<OutputZoomState>>().unwrap();
         output_state.lock().unwrap().render(renderer, output)

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -903,7 +903,7 @@ impl<P, R> AsRenderElements<R> for IcedElement<P>
 where
     P: Program + Send + 'static,
     R: Renderer + ImportMem,
-    <R as Renderer>::TextureId: Send + Clone + 'static,
+    R::TextureId: Send + Clone + 'static,
 {
     type RenderElement = MemoryRenderBufferRenderElement<R>;
 

--- a/src/utils/screenshot.rs
+++ b/src/utils/screenshot.rs
@@ -29,8 +29,8 @@ pub fn screenshot_window(state: &mut State, surface: &CosmicSurface) {
     ) -> anyhow::Result<()>
     where
         R: Renderer + ImportAll + Offscreen<GlesRenderbuffer> + ExportMem,
-        <R as Renderer>::TextureId: Clone + 'static,
-        <R as Renderer>::Error: Send + Sync + 'static,
+        R::TextureId: Clone + 'static,
+        R::Error: Send + Sync + 'static,
     {
         let bbox = bbox_from_surface_tree(&window.wl_surface().unwrap(), (0, 0));
         let elements = AsRenderElements::<R>::render_elements::<WaylandSurfaceRenderElement<R>>(
@@ -43,22 +43,25 @@ pub fn screenshot_window(state: &mut State, surface: &CosmicSurface) {
 
         // TODO: 10-bit
         let format = Fourcc::Abgr8888;
-        let render_buffer = Offscreen::<GlesRenderbuffer>::create_buffer(
+        let mut render_buffer = Offscreen::<GlesRenderbuffer>::create_buffer(
             renderer,
             format,
             bbox.size.to_buffer(1, Transform::Normal),
         )?;
-        renderer.bind(render_buffer)?;
+        let mut fb = renderer.bind(&mut render_buffer)?;
         let mut output_damage_tracker =
             OutputDamageTracker::new(bbox.size.to_physical(1), 1.0, Transform::Normal);
         output_damage_tracker
-            .render_output(renderer, 0, &elements, [0.0, 0.0, 0.0, 0.0])
+            .render_output(renderer, &mut fb, 0, &elements, [0.0, 0.0, 0.0, 0.0])
             .map_err(|err| match err {
                 smithay::backend::renderer::damage::Error::Rendering(err) => err,
                 smithay::backend::renderer::damage::Error::OutputNoMode(_) => unreachable!(),
             })?;
-        let mapping =
-            renderer.copy_framebuffer(bbox.to_buffer(1, Transform::Normal, &bbox.size), format)?;
+        let mapping = renderer.copy_framebuffer(
+            &mut fb,
+            bbox.to_buffer(1, Transform::Normal, &bbox.size),
+            format,
+        )?;
         let gl_data = renderer.map_texture(&mapping)?;
 
         if let Ok(Some(path)) = xdg_user::pictures() {


### PR DESCRIPTION
This is the big framebuffer-api-update.

Overall seems to work just as well, but touches a bunch of the screencopy logic, that previously implicitly passed the framebuffer around as state of the renderer.

So it is likely better to leave this for a couple of days and test with cosmic-workspaces and xdg-desktop-portal-cosmic before merging.