### PR TITLE
EDID matching for output stack

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     backend::render::{output_elements, CursorMode, GlMultiRenderer, CLEAR_COLOR},
-    config::{AdaptiveSync, OutputConfig, OutputState, ScreenFilter},
+    config::{AdaptiveSync, EdidProduct, OutputConfig, OutputState, ScreenFilter},
     shell::Shell,
     utils::prelude::*,
     wayland::protocols::screencopy::Frame as ScreencopyFrame,
@@ -743,7 +743,7 @@ fn create_output_for_conn(drm: &mut DrmDevice, conn: connector::Handle) -> Resul
         .ok();
     let (phys_w, phys_h) = conn_info.size().unwrap_or((0, 0));
 
-    Ok(Output::new(
+    let output = Output::new(
         interface,
         PhysicalProperties {
             size: (phys_w as i32, phys_h as i32).into(),
@@ -764,7 +764,13 @@ fn create_output_for_conn(drm: &mut DrmDevice, conn: connector::Handle) -> Resul
                 .and_then(|info| info.model())
                 .unwrap_or_else(|| String::from("Unknown")),
         },
-    ))
+    );
+    if let Some(edid) = edid_info.as_ref().and_then(|x| x.edid()) {
+        output
+            .user_data()
+            .insert_if_missing(|| EdidProduct::from(edid.vendor_product()));
+    }
+    Ok(output)
 }
 
 fn populate_modes(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -94,6 +94,29 @@ impl From<Output> for OutputInfo {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EdidProduct {
+    pub manufacturer: [char; 3],
+    pub product: u16,
+    pub serial: Option<u32>,
+    pub manufacture_week: i32,
+    pub manufacture_year: i32,
+    pub model_year: Option<i32>,
+}
+
+impl From<libdisplay_info::edid::VendorProduct> for EdidProduct {
+    fn from(vp: libdisplay_info::edid::VendorProduct) -> Self {
+        Self {
+            manufacturer: vp.manufacturer,
+            product: vp.product,
+            serial: vp.serial,
+            manufacture_week: vp.manufacture_week,
+            manufacture_year: vp.manufacture_year,
+            model_year: vp.model_year,
+        }
+    }
+}
+
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct NumlockStateConfig {
     pub last_state: bool,

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -85,7 +85,7 @@ pub struct Workspace {
     pub handle: WorkspaceHandle,
     pub focus_stack: FocusStacks,
     pub screencopy: ScreencopySessions,
-    pub output_stack: VecDeque<String>,
+    output_stack: VecDeque<String>,
     pub(super) backdrop_id: Id,
     pub dirty: AtomicBool,
 }
@@ -361,7 +361,11 @@ impl Workspace {
         &self.output
     }
 
-    pub fn set_output(&mut self, output: &Output) {
+    // Set output the workspace is on
+    //
+    // If `explicit` is `true`, the user has explicitly moved the workspace
+    // to this output, so previous outputs it was on can be forgotten.
+    pub fn set_output(&mut self, output: &Output, explicit: bool) {
         self.tiling_layer.set_output(output);
         self.floating_layer.set_output(output);
         for mapped in self.mapped() {
@@ -375,6 +379,9 @@ impl Workspace {
                 toplevel_leave_output(&surface, &self.output);
                 toplevel_enter_output(&surface, output);
             }
+        }
+        if explicit {
+            self.output_stack.clear();
         }
         let output_name = output.name();
         if let Some(pos) = self

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -9,7 +9,7 @@ pub use crate::shell::{SeatExt, Shell, Workspace};
 pub use crate::state::{Common, State};
 pub use crate::wayland::handlers::xdg_shell::popup::update_reactive_popups;
 use crate::{
-    config::{AdaptiveSync, OutputConfig, OutputState},
+    config::{AdaptiveSync, EdidProduct, OutputConfig, OutputState},
     shell::zoom::OutputZoomState,
 };
 
@@ -35,6 +35,8 @@ pub trait OutputExt {
     fn is_enabled(&self) -> bool;
     fn config(&self) -> Ref<'_, OutputConfig>;
     fn config_mut(&self) -> RefMut<'_, OutputConfig>;
+
+    fn edid(&self) -> Option<&EdidProduct>;
 }
 
 struct Vrr(AtomicU8);
@@ -157,5 +159,9 @@ impl OutputExt for Output {
             .get::<RefCell<OutputConfig>>()
             .unwrap()
             .borrow_mut()
+    }
+
+    fn edid(&self) -> Option<&EdidProduct> {
+        self.user_data().get()
     }
 }


### PR DESCRIPTION
EDID matching in https://github.com/pop-os/cosmic-comp/pull/1252, but for output stacks.

It seems better to add here first (where it isn't persisted) and overhaul the on-disk format for output configuration along with pinned workspace persisting, which will also need this.

For persistent workspaces, I think it makes sense not to persist the whole output stack, but only the last output a workspace was explicitly placed on (where it was created, or moved to by the user). Though there may be edge cases where this is undesirable and confusing. (Which is also a potential problem for any other alternative.)

So when a workspace is moved explictly by the user, the output stack is cleared. And the earliest output in the stack is where it was placed explictly.

Getting the behaviors right when multiple displays have the same edid information is harder.
- We want to ignore connectors, and match by edid information when possible
- But if two monitors with same edid information are connected *at the same time*, they should be distinguished

I had the idea that `Workspaces::add_output` should check if the edid matches an existing output on a different connector, then try to move workspaces that were explictly assigned to that output with that connector, though the way `.matches()` is used for truncating the output stack will need to change too...