### PR TITLE
Workspace related fixes/improvement

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -683,7 +683,7 @@ impl Workspaces {
         // Remove workspaces that prefer this output from other sets
         let mut moved_workspaces = Vec::new();
         for other_set in self.sets.values_mut() {
-            let active_handle = other_set.workspaces[set.active].handle;
+            let active_handle = other_set.workspaces[other_set.active].handle;
             let (prefers, doesnt) = other_set
                 .workspaces
                 .drain(..)

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -705,7 +705,12 @@ impl Workspaces {
                 .workspaces
                 .iter()
                 .position(|w| w.handle == active_handle)
-                .unwrap_or(other_set.workspaces.len() - 1);
+                .unwrap_or_else(|| {
+                    let idx = other_set.workspaces.len() - 1;
+                    let workspace = &other_set.workspaces[idx];
+                    workspace_state.add_workspace_state(&workspace.handle, WState::Active);
+                    idx
+                })
         }
 
         // Add `moved_workspaces` to set, and update output and index of workspaces

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -767,7 +767,7 @@ impl Workspaces {
 
                 let new_set = self.sets.get_mut(&new_output).unwrap();
                 let workspace_group = new_set.group;
-                for mut workspace in set.workspaces.into_iter() {
+                for (i, mut workspace) in set.workspaces.into_iter().enumerate() {
                     if workspace.is_empty() {
                         workspace_state.remove_workspace(workspace.handle);
                     } else {
@@ -778,6 +778,21 @@ impl Workspaces {
                         workspace.set_output(&new_output);
                         workspace.refresh(xdg_activation_state);
                         new_set.workspaces.push(workspace);
+
+                        // If workspace was active, and the new set's active workspace is empty, make this workspace
+                        // active on the new set. Instead of leaving an empty workspace active, and a previously active
+                        // workspace hidden.
+                        if i == set.active && new_set.workspaces[new_set.active].is_empty() {
+                            workspace_state.remove_workspace_state(
+                                &new_set.workspaces[new_set.active].handle,
+                                WState::Active,
+                            );
+                            new_set.active = new_set.workspaces.len() - 1;
+                            workspace_state.add_workspace_state(
+                                &new_set.workspaces[new_set.active].handle,
+                                WState::Active,
+                            );
+                        }
                     }
                 }
 

--- a/src/wayland/protocols/workspace/cosmic_v2.rs
+++ b/src/wayland/protocols/workspace/cosmic_v2.rs
@@ -19,21 +19,21 @@ use super::{
 };
 
 #[derive(Default)]
-pub struct CosmicWorkspaceDataInner {
+pub struct CosmicWorkspaceV2DataInner {
     capabilities: Option<WorkspaceCapabilities>,
     tiling: Option<zcosmic_workspace_handle_v2::TilingState>,
 }
 
-pub struct CosmicWorkspaceData {
+pub struct CosmicWorkspaceV2Data {
     workspace: Weak<ExtWorkspaceHandleV1>,
-    inner: Mutex<CosmicWorkspaceDataInner>,
+    inner: Mutex<CosmicWorkspaceV2DataInner>,
 }
 
 impl<D> GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData, D> for WorkspaceState<D>
 where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static,
@@ -58,7 +58,7 @@ impl<D> Dispatch<ZcosmicWorkspaceManagerV2, (), D> for WorkspaceState<D>
 where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static,
@@ -79,9 +79,9 @@ where
             } => {
                 let cosmic_workspace = data_init.init(
                     cosmic_workspace,
-                    CosmicWorkspaceData {
+                    CosmicWorkspaceV2Data {
                         workspace: workspace.downgrade(),
-                        inner: Mutex::new(CosmicWorkspaceDataInner::default()),
+                        inner: Mutex::new(CosmicWorkspaceV2DataInner::default()),
                     },
                 );
                 if let Some(data) = workspace.data::<WorkspaceData>() {
@@ -115,11 +115,11 @@ where
     }
 }
 
-impl<D> Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData, D> for WorkspaceState<D>
+impl<D> Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data, D> for WorkspaceState<D>
 where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static,
@@ -129,7 +129,7 @@ where
         client: &Client,
         _obj: &ZcosmicWorkspaceHandleV2,
         request: zcosmic_workspace_handle_v2::Request,
-        data: &CosmicWorkspaceData,
+        data: &CosmicWorkspaceV2Data,
         _dh: &DisplayHandle,
         _data_init: &mut DataInit<'_, D>,
     ) {
@@ -184,7 +184,7 @@ pub fn send_workspace_to_client(
     let mut changed = false;
 
     let mut handle_state = instance
-        .data::<CosmicWorkspaceData>()
+        .data::<CosmicWorkspaceV2Data>()
         .unwrap()
         .inner
         .lock()

--- a/src/wayland/protocols/workspace/cosmic_v2.rs
+++ b/src/wayland/protocols/workspace/cosmic_v2.rs
@@ -20,7 +20,7 @@ use super::{
 
 #[derive(Default)]
 pub struct CosmicWorkspaceV2DataInner {
-    capabilities: Option<WorkspaceCapabilities>,
+    capabilities: Option<zcosmic_workspace_handle_v2::WorkspaceCapabilities>,
     tiling: Option<zcosmic_workspace_handle_v2::TilingState>,
 }
 
@@ -190,22 +190,22 @@ pub fn send_workspace_to_client(
         .lock()
         .unwrap();
 
-    if handle_state.capabilities != Some(workspace.capabilities) {
-        let caps = workspace
-            .capabilities
-            .iter()
-            .filter_map(|cap| match cap {
-                WorkspaceCapabilities::Rename => {
-                    Some(zcosmic_workspace_handle_v2::WorkspaceCapabilities::Rename)
-                }
-                WorkspaceCapabilities::SetTilingState => {
-                    Some(zcosmic_workspace_handle_v2::WorkspaceCapabilities::SetTilingState)
-                }
-                _ => None,
-            })
-            .collect::<zcosmic_workspace_handle_v2::WorkspaceCapabilities>();
-        instance.capabilities(caps);
-        handle_state.capabilities = Some(workspace.capabilities);
+    let capabilities = workspace
+        .capabilities
+        .iter()
+        .filter_map(|cap| match cap {
+            WorkspaceCapabilities::Rename => {
+                Some(zcosmic_workspace_handle_v2::WorkspaceCapabilities::Rename)
+            }
+            WorkspaceCapabilities::SetTilingState => {
+                Some(zcosmic_workspace_handle_v2::WorkspaceCapabilities::SetTilingState)
+            }
+            _ => None,
+        })
+        .collect::<zcosmic_workspace_handle_v2::WorkspaceCapabilities>();
+    if handle_state.capabilities != Some(capabilities) {
+        instance.capabilities(capabilities);
+        handle_state.capabilities = Some(capabilities);
         changed = true;
     }
 

--- a/src/wayland/protocols/workspace/ext.rs
+++ b/src/wayland/protocols/workspace/ext.rs
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2;
+
 use smithay::reexports::wayland_server::{
     backend::{ClientData, ClientId},
-    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
 };
 
+use std::sync::Mutex;
+
 use super::{
-    Request, Workspace, WorkspaceCapabilities, WorkspaceClientHandler, WorkspaceData,
-    WorkspaceGlobalData, WorkspaceGroup, WorkspaceGroupData, WorkspaceGroupHandle,
-    WorkspaceHandler, WorkspaceState,
+    Request, Workspace, WorkspaceCapabilities, WorkspaceClientHandler, WorkspaceGlobalData,
+    WorkspaceGroup, WorkspaceGroupData, WorkspaceGroupHandle, WorkspaceHandler, WorkspaceState,
 };
 
 use smithay::reexports::wayland_protocols::ext::workspace::v1::server::{
@@ -16,6 +19,17 @@ use smithay::reexports::wayland_protocols::ext::workspace::v1::server::{
     ext_workspace_handle_v1::{self, ExtWorkspaceHandleV1},
     ext_workspace_manager_v1::{self, ExtWorkspaceManagerV1},
 };
+
+#[derive(Default)]
+pub struct WorkspaceDataInner {
+    name: String,
+    capabilities: Option<WorkspaceCapabilities>,
+    coordinates: Vec<u32>,
+    states: Option<ext_workspace_handle_v1::State>,
+    pub(super) cosmic_v2_handle: Option<Weak<ZcosmicWorkspaceHandleV2>>,
+}
+
+pub type WorkspaceData = Mutex<WorkspaceDataInner>;
 
 impl<D> GlobalDispatch<ExtWorkspaceManagerV1, WorkspaceGlobalData, D> for WorkspaceState<D>
 where

--- a/src/wayland/protocols/workspace/ext.rs
+++ b/src/wayland/protocols/workspace/ext.rs
@@ -23,7 +23,7 @@ use smithay::reexports::wayland_protocols::ext::workspace::v1::server::{
 #[derive(Default)]
 pub struct WorkspaceDataInner {
     name: String,
-    capabilities: Option<WorkspaceCapabilities>,
+    capabilities: Option<ext_workspace_handle_v1::WorkspaceCapabilities>,
     coordinates: Vec<u32>,
     states: Option<ext_workspace_handle_v1::State>,
     pub(super) cosmic_v2_handle: Option<Weak<ZcosmicWorkspaceHandleV2>>,
@@ -416,6 +416,7 @@ where
         handle_state.name = workspace.name.clone();
         changed = true;
     }
+
     if handle_state.coordinates != workspace.coordinates {
         let coords = workspace
             .coordinates
@@ -426,30 +427,32 @@ where
         handle_state.coordinates = workspace.coordinates.clone();
         changed = true;
     }
-    if handle_state.capabilities != Some(workspace.capabilities) {
-        let caps = workspace
-            .capabilities
-            .iter()
-            .filter_map(|cap| match cap {
-                WorkspaceCapabilities::Activate => {
-                    Some(ext_workspace_handle_v1::WorkspaceCapabilities::Activate)
-                }
-                WorkspaceCapabilities::Deactivate => {
-                    Some(ext_workspace_handle_v1::WorkspaceCapabilities::Deactivate)
-                }
-                WorkspaceCapabilities::Remove => {
-                    Some(ext_workspace_handle_v1::WorkspaceCapabilities::Remove)
-                }
-                WorkspaceCapabilities::Assign => {
-                    Some(ext_workspace_handle_v1::WorkspaceCapabilities::Assign)
-                }
-                _ => None,
-            })
-            .collect::<ext_workspace_handle_v1::WorkspaceCapabilities>();
-        instance.capabilities(caps);
-        handle_state.capabilities = Some(workspace.capabilities.clone());
+
+    let capabilities = workspace
+        .capabilities
+        .iter()
+        .filter_map(|cap| match cap {
+            WorkspaceCapabilities::Activate => {
+                Some(ext_workspace_handle_v1::WorkspaceCapabilities::Activate)
+            }
+            WorkspaceCapabilities::Deactivate => {
+                Some(ext_workspace_handle_v1::WorkspaceCapabilities::Deactivate)
+            }
+            WorkspaceCapabilities::Remove => {
+                Some(ext_workspace_handle_v1::WorkspaceCapabilities::Remove)
+            }
+            WorkspaceCapabilities::Assign => {
+                Some(ext_workspace_handle_v1::WorkspaceCapabilities::Assign)
+            }
+            _ => None,
+        })
+        .collect::<ext_workspace_handle_v1::WorkspaceCapabilities>();
+    if handle_state.capabilities != Some(capabilities) {
+        instance.capabilities(capabilities);
+        handle_state.capabilities = Some(capabilities);
         changed = true;
     }
+
     if handle_state.states != Some(workspace.states) {
         instance.state(workspace.states);
         handle_state.states = Some(workspace.states.clone());

--- a/src/wayland/protocols/workspace/mod.rs
+++ b/src/wayland/protocols/workspace/mod.rs
@@ -32,9 +32,11 @@ use cosmic_protocols::workspace::{
 };
 
 mod cosmic;
+pub use cosmic::CosmicWorkspaceV1Data;
 mod cosmic_v2;
-pub use cosmic_v2::CosmicWorkspaceData;
+pub use cosmic_v2::CosmicWorkspaceV2Data;
 mod ext;
+pub use ext::WorkspaceData;
 
 pub use smithay::reexports::wayland_protocols::ext::workspace::v1::server::ext_workspace_group_handle_v1::GroupCapabilities;
 
@@ -59,14 +61,14 @@ where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV1, ()>
         + Dispatch<ZcosmicWorkspaceGroupHandleV1, WorkspaceGroupData>
-        + Dispatch<ZcosmicWorkspaceHandleV1, WorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV1, CosmicWorkspaceV1Data>
         + GlobalDispatch<ExtWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ExtWorkspaceManagerV1, ()>
         + Dispatch<ExtWorkspaceGroupHandleV1, WorkspaceGroupData>
         + Dispatch<ExtWorkspaceHandleV1, WorkspaceData>
         + GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static,
@@ -85,7 +87,7 @@ where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV1, ()>
         + Dispatch<ZcosmicWorkspaceGroupHandleV1, WorkspaceGroupData>
-        + Dispatch<ZcosmicWorkspaceHandleV1, WorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV1, CosmicWorkspaceV1Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static;
@@ -155,31 +157,19 @@ pub struct WorkspaceHandle {
     id: usize,
 }
 
-#[derive(Default)]
-pub struct WorkspaceDataInner {
-    name: String,
-    capabilities: Option<WorkspaceCapabilities>,
-    coordinates: Vec<u32>,
-    states: Option<ext_workspace_handle_v1::State>,
-    tiling: Option<zcosmic_workspace_handle_v2::TilingState>,
-    cosmic_v2_handle: Option<Weak<ZcosmicWorkspaceHandleV2>>,
-}
-
-pub type WorkspaceData = Mutex<WorkspaceDataInner>;
-
 pub trait WorkspaceHandler
 where
     Self: GlobalDispatch<ZcosmicWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV1, ()>
         + Dispatch<ZcosmicWorkspaceGroupHandleV1, WorkspaceGroupData>
-        + Dispatch<ZcosmicWorkspaceHandleV1, WorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV1, CosmicWorkspaceV1Data>
         + GlobalDispatch<ExtWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ExtWorkspaceManagerV1, ()>
         + Dispatch<ExtWorkspaceGroupHandleV1, WorkspaceGroupData>
         + Dispatch<ExtWorkspaceHandleV1, WorkspaceData>
         + GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + Sized
         + 'static,
 {
@@ -232,14 +222,14 @@ where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV1, ()>
         + Dispatch<ZcosmicWorkspaceGroupHandleV1, WorkspaceGroupData>
-        + Dispatch<ZcosmicWorkspaceHandleV1, WorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV1, CosmicWorkspaceV1Data>
         + GlobalDispatch<ExtWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ExtWorkspaceManagerV1, ()>
         + Dispatch<ExtWorkspaceGroupHandleV1, WorkspaceGroupData>
         + Dispatch<ExtWorkspaceHandleV1, WorkspaceData>
         + GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static,
@@ -501,13 +491,13 @@ where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV1, ()>
         + Dispatch<ZcosmicWorkspaceGroupHandleV1, WorkspaceGroupData>
-        + Dispatch<ZcosmicWorkspaceHandleV1, WorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV1, CosmicWorkspaceV1Data>
         + Dispatch<ExtWorkspaceManagerV1, ()>
         + Dispatch<ExtWorkspaceGroupHandleV1, WorkspaceGroupData>
         + Dispatch<ExtWorkspaceHandleV1, WorkspaceData>
         + GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static,
@@ -763,14 +753,14 @@ where
     D: GlobalDispatch<ZcosmicWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV1, ()>
         + Dispatch<ZcosmicWorkspaceGroupHandleV1, WorkspaceGroupData>
-        + Dispatch<ZcosmicWorkspaceHandleV1, WorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV1, CosmicWorkspaceV1Data>
         + GlobalDispatch<ExtWorkspaceManagerV1, WorkspaceGlobalData>
         + Dispatch<ExtWorkspaceManagerV1, ()>
         + Dispatch<ExtWorkspaceGroupHandleV1, WorkspaceGroupData>
         + Dispatch<ExtWorkspaceHandleV1, WorkspaceData>
         + GlobalDispatch<ZcosmicWorkspaceManagerV2, WorkspaceGlobalData>
         + Dispatch<ZcosmicWorkspaceManagerV2, ()>
-        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceData>
+        + Dispatch<ZcosmicWorkspaceHandleV2, CosmicWorkspaceV2Data>
         + WorkspaceHandler
         + 'static,
     <D as WorkspaceHandler>::Client: ClientData + WorkspaceClientHandler + 'static,
@@ -792,7 +782,7 @@ macro_rules! delegate_workspace {
             cosmic_protocols::workspace::v1::server::zcosmic_workspace_group_handle_v1::ZcosmicWorkspaceGroupHandleV1: $crate::wayland::protocols::workspace::WorkspaceGroupData
         ] => $crate::wayland::protocols::workspace::WorkspaceState<Self>);
         smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            cosmic_protocols::workspace::v1::server::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1: $crate::wayland::protocols::workspace::WorkspaceData
+            cosmic_protocols::workspace::v1::server::zcosmic_workspace_handle_v1::ZcosmicWorkspaceHandleV1: $crate::wayland::protocols::workspace::CosmicWorkspaceV1Data
         ] => $crate::wayland::protocols::workspace::WorkspaceState<Self>);
 
         smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
@@ -815,7 +805,7 @@ macro_rules! delegate_workspace {
             cosmic_protocols::workspace::v2::server::zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2: ()
         ] => $crate::wayland::protocols::workspace::WorkspaceState<Self>);
         smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2: $crate::wayland::protocols::workspace::CosmicWorkspaceData
+            cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2: $crate::wayland::protocols::workspace::CosmicWorkspaceV2Data
         ] => $crate::wayland::protocols::workspace::WorkspaceState<Self>);
     };
 }


### PR DESCRIPTION
A couple changes to how `output_add` and `output_remove` handle workspace moves. (Plus a minor improvement to the workspace protocol.)

I think this fixes the issues where output hotplug can results in 0 or 2 workspaces being shown as active instead of 1, and also addresses another case where hotplug results in an empty focused workspace followed by other workspaces (that one's not technically a bug, but I think this is better).