### PR TITLE
a11y/zoom: Various fixes

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -133,6 +133,7 @@ pub struct ZoomConfig {
     pub show_overlay: bool,
     pub increment: u32,
     pub view_moves: ZoomMovement,
+    pub enable_mouse_zoom_shortcuts: bool,
 }
 
 impl Default for ZoomConfig {
@@ -142,6 +143,7 @@ impl Default for ZoomConfig {
             show_overlay: true,
             increment: 50,
             view_moves: ZoomMovement::Continuously,
+            enable_mouse_zoom_shortcuts: true,
         }
     }
 }

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -130,6 +130,7 @@ fn default_repeat_delay() -> u32 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ZoomConfig {
     pub start_on_login: bool,
+    pub show_overlay: bool,
     pub increment: u32,
     pub view_moves: ZoomMovement,
 }
@@ -138,6 +139,7 @@ impl Default for ZoomConfig {
     fn default() -> Self {
         ZoomConfig {
             start_on_login: false,
+            show_overlay: true,
             increment: 50,
             view_moves: ZoomMovement::Continuously,
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -79,7 +79,14 @@ pub fn init_backend_auto(
             .accessibility_zoom
             .start_on_login
         {
-            state.update_zoom(&initial_seat, 1.0, true);
+            state.common.shell.write().unwrap().trigger_zoom(
+                &initial_seat,
+                None,
+                1.0 + (state.common.config.cosmic_conf.accessibility_zoom.increment as f64 / 100.),
+                &state.common.config.cosmic_conf.accessibility_zoom,
+                true,
+                &state.common.event_loop_handle,
+            );
         }
 
         let desired_numlock = state

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -433,7 +433,7 @@ where
         .map(|state| {
             (
                 state.animating_focal_point(Some(&output)).to_local(&output),
-                state.animating_level(),
+                state.animating_level(&output),
             )
         })
         .unwrap_or_else(|| ((0., 0.).into(), 1.));
@@ -741,7 +741,7 @@ where
         .map(|state| {
             (
                 state.animating_focal_point(Some(&output)).to_local(&output),
-                state.animating_level(),
+                state.animating_level(&output),
             )
         })
         .unwrap_or_else(|| ((0., 0.).into(), 1.));

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -1027,10 +1027,11 @@ impl State {
     }
 
     pub fn update_zoom(&mut self, seat: &Seat<State>, change: f64, animate: bool) {
+        let output = seat.active_output();
         let mut shell = self.common.shell.write().unwrap();
         let (zoom_seat, current_level) = shell
             .zoom_state()
-            .map(|state| (state.current_seat(), state.current_level()))
+            .map(|state| (state.current_seat(), state.current_level(&output)))
             .unwrap_or_else(|| (seat.clone(), 1.0));
 
         if current_level == 1. && change <= 0. {
@@ -1041,6 +1042,7 @@ impl State {
             let new_level = (current_level + change).max(1.0);
             shell.trigger_zoom(
                 &seat,
+                Some(&output),
                 new_level,
                 &self.common.config.cosmic_conf.accessibility_zoom,
                 animate,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -853,6 +853,7 @@ impl State {
                             .accessibility_zoom
                             .enable_mouse_zoom_shortcuts
                     {
+                        seat.modifiers_shortcut_queue().clear();
                         if let Some(mut percentage) = event
                             .amount_v120(Axis::Vertical)
                             .map(|val| val / 120.)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -845,7 +845,14 @@ impl State {
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
 
-                    if seat.get_keyboard().unwrap().modifier_state().logo {
+                    if seat.get_keyboard().unwrap().modifier_state().logo
+                        && self
+                            .common
+                            .config
+                            .cosmic_conf
+                            .accessibility_zoom
+                            .enable_mouse_zoom_shortcuts
+                    {
                         if let Some(mut percentage) = event
                             .amount_v120(Axis::Vertical)
                             .map(|val| val / 120.)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2247,7 +2247,7 @@ where
     B::Device: 'static,
 {
     let geometry = zoom_state
-        .and_then(|state| output.zoomed_geometry(state.current_level()))
+        .and_then(|_| output.zoomed_geometry())
         .unwrap_or_else(|| output.geometry());
     let transform = output.current_transform();
     let size = transform

--- a/src/shell/focus/order.rs
+++ b/src/shell/focus/order.rs
@@ -73,7 +73,7 @@ fn render_input_order_internal<R: 'static>(
     if shell
         .zoom_state
         .as_ref()
-        .is_some_and(|state| state.current_level() != 1.0)
+        .is_some_and(|state| state.show_overlay && state.current_level() != 1.0)
     {
         callback(Stage::ZoomUI)?;
     }

--- a/src/shell/focus/order.rs
+++ b/src/shell/focus/order.rs
@@ -73,7 +73,7 @@ fn render_input_order_internal<R: 'static>(
     if shell
         .zoom_state
         .as_ref()
-        .is_some_and(|state| state.show_overlay && state.current_level() != 1.0)
+        .is_some_and(|state| state.show_overlay && state.current_level(output) != 1.0)
     {
         callback(Stage::ZoomUI)?;
     }

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -522,11 +522,11 @@ impl PointerGrab<State> for MenuGrab {
             let mut guard = self.elements.lock().unwrap();
             let elements = &mut *guard;
             let event_location = if let Some(output) = self.screen_space_relative.as_ref() {
-                if let Some(zoom_state) = state.common.shell.read().unwrap().zoom_state() {
+                if state.common.shell.read().unwrap().zoom_state().is_some() {
                     event
                         .location
                         .as_global()
-                        .to_zoomed(output, zoom_state.level)
+                        .to_zoomed(output)
                         .to_global(output)
                         .as_logical()
                 } else {
@@ -726,11 +726,11 @@ impl TouchGrab<State> for MenuGrab {
             let mut guard = self.elements.lock().unwrap();
             let elements = &mut *guard;
             let event_location = if let Some(output) = self.screen_space_relative.as_ref() {
-                if let Some(zoom_state) = data.common.shell.read().unwrap().zoom_state() {
+                if data.common.shell.read().unwrap().zoom_state().is_some() {
                     event
                         .location
                         .as_global()
-                        .to_zoomed(output, zoom_state.level)
+                        .to_zoomed(output)
                         .to_global(output)
                         .as_logical()
                 } else {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1249,6 +1249,7 @@ impl Common {
         if let Some(zoom_state) = shell_ref.zoom_state.as_mut() {
             zoom_state.increment = self.config.cosmic_conf.accessibility_zoom.increment;
             zoom_state.movement = self.config.cosmic_conf.accessibility_zoom.view_moves;
+            zoom_state.show_overlay = self.config.cosmic_conf.accessibility_zoom.show_overlay;
 
             for output in shell_ref.workspaces.sets.keys() {
                 let output_state = output.user_data().get::<Mutex<OutputZoomState>>().unwrap();
@@ -2051,6 +2052,7 @@ impl Shell {
                     self.theme.clone(),
                 );
             }
+
             1.
         };
 
@@ -2064,6 +2066,7 @@ impl Shell {
 
         self.zoom_state = Some(ZoomState {
             seat: seat.clone(),
+            show_overlay: zoom_config.show_overlay,
             level,
             increment: zoom_config.increment,
             movement: zoom_config.view_moves,

--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -280,7 +280,7 @@ impl ZoomState {
             ZoomMovement::Continuously => output_state_ref.focal_point = cursor_position.to_f64(),
             ZoomMovement::OnEdge => {
                 if !zoomed_output_geometry
-                    .overlaps_or_touches(Rectangle::new(original_position, Size::from((1, 1))))
+                    .overlaps_or_touches(Rectangle::new(original_position, Size::from((16, 16))))
                 {
                     zoomed_output_geometry.loc = cursor_position.to_global(&output)
                         - zoomed_output_geometry.size.downscale(2).to_point();

--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -701,7 +701,8 @@ impl Program for ZoomProgram {
                                         Item::new(crate::fl!("a11y-zoom-settings"), |handle| {
                                             let _ = handle.insert_idle(move |state| {
                                                 state.spawn_command(
-                                                    "cosmic-settings page-accessibility".into(),
+                                                    "cosmic-settings accessibility-magnifier"
+                                                        .into(),
                                                 );
                                             });
                                         }),

--- a/src/state.rs
+++ b/src/state.rs
@@ -197,7 +197,6 @@ pub struct Common {
 
     pub popups: PopupManager,
     pub shell: Arc<RwLock<Shell>>,
-    pub zoom_config_debounce: Option<RegistrationToken>,
 
     pub clock: Clock<Monotonic>,
     pub startup_done: Arc<AtomicBool>,
@@ -615,7 +614,6 @@ impl State {
 
                 popups: PopupManager::default(),
                 shell,
-                zoom_config_debounce: None,
 
                 local_offset,
 

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1,7 +1,11 @@
+use std::sync::Mutex;
+
 use smithay::{
     output::Output,
     utils::{Coordinate, Logical, Point, Rectangle, Size},
 };
+
+use crate::shell::zoom::OutputZoomState;
 
 use super::prelude::OutputExt;
 
@@ -20,7 +24,7 @@ pub trait PointExt<C: Coordinate> {
 
 pub trait PointGlobalExt<C: Coordinate> {
     fn to_local(self, output: &Output) -> Point<C, Local>;
-    fn to_zoomed(self, output: &Output, level: f64) -> Point<C, Local>;
+    fn to_zoomed(self, output: &Output) -> Point<C, Local>;
     fn as_logical(self) -> Point<C, Logical>;
 }
 
@@ -66,8 +70,15 @@ impl<C: Coordinate> PointGlobalExt<C> for Point<C, Global> {
         (C::from_f64(point.x), C::from_f64(point.y)).into()
     }
 
-    fn to_zoomed(self, output: &Output, level: f64) -> Point<C, Local> {
-        let zoomed_output_geometry = output.zoomed_geometry(level).unwrap();
+    fn to_zoomed(self, output: &Output) -> Point<C, Local> {
+        let zoomed_output_geometry = output.zoomed_geometry().unwrap();
+        let level = output
+            .user_data()
+            .get::<Mutex<OutputZoomState>>()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .current_level();
         let point = (self.to_f64() - zoomed_output_geometry.loc.to_f64())
             .upscale(level)
             .as_logical();

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -23,7 +23,7 @@ use std::{
 
 pub trait OutputExt {
     fn geometry(&self) -> Rectangle<i32, Global>;
-    fn zoomed_geometry(&self, level: f64) -> Option<Rectangle<i32, Global>>;
+    fn zoomed_geometry(&self) -> Option<Rectangle<i32, Global>>;
 
     fn adaptive_sync(&self) -> AdaptiveSync;
     fn set_adaptive_sync(&self, vrr: AdaptiveSync);
@@ -57,7 +57,7 @@ impl OutputExt for Output {
         .as_global()
     }
 
-    fn zoomed_geometry(&self, level: f64) -> Option<Rectangle<i32, Global>> {
+    fn zoomed_geometry(&self) -> Option<Rectangle<i32, Global>> {
         let output_geometry = self.geometry();
 
         let output_state = self.user_data().get::<Mutex<OutputZoomState>>()?;
@@ -66,7 +66,7 @@ impl OutputExt for Output {
         let focal_point = output_state_ref.current_focal_point().to_global(self);
         let mut zoomed_output_geo = output_geometry.to_f64();
         zoomed_output_geo.loc -= focal_point;
-        zoomed_output_geo = zoomed_output_geo.downscale(level);
+        zoomed_output_geo = zoomed_output_geo.downscale(output_state_ref.current_level());
         zoomed_output_geo.loc += focal_point;
 
         Some(zoomed_output_geo.to_i32_round())

--- a/src/wayland/handlers/a11y.rs
+++ b/src/wayland/handlers/a11y.rs
@@ -21,7 +21,7 @@ impl A11yHandler for State {
         {
             let seat = shell.seats.last_active().clone();
             let level = if enabled {
-                self.common.config.dynamic_conf.zoom_state().last_level
+                1.0 + (self.common.config.cosmic_conf.accessibility_zoom.increment as f64 / 100.0)
             } else {
                 1.0
             };

--- a/src/wayland/handlers/a11y.rs
+++ b/src/wayland/handlers/a11y.rs
@@ -16,7 +16,7 @@ impl A11yHandler for State {
 
         if shell
             .zoom_state()
-            .is_some_and(|state| state.current_level() != 1.0)
+            .is_some_and(|state| shell.outputs().any(|o| state.current_level(o) != 1.0))
             != enabled
         {
             let seat = shell.seats.last_active().clone();
@@ -29,6 +29,7 @@ impl A11yHandler for State {
 
             shell.trigger_zoom(
                 &seat,
+                None,
                 level,
                 zoom_config,
                 true,


### PR DESCRIPTION
Changes:

- [x] Add setting to disable the overlay (https://github.com/pop-os/cosmic-comp/issues/1237)
  - [x] Needs cosmic-settings changes
- [x] Add setting to disable Super+Scroll
  - [x] Needs cosmic-settings changes
- [x] Remove remembering of the last state (https://github.com/pop-os/cosmic-comp/issues/1260)
- [x] Allow changing the zoom level per output (https://github.com/pop-os/cosmic-comp/issues/1237)
  - [x] This needs a good bit of code cleanup, if we decide to keep it
- [x] Fix for on-edge-movement jumping very frequently (https://github.com/pop-os/cosmic-comp/issues/1237)
- [x] Fix triggering modifier-only shortcuts (e.g. the Launcher by default), when using Super+Scroll
- [x] Fix "Magnifier settings" not working (https://github.com/pop-os/cosmic-comp/issues/1256)