### PR TITLE
config: Refactor WorkspaceLayout to use the Default macro

### DIFF
--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -2,14 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
-fn default_workspace_layout() -> WorkspaceLayout {
-    WorkspaceLayout::Vertical
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
     pub workspace_mode: WorkspaceMode,
-    #[serde(default = "default_workspace_layout")]
+    #[serde(default)]
     pub workspace_layout: WorkspaceLayout,
 }
 
@@ -28,8 +24,9 @@ pub enum WorkspaceMode {
     Global,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WorkspaceLayout {
+    #[default]
     Vertical,
     Horizontal,
 }


### PR DESCRIPTION
cosmic-comp-config uses an extra function and #[serde(default = ...)] macro rather than simply applying the default at the enum level. This aligns better with the code style of TileBehavior in lib.rs