### PR TITLE
kms/surface/timings: handle potential overflow when calculating avg frametime

### DIFF
--- a/src/backend/kms/surface/timings.rs
+++ b/src/backend/kms/surface/timings.rs
@@ -213,7 +213,7 @@ impl Timings {
                 .rev()
                 .take(window)
                 .map(|f| f.frame_time())
-                .sum::<Duration>()
+                .try_fold(Duration::ZERO, |acc, x| acc.checked_add(x))?
                 / (window.min(self.previous_frames.len()) as u32),
         )
     }


### PR DESCRIPTION
Fixes #1062

I'm not sure if this is the right approach, I'm not sure why this is sometimes overflowing (and why it happens on some platforms way more often than others), and there are probably(?) other areas where overflow can occur... but this patch did fix the crash for me on a ARM device (using the SDM845 SOC)