### PR TITLE
Fix `dependency_on_unit_never_type_fallback` warning on latest Rustc

### DIFF
--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -739,7 +739,7 @@ where
         )
     };
 
-    render_input_order(
+    render_input_order::<()>(
         &*shell,
         output,
         previous,


### PR DESCRIPTION
Apparently in Rust 2024, the inferred type here would be `!`, which doesn't implement `Default`. Explicitly use `()` instead.

https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html