### PR TITLE
Improve handling of XDG activation tokens in shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4672,7 +4672,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.5.0"
-source = "git+https://github.com/smithay/smithay?rev=a503d98#a503d981d1be9a54b286ab5e160e4b9edddb500f"
+source = "git+https://github.com/smithay/smithay//?rev=796c41c#796c41c0294ccc195b0f59228d6467cc6c8f5de8"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,6 @@ lto = "fat"
 [patch."https://github.com/pop-os/cosmic-protocols"]
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", rev = "e706814" }
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", rev = "e706814" }
+
+[patch."https://github.com/smithay/smithay"]
+smithay = { git = "https://github.com/smithay/smithay//", rev = "796c41c" }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -993,7 +993,6 @@ impl State {
 
         let output = shell.seats.last_active().active_output();
         let workspace = shell.active_space_mut(&output).unwrap();
-        workspace.pending_tokens.insert(token.clone());
         let handle = workspace.handle;
         std::mem::drop(shell);
         data.user_data

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -725,7 +725,6 @@ impl State {
                                                             false,
                                                             &state.common.config,
                                                             &state.common.event_loop_handle,
-                                                            &state.common.xdg_activation_state,
                                                             false,
                                                         );
                                                         drop(shell);

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -705,7 +705,6 @@ impl CosmicStack {
                             true,
                             &state.common.config,
                             &state.common.event_loop_handle,
-                            &state.common.xdg_activation_state,
                             false,
                         );
                         if let Some((grab, focus)) = res {
@@ -848,7 +847,6 @@ impl Program for CosmicStackInternal {
                                 false,
                                 &state.common.config,
                                 &state.common.event_loop_handle,
-                                &state.common.xdg_activation_state,
                                 false,
                             );
                             if let Some((grab, focus)) = res {
@@ -1493,7 +1491,6 @@ impl PointerTarget<State> for CosmicStack {
                             true,
                             &state.common.config,
                             &state.common.event_loop_handle,
-                            &state.common.xdg_activation_state,
                             false,
                         );
                         if let Some((grab, focus)) = res {

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -439,7 +439,6 @@ impl Program for CosmicWindowInternal {
                                 false,
                                 &state.common.config,
                                 &state.common.event_loop_handle,
-                                &state.common.xdg_activation_state,
                                 false,
                             );
                             if let Some((grab, focus)) = res {

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -256,7 +256,6 @@ pub fn window_items(
                         false,
                         &state.common.config,
                         &state.common.event_loop_handle,
-                        &state.common.xdg_activation_state,
                         false,
                     );
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -361,11 +361,7 @@ impl BackendData {
             });
 
             match final_config.enabled {
-                OutputState::Enabled => {
-                    shell
-                        .workspaces
-                        .add_output(&output, workspace_state, xdg_activation_state)
-                }
+                OutputState::Enabled => shell.workspaces.add_output(&output, workspace_state),
                 _ => {
                     let shell = &mut *shell;
                     shell.workspaces.remove_output(

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -45,7 +45,6 @@ impl XdgActivationHandler for State {
                 let output = seat.active_output();
                 let mut shell = self.common.shell.write().unwrap();
                 let workspace = shell.active_space_mut(&output).unwrap();
-                workspace.pending_tokens.insert(token.clone());
                 let handle = workspace.handle;
                 data.user_data
                     .insert_if_missing(move || ActivationContext::Workspace(handle));
@@ -89,7 +88,6 @@ impl XdgActivationHandler for State {
             let output = seat.active_output();
             let mut shell = self.common.shell.write().unwrap();
             let workspace = shell.active_space_mut(&output).unwrap();
-            workspace.pending_tokens.insert(token.clone());
             let handle = workspace.handle;
             data.user_data
                 .insert_if_missing(move || ActivationContext::Workspace(handle));

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -174,7 +174,6 @@ impl XdgShellHandler for State {
             false,
             &self.common.config,
             &self.common.event_loop_handle,
-            &self.common.xdg_activation_state,
             true,
         ) {
             std::mem::drop(shell);
@@ -421,7 +420,7 @@ impl XdgShellHandler for State {
                 .visible_output_for_surface(surface.wl_surface())
                 .cloned();
             if let Some(output) = output.as_ref() {
-                shell.refresh_active_space(output, &self.common.xdg_activation_state);
+                shell.refresh_active_space(output);
             }
 
             // animations might be unblocked now

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -430,7 +430,7 @@ impl XwmHandler for State {
             shell.outputs().cloned().collect::<Vec<_>>()
         };
         for output in outputs.iter() {
-            shell.refresh_active_space(output, &self.common.xdg_activation_state);
+            shell.refresh_active_space(output);
         }
 
         for output in outputs.into_iter() {
@@ -593,7 +593,6 @@ impl XwmHandler for State {
                 false,
                 &self.common.config,
                 &self.common.event_loop_handle,
-                &self.common.xdg_activation_state,
                 true,
             ) {
                 std::mem::drop(shell);


### PR DESCRIPTION
Requires https://github.com/Smithay/smithay/pull/1676.

This changes two things:
* `Workspace::is_empty` no longer checks if there are activation tokens,
  but a separate `Workspace::can_auto_remove` checks if the workspace is
  empty and has no activation tokens.
  - When we add workspace pinning, that can also be checked there.
* `Workspace` no longer contains a `pending_tokens` list that is updated
  on `refresh`. Instead, `can_auto_remove` takes the xdg activation
  state as an argument.

Since `Workspace::refresh` normally is run for focused workspaces, this
fixes allowing non-focused workspaces to be removed when an activation
token expires. It seems generally good to avoid tracking the activation
tokens in two places, and this is probably more efficient than needing
to refresh in more places.

By splitting this, we still don't remove an empty workspace if it has a
pending activation token, but we also don't add an empty workspace for
an activation token.

This mitigates the confusing behavior with activation tokens that aren't
used, but having to wait a few seconds in some cases before a workspace
is removed is still a little confusing. (We probably want `cosmic-term`
and `cosmic-workspace` to either consume the activation tokens they are
passed, or not be passed tokens when started by keybinding?)

Fixes https://github.com/pop-os/cosmic-comp/issues/1099.