### PR TITLE
Various cursor fixes

### DIFF
--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -20,7 +20,8 @@ use smithay::{
     reexports::wayland_server::protocol::wl_surface,
     render_elements,
     utils::{
-        Buffer as BufferCoords, IsAlive, Logical, Monotonic, Point, Scale, Size, Time, Transform,
+        Buffer as BufferCoords, IsAlive, Logical, Monotonic, Physical, Point, Scale, Size, Time,
+        Transform,
     },
     wayland::compositor::{get_role, with_states},
 };
@@ -128,7 +129,7 @@ pub fn draw_surface_cursor<R>(
     surface: &wl_surface::WlSurface,
     location: impl Into<Point<i32, Logical>>,
     scale: impl Into<Scale<f64>>,
-) -> Vec<(CursorRenderElement<R>, Point<i32, BufferCoords>)>
+) -> Vec<(CursorRenderElement<R>, Point<i32, Physical>)>
 where
     R: Renderer + ImportAll,
     R::TextureId: Clone + 'static,
@@ -143,11 +144,7 @@ where
             .lock()
             .unwrap()
             .hotspot
-            .to_buffer(
-                1,
-                Transform::Normal,
-                &Size::from((1, 1)), /* Size doesn't matter for Transform::Normal */
-            )
+            .to_physical_precise_round(scale)
     });
 
     render_elements_from_surface_tree(
@@ -259,7 +256,7 @@ pub fn draw_cursor<R>(
     buffer_scale: f64,
     time: Time<Monotonic>,
     draw_default: bool,
-) -> Vec<(CursorRenderElement<R>, Point<i32, BufferCoords>)>
+) -> Vec<(CursorRenderElement<R>, Point<i32, Physical>)>
 where
     R: Renderer + ImportMem + ImportAll,
     R::TextureId: Send + Clone + 'static,
@@ -320,7 +317,12 @@ where
             }
         };
 
-        let hotspot = Point::<i32, BufferCoords>::from((frame.xhot as i32, frame.yhot as i32));
+        let hotspot = Point::<i32, BufferCoords>::from((frame.xhot as i32, frame.yhot as i32))
+            .to_logical(
+                actual_scale as i32,
+                Transform::Normal,
+                &Size::from((frame.width as i32, frame.height as i32)),
+            );
         state.current_image = Some(frame);
 
         return vec![(
@@ -336,10 +338,10 @@ where
                 )
                 .expect("Failed to import cursor bitmap"),
             ),
-            hotspot,
+            hotspot.to_physical_precise_round(scale),
         )];
     } else if let CursorImageStatus::Surface(ref wl_surface) = cursor_status {
-        return draw_surface_cursor(renderer, wl_surface, location.to_i32_round(), scale);
+        return draw_surface_cursor(renderer, wl_surface, location, scale);
     } else {
         Vec::new()
     }

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -219,7 +219,7 @@ impl CursorStateInner {
     }
 }
 
-pub fn load_cursor_theme() -> (CursorTheme, u32) {
+pub fn load_cursor_env() -> (String, u32) {
     let name = std::env::var("XCURSOR_THEME")
         .ok()
         .unwrap_or_else(|| "default".into());
@@ -227,6 +227,11 @@ pub fn load_cursor_theme() -> (CursorTheme, u32) {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(24);
+    (name, size)
+}
+
+pub fn load_cursor_theme() -> (CursorTheme, u32) {
+    let (name, size) = load_cursor_env();
     (CursorTheme::load(&name), size)
 }
 

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -127,14 +127,13 @@ render_elements! {
 pub fn draw_surface_cursor<R>(
     renderer: &mut R,
     surface: &wl_surface::WlSurface,
-    location: impl Into<Point<i32, Logical>>,
+    location: Point<f64, Logical>,
     scale: impl Into<Scale<f64>>,
 ) -> Vec<(CursorRenderElement<R>, Point<i32, Physical>)>
 where
     R: Renderer + ImportAll,
     R::TextureId: Clone + 'static,
 {
-    let position = location.into();
     let scale = scale.into();
     let h = with_states(&surface, |states| {
         states
@@ -150,7 +149,7 @@ where
     render_elements_from_surface_tree(
         renderer,
         surface,
-        position.to_physical_precise_round(scale),
+        location.to_physical(scale).to_i32_round(),
         scale,
         1.0,
         Kind::Cursor,
@@ -164,7 +163,7 @@ where
 pub fn draw_dnd_icon<R>(
     renderer: &mut R,
     surface: &wl_surface::WlSurface,
-    location: impl Into<Point<i32, Logical>>,
+    location: Point<f64, Logical>,
     scale: impl Into<Scale<f64>>,
 ) -> Vec<WaylandSurfaceRenderElement<R>>
 where
@@ -181,7 +180,7 @@ where
     render_elements_from_surface_tree(
         renderer,
         surface,
-        location.into().to_physical_precise_round(scale),
+        location.to_physical(scale).to_i32_round(),
         scale,
         1.0,
         Kind::Unspecified,

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -1,7 +1,7 @@
 use std::{ffi::OsString, os::unix::io::OwnedFd, process::Stdio};
 
 use crate::{
-    backend::render::cursor::{load_cursor_theme, Cursor},
+    backend::render::cursor::{load_cursor_env, load_cursor_theme, Cursor},
     shell::{
         focus::target::KeyboardFocusTarget, grabs::ReleaseMode, CosmicSurface, PendingWindow, Shell,
     },
@@ -595,6 +595,8 @@ impl Common {
                     .filter_map(|s| s.0.x11_surface().map(|x| (x.clone(), x.geometry())))
                     .collect::<Vec<_>>();
 
+                let (_, cursor_size) = load_cursor_env();
+
                 // update xorg dpi
                 if let Some(xwm) = xwayland.xwm.as_mut() {
                     let dpi = new_scale * 96. * 1024.;
@@ -602,12 +604,20 @@ impl Common {
                         [
                             ("Xft/DPI".into(), (dpi.round() as i32).into()),
                             (
+                                "Xcursor/size".into(),
+                                ((new_scale * cursor_size as f64).round() as i32).into(),
+                            ),
+                            (
                                 "Gdk/UnscaledDPI".into(),
                                 ((dpi / new_scale).round() as i32).into(),
                             ),
                             (
                                 "Gdk/WindowScalingFactor".into(),
                                 (new_scale.round() as i32).into(),
+                            ),
+                            (
+                                "Gtk/CursorThemeSize".into(),
+                                ((new_scale * cursor_size as f64).round() as i32).into(),
                             ),
                         ]
                         .into_iter(),


### PR DESCRIPTION
This fixes https://github.com/pop-os/cosmic-comp/issues/875 and some tiny cursor in Xwayland when any but the "compatibility"-scaling setting is choosen.

~~However I cannot figure out why chromium based (so chrome + electron) flatpak apps don't respect it, when running under X11. Works just fine, when they are installed from .deb-files. Presumably they read the xcursor size from a different source, as I confirmed the xsettings propagate correctly into the sandbox, but the chromium source code isn't exactly straight forward.~~ Seems to be a packaging issue.