### PR TITLE
Fractional Xwayland scaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
+
+[[package]]
 name = "atomicwrites"
 version = "0.4.2"
 source = "git+https://github.com/jackpot51/rust-atomicwrites#043ab4859d53ffd3d55334685303d8df39c9f768"
@@ -4679,11 +4685,12 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.5.0"
-source = "git+https://github.com/smithay/smithay//?rev=657170c#657170c1c1995f13bde81ced508b47defa4af8ec"
+source = "git+https://github.com/smithay/smithay//?rev=ce61c9b#ce61c9b3293b13adf03863848426f0d7c4907c3e"
 dependencies = [
  "aliasable",
  "appendlist",
  "ash",
+ "atomic_float",
  "bitflags 2.8.0",
  "calloop 0.14.2",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?rev=ee0d46f#ee0d46f4b7e1508011a98225f14c4a0528ab2914"
+source = "git+https://github.com/pop-os//cosmic-protocols?rev=67df697#67df697105486fa4c9dd6ce00889c8b0526c9bb4"
 dependencies = [
  "bitflags 2.8.0",
  "cosmic-protocols",
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?rev=ee0d46f#ee0d46f4b7e1508011a98225f14c4a0528ab2914"
+source = "git+https://github.com/pop-os//cosmic-protocols?rev=67df697#67df697105486fa4c9dd6ce00889c8b0526c9bb4"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -1480,7 +1480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2925,7 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4399,7 +4399,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5001,7 +5001,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5294,7 +5294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5974,7 +5974,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,4 +122,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", rev = 
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", rev = "ee0d46f" }
 
 [patch."https://github.com/smithay/smithay"]
-smithay = { git = "https://github.com/smithay/smithay//", rev = "657170c" }
+smithay = { git = "https://github.com/smithay/smithay//", rev = "ce61c9b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,8 +118,8 @@ inherits = "release"
 lto = "fat"
 
 [patch."https://github.com/pop-os/cosmic-protocols"]
-cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", rev = "ee0d46f" }
-cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", rev = "ee0d46f" }
+cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", rev = "67df697" }
+cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", rev = "67df697" }
 
 [patch."https://github.com/smithay/smithay"]
 smithay = { git = "https://github.com/smithay/smithay//", rev = "ce61c9b" }

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -45,7 +45,7 @@ pub struct CosmicCompConfig {
     /// The delay in milliseconds before focus follows mouse (if enabled)
     pub focus_follows_cursor_delay: u64,
     /// Let X11 applications scale themselves
-    pub descale_xwayland: bool,
+    pub descale_xwayland: XwaylandDescaling,
     /// Let X11 applications snoop on certain key-presses to allow for global shortcuts
     pub xwayland_eavesdropping: XwaylandEavesdropping,
     /// The threshold before windows snap themselves to output edges
@@ -80,7 +80,7 @@ impl Default for CosmicCompConfig {
             focus_follows_cursor: false,
             cursor_follows_focus: false,
             focus_follows_cursor_delay: 250,
-            descale_xwayland: false,
+            descale_xwayland: XwaylandDescaling::Fractional,
             xwayland_eavesdropping: XwaylandEavesdropping::default(),
             edge_snap_threshold: 0,
             accessibility_zoom: ZoomConfig::default(),
@@ -171,4 +171,15 @@ pub enum EavesdroppingKeyboardMode {
     Modifiers,
     Combinations,
     All,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum XwaylandDescaling {
+    #[serde(rename = "true")]
+    Enabled,
+    #[serde(rename = "false")]
+    Disabled,
+    #[default]
+    Fractional,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,7 +45,7 @@ pub use self::types::*;
 use cosmic::config::CosmicTk;
 use cosmic_comp_config::{
     input::InputConfig, workspace::WorkspaceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior,
-    XkbConfig, XwaylandEavesdropping, ZoomConfig,
+    XkbConfig, XwaylandDescaling, XwaylandEavesdropping, ZoomConfig,
 };
 
 #[derive(Debug)]
@@ -917,7 +917,7 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                 }
             }
             "descale_xwayland" => {
-                let new = get_config::<bool>(&config, "descale_xwayland");
+                let new = get_config::<XwaylandDescaling>(&config, "descale_xwayland");
                 if new != state.common.config.cosmic_conf.descale_xwayland {
                     state.common.config.cosmic_conf.descale_xwayland = new;
                     state.common.update_xwayland_scale();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -163,6 +163,8 @@ pub struct OutputConfig {
     pub enabled: OutputState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_bpc: Option<u32>,
+    #[serde(default)]
+    pub xwayland_primary: bool,
 }
 
 impl Default for OutputConfig {
@@ -175,6 +177,7 @@ impl Default for OutputConfig {
             position: (0, 0),
             enabled: OutputState::Enabled,
             max_bpc: None,
+            xwayland_primary: false,
         }
     }
 }
@@ -590,6 +593,12 @@ impl Config {
         } else {
             // we don't have a config, so lets generate somewhat sane positions
             let mut w = 0;
+            if !outputs.iter().any(|o| o.config().xwayland_primary) {
+                // if we don't have a primary output for xwayland from a previous config, pick one
+                if let Some(primary) = outputs.iter().find(|o| o.mirroring().is_none()) {
+                    primary.config_mut().xwayland_primary = true;
+                }
+            }
             for output in outputs.iter().filter(|o| o.mirroring().is_none()) {
                 {
                     let mut config = output.config_mut();

--- a/src/state.rs
+++ b/src/state.rs
@@ -243,7 +243,7 @@ pub struct Common {
     pub xdg_activation_state: XdgActivationState,
     pub xdg_foreign_state: XdgForeignState,
     pub workspace_state: WorkspaceState<State>,
-    pub xwayland_scale: Option<i32>,
+    pub xwayland_scale: Option<f64>,
     pub xwayland_state: Option<XWaylandState>,
     pub xwayland_shell_state: XWaylandShellState,
     pub pointer_focus_state: Option<PointerFocusState>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -382,7 +382,10 @@ impl BackendData {
         // Update layout for changes in resolution, scale, orientation
         shell.workspaces.recalculate();
 
-        loop_handle.insert_idle(|state| state.common.update_xwayland_scale());
+        loop_handle.insert_idle(move |state| {
+            state.common.update_xwayland_scale();
+            state.common.update_xwayland_primary_output();
+        });
 
         Ok(())
     }

--- a/src/wayland/handlers/output_configuration.rs
+++ b/src/wayland/handlers/output_configuration.rs
@@ -6,6 +6,7 @@ use tracing::{error, warn};
 use crate::{
     config::{OutputConfig, OutputState},
     state::State,
+    utils::prelude::OutputExt,
     wayland::protocols::output_configuration::{
         delegate_output_configuration, ModeConfiguration, OutputConfiguration,
         OutputConfigurationHandler, OutputConfigurationState,
@@ -24,6 +25,17 @@ impl OutputConfigurationHandler for State {
     }
     fn apply_configuration(&mut self, conf: Vec<(Output, OutputConfiguration)>) -> bool {
         self.output_configuration(false, conf)
+    }
+
+    fn request_xwayland_primary(&mut self, primary_output: Option<Output>) {
+        for output in self.common.output_configuration_state.outputs() {
+            output.config_mut().xwayland_primary =
+                primary_output.as_ref().is_some_and(|o| *o == output);
+        }
+        self.common.update_xwayland_primary_output();
+        self.common
+            .config
+            .write_outputs(self.common.output_configuration_state.outputs());
     }
 }
 

--- a/src/wayland/protocols/output_configuration/mod.rs
+++ b/src/wayland/protocols/output_configuration/mod.rs
@@ -58,6 +58,8 @@ pub trait OutputConfigurationHandler: Sized {
 
     fn test_configuration(&mut self, conf: Vec<(Output, OutputConfiguration)>) -> bool;
     fn apply_configuration(&mut self, conf: Vec<(Output, OutputConfiguration)>) -> bool;
+
+    fn request_xwayland_primary(&mut self, output: Option<Output>);
 }
 
 pub struct OutputMngrGlobalData {
@@ -189,7 +191,7 @@ where
         );
 
         let extension_global = dh.create_global::<D, ZcosmicOutputManagerV1, _>(
-            2,
+            3,
             OutputMngrGlobalData {
                 filter: Box::new(client_filter),
             },
@@ -503,6 +505,14 @@ where
         }
         if physical.model != "Unknown" {
             instance.obj.model(physical.model);
+        }
+    }
+
+    if let Some(extension_obj) = instance.extension_obj.as_ref() {
+        if inner.enabled
+            && extension_obj.version() >= zcosmic_output_head_v1::EVT_XWAYLAND_PRIMARY_SINCE
+        {
+            extension_obj.xwayland_primary(output.config().xwayland_primary as u32);
         }
     }
 }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -506,7 +506,7 @@ impl Common {
                     .get_data::<XWaylandClientData>()
                     .unwrap()
                     .compositor_state
-                    .set_client_scale(new_scale as u32);
+                    .set_client_scale(new_scale as f64);
 
                 // update wl/xdg_outputs
                 for output in self.shell.read().unwrap().outputs() {

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -11,16 +11,28 @@ use crate::{
         toplevel_management::minimize_rectangle, xdg_activation::ActivationContext,
     },
 };
-use cosmic_comp_config::EavesdroppingKeyboardMode;
+use cosmic_comp_config::{EavesdroppingKeyboardMode, XwaylandDescaling};
 use smithay::{
     backend::{
+        allocator::Fourcc,
         drm::DrmNode,
         input::{ButtonState, KeyState, Keycode},
+        renderer::{
+            element::{
+                memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
+                Kind,
+            },
+            pixman::{PixmanError, PixmanRenderer},
+            utils::draw_render_elements,
+            Bind, Frame, Offscreen, Renderer,
+        },
     },
     desktop::space::SpaceElement,
     input::{keyboard::ModifiersState, pointer::CursorIcon},
     reexports::{wayland_server::Client, x11rb::protocol::xproto::Window as X11Window},
-    utils::{Logical, Point, Rectangle, Serial, Size, SERIAL_COUNTER},
+    utils::{
+        Buffer as BufferCoords, Logical, Point, Rectangle, Serial, Size, Transform, SERIAL_COUNTER,
+    },
     wayland::{
         selection::{
             data_device::{
@@ -41,6 +53,7 @@ use smithay::{
     },
 };
 use tracing::{error, trace, warn};
+use xcursor::parser::Image;
 use xkbcommon::xkb::Keysym;
 
 #[derive(Debug)]
@@ -97,7 +110,7 @@ impl State {
                         last_modifier_state: None,
                     });
 
-                    let mut wm = match X11Wm::start_wm(
+                    let wm = match X11Wm::start_wm(
                         data.common.event_loop_handle.clone(),
                         x11_socket,
                         client.clone(),
@@ -109,23 +122,9 @@ impl State {
                         }
                     };
 
-                    let (theme, size) = load_cursor_theme();
-                    let cursor = Cursor::load(&theme, CursorIcon::Default, size);
-                    let image = cursor.get_image(1, 0);
-                    if let Err(err) = wm.set_cursor(
-                        &image.pixels_rgba,
-                        Size::from((image.width as u16, image.height as u16)),
-                        Point::from((image.xhot as u16, image.yhot as u16)),
-                    ) {
-                        warn!(
-                            id = ?wm.id(),
-                            ?err,
-                            "Failed to set default cursor for Xwayland WM",
-                        );
-                    }
-
                     let xwayland_state = data.common.xwayland_state.as_mut().unwrap();
                     xwayland_state.xwm = Some(wm);
+                    xwayland_state.reload_cursor(1.);
                     data.notify_ready();
 
                     data.common.update_xwayland_scale();
@@ -142,6 +141,102 @@ impl State {
                 error!(?err, "Failed to listen for Xwayland");
                 self.notify_ready();
                 return;
+            }
+        }
+    }
+}
+
+fn scale_cursor(
+    scale: f64,
+    cursor_size: u32,
+    image: &Image,
+) -> Result<(Vec<u8>, Size<u16, Logical>, Point<u16, Logical>), PixmanError> {
+    let mut renderer = PixmanRenderer::new()?;
+    let image_scale = (image.size / cursor_size).max(1);
+    let pixel_size = (cursor_size as f64 * scale).round() as i32;
+    let buffer_size = Size::<i32, BufferCoords>::from((pixel_size, pixel_size));
+    let output_size = buffer_size.to_logical(1, Transform::Normal).to_physical(1);
+
+    let image_buffer = MemoryRenderBuffer::from_slice(
+        &image.pixels_rgba,
+        Fourcc::Abgr8888,
+        (image.width as i32, image.height as i32),
+        image_scale as i32,
+        Transform::Normal,
+        None,
+    );
+    let element = MemoryRenderBufferRenderElement::from_buffer(
+        &mut renderer,
+        (0., 0.),
+        &image_buffer,
+        None,
+        None,
+        None,
+        Kind::Unspecified,
+    )?;
+
+    let mut buffer = renderer.create_buffer(Fourcc::Abgr8888, buffer_size)?;
+    let mut fb = renderer.bind(&mut buffer)?;
+    let mut frame = renderer.render(&mut fb, output_size, Transform::Normal)?;
+    draw_render_elements(
+        &mut frame,
+        scale,
+        &[element],
+        &[Rectangle::new((0, 0).into(), output_size)],
+    )?;
+    let sync = frame.finish()?;
+    while let Err(_) = sync.wait() {}
+
+    let len = (buffer_size.w * buffer_size.h * 4) as usize;
+    let mut data = Vec::with_capacity(len);
+    assert_eq!(buffer.stride(), (buffer_size.w * 4) as usize);
+    data.extend_from_slice(unsafe { std::slice::from_raw_parts(buffer.data() as *mut u8, len) });
+
+    let hotspot = Point::<i32, BufferCoords>::from((image.xhot as i32, image.yhot as i32))
+        .to_f64()
+        .to_logical(
+            image_scale as f64,
+            Transform::Normal,
+            &Size::from((image.width as f64, image.height as f64)),
+        )
+        .to_buffer(
+            scale,
+            Transform::Normal,
+            &output_size.to_logical(1).to_f64(),
+        )
+        .to_i32_round::<i32>();
+    Ok((
+        data,
+        Size::from((buffer_size.w as u16, buffer_size.h as u16)),
+        Point::from((hotspot.x as u16, hotspot.y as u16)),
+    ))
+}
+
+impl XWaylandState {
+    pub fn reload_cursor(&mut self, scale: f64) {
+        if let Some(wm) = self.xwm.as_mut() {
+            let (theme, size) = load_cursor_theme();
+            let cursor = Cursor::load(&theme, CursorIcon::Default, size);
+            let image = cursor.get_image(scale.ceil() as u32, 0);
+
+            let (pixels_rgba, size, hotspot) = match scale_cursor(scale, size, &image) {
+                Ok(x) => x,
+                Err(err) => {
+                    warn!("Failed to scale Xwayland cursor image: {}", err);
+                    (
+                        image.pixels_rgba,
+                        Size::from((image.width as u16, image.height as u16)),
+                        Point::from((image.xhot as u16, image.yhot as u16)),
+                    )
+                }
+            };
+
+            if let Err(err) = wm.set_cursor(&pixels_rgba, size, hotspot) {
+                warn!(
+                    id = ?wm.id(),
+                    ?err,
+                    "Failed to set default cursor for Xwayland WM",
+                );
             }
         }
     }
@@ -461,15 +556,23 @@ impl Common {
     }
 
     pub fn update_xwayland_scale(&mut self) {
-        let new_scale = if self.config.cosmic_conf.descale_xwayland {
-            let shell = self.shell.read().unwrap();
-            shell
-                .outputs()
-                .map(|o| o.current_scale().integer_scale())
-                .max()
-                .unwrap_or(1)
-        } else {
-            1
+        let new_scale = match self.config.cosmic_conf.descale_xwayland {
+            XwaylandDescaling::Disabled => 1.,
+            XwaylandDescaling::Enabled => {
+                let shell = self.shell.read().unwrap();
+                shell
+                    .outputs()
+                    .map(|o| o.current_scale().integer_scale())
+                    .max()
+                    .unwrap_or(1) as f64
+            }
+            XwaylandDescaling::Fractional => {
+                let shell = self.shell.read().unwrap();
+                shell
+                    .outputs()
+                    .map(|o| o.current_scale().fractional_scale())
+                    .fold(1f64, |acc, val| acc.max(val))
+            }
         };
 
         // compare with current scale
@@ -487,12 +590,18 @@ impl Common {
 
                 // update xorg dpi
                 if let Some(xwm) = xwayland.xwm.as_mut() {
-                    let dpi = new_scale.abs() * 96 * 1024;
+                    let dpi = new_scale * 96. * 1024.;
                     if let Err(err) = xwm.set_xsettings(
                         [
-                            ("Xft/DPI".into(), dpi.into()),
-                            ("Gdk/UnscaledDPI".into(), (dpi / new_scale).into()),
-                            ("Gdk/WindowScalingFactor".into(), new_scale.into()),
+                            ("Xft/DPI".into(), (dpi.round() as i32).into()),
+                            (
+                                "Gdk/UnscaledDPI".into(),
+                                ((dpi / new_scale).round() as i32).into(),
+                            ),
+                            (
+                                "Gdk/WindowScalingFactor".into(),
+                                (new_scale.round() as i32).into(),
+                            ),
                         ]
                         .into_iter(),
                     ) {
@@ -500,13 +609,16 @@ impl Common {
                     }
                 }
 
+                // update cursor
+                xwayland.reload_cursor(new_scale);
+
                 // update client scale
                 xwayland
                     .client
                     .get_data::<XWaylandClientData>()
                     .unwrap()
                     .compositor_state
-                    .set_client_scale(new_scale as f64);
+                    .set_client_scale(new_scale);
 
                 // update wl/xdg_outputs
                 for output in self.shell.read().unwrap().outputs() {

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -652,9 +652,12 @@ impl Common {
             if let Some(xwm) = xstate.xwm.as_mut() {
                 if let Err(err) = xwm.set_randr_primary_output(xwayland_primary_output.as_ref()) {
                     warn!("Failed to set xwayland primary output: {}", err);
+                    return;
                 };
             }
         }
+
+        self.output_configuration_state.update();
     }
 }
 

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -569,10 +569,16 @@ impl Common {
             }
             XwaylandDescaling::Fractional => {
                 let shell = self.shell.read().unwrap();
-                shell
-                    .outputs()
-                    .map(|o| o.current_scale().fractional_scale())
-                    .fold(1f64, |acc, val| acc.max(val))
+                let val =
+                    if let Some(output) = shell.outputs().find(|o| o.config().xwayland_primary) {
+                        output.current_scale().fractional_scale().max(1f64)
+                    } else {
+                        shell
+                            .outputs()
+                            .map(|o| o.current_scale().fractional_scale())
+                            .fold(1f64, |acc, val| acc.max(val))
+                    };
+                val
             }
         };
 
@@ -1143,6 +1149,7 @@ impl XwmHandler for State {
                 output_name.as_deref().is_some_and(|o| o == output.name());
         }
         self.common.output_configuration_state.update();
+        self.common.update_xwayland_scale();
         self.common
             .config
             .write_outputs(self.common.output_configuration_state.outputs());


### PR DESCRIPTION
Seems to work surprisingly well, but some apps don't match the fractional scale factor (how would they, given this was never supported by any toolkit).

Many will increase their font size with the dpi value (Qt apps) or be slightly off (in the worse case up to 50% until the nearest integer value), appearing larger/smaller accordingly (e.g. GTK3 apps).

Others like Steam can scale to whatever and still don't seem to get it completely right (window is slightly too small by default), but given the custom toolkit doesn't fit into the desktop, it looks correct.

It certainly works much much better with games, which now see the correct resolution on the monitor with the highest scaling value (no matter with fractional or not), while only the others are slightly off and will be scaled accordingly. (If we would want to make this truly configurable, we should allow user to set the "primary" display as exposed to Xwayland and take that output's scale for the client-scale.)

I am a bit weary about all the potential for rounding errors this introduces, but I haven't found anything obviously broken related to input or rendering.

Not sure, if we want this and if so, if this should replace our current implementation (which works more consistently with apps, but not games) or be a separate option (how do we explain this in the UI?).

Anyway, draft for testing.