### PR TITLE
Change default X11 eavesdropping to None

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -166,9 +166,9 @@ pub struct XwaylandEavesdropping {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 pub enum EavesdroppingKeyboardMode {
+    #[default]
     None,
     Modifiers,
-    #[default]
     Combinations,
     All,
 }


### PR DESCRIPTION
Requested by @WatchMkr.

May be less confusing for users than having some functionality work but not others by default. This way, something is clearly not working and they'll hopefully know to look the setting up so they can learn all the available options and their security implications.