### PR TITLE
Profiling / Performance fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
+ "tracy-client 0.18.0",
  "wayland-backend",
  "wayland-scanner",
  "xcursor",
@@ -1481,7 +1482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2926,7 +2927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4081,7 +4082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 dependencies = [
  "profiling-procmacros",
- "tracy-client",
+ "tracy-client 0.17.6",
 ]
 
 [[package]]
@@ -4400,7 +4401,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5002,7 +5003,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5289,13 +5290,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracy-client"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
 name = "tracy-client-sys"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5975,7 +5987,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tiny-skia = "0.11"
 tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
 tracing-journald = "0.3.0"
 tracing-subscriber = {version = "0.3.16", features = ["env-filter", "tracing-log"]}
+tracy-client = { version = "0.18.0", default-features = false }
 wayland-backend = "0.3.3"
 wayland-scanner = "0.31.1"
 xcursor = "0.3.3"
@@ -100,7 +101,7 @@ rev = "e720136"
 debug = ["egui", "egui_plot", "smithay-egui", "anyhow/backtrace"]
 default = ["systemd"]
 systemd = ["libsystemd"]
-profile-with-tracy = ["profiling/profile-with-tracy"]
+profile-with-tracy = ["profiling/profile-with-tracy", "tracy-client/default"]
 
 [profile.dev.package.tiny-skia]
 opt-level = 2

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -47,6 +47,7 @@ use std::{
     fmt,
     path::{Path, PathBuf},
     sync::{atomic::AtomicBool, mpsc::Receiver, Arc, RwLock},
+    time::Duration,
 };
 
 use super::{drm_helpers, socket::Socket, surface::Surface};
@@ -64,6 +65,7 @@ pub type GbmDrmOutputManager = DrmOutputManager<
     Option<(
         OutputPresentationFeedback,
         Receiver<(ScreencopyFrame, Vec<Rectangle<i32, BufferCoords>>)>,
+        Duration,
     )>,
     DrmDeviceFd,
 >;

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1008,14 +1008,12 @@ impl SurfaceThreadState {
         .map_err(|err| {
             anyhow::format_err!("Failed to accumulate elements for rendering: {:?}", err)
         })?;
-        let additional_frame_flags = if vrr
-            && has_active_fullscreen
-            && !self.timings.past_min_presentation_time(&self.clock)
-        {
-            FrameFlags::SKIP_CURSOR_ONLY_UPDATES
-        } else {
-            FrameFlags::empty()
-        };
+        let additional_frame_flags =
+            if vrr && has_active_fullscreen && !self.timings.past_min_render_time(&self.clock) {
+                FrameFlags::SKIP_CURSOR_ONLY_UPDATES
+            } else {
+                FrameFlags::empty()
+            };
         self.timings.set_vrr(vrr);
         self.timings.elements_done(&self.clock);
 

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -523,7 +523,7 @@ fn surface_thread(
         vrr_mode: AdaptiveSync::Disabled,
 
         state: QueueState::Idle,
-        timings: Timings::new(None, None, false),
+        timings: Timings::new(None, None, false, target_node),
         frame_callback_seq: 0,
         thread_sender,
 

--- a/src/backend/kms/surface/timings.rs
+++ b/src/backend/kms/surface/timings.rs
@@ -51,7 +51,7 @@ impl Frame {
 }
 
 impl Timings {
-    const WINDOW_SIZE: usize = 360;
+    const CLEANUP: usize = 360;
 
     pub fn new(
         refresh_interval: Option<Duration>,
@@ -171,8 +171,9 @@ impl Timings {
                 );
             }
             self.previous_frames.push_back(new_frame);
-            while self.previous_frames.len() > Self::WINDOW_SIZE {
-                self.previous_frames.pop_front();
+
+            if let Some(overflow) = self.previous_frames.len().checked_sub(Self::CLEANUP * 2) {
+                self.previous_frames = self.previous_frames.split_off(overflow + Self::CLEANUP);
             }
         }
     }

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -572,15 +572,16 @@ where
     CosmicMappedRenderElement<R>: RenderElement<R>,
     WorkspaceRenderElement<R>: RenderElement<R>,
 {
-    let shell_guard = shell.read().unwrap();
     #[cfg(feature = "debug")]
     let mut debug_elements = {
         let output_geo = output.geometry();
+        let shell_guard = shell.read().unwrap();
         let seats = shell_guard.seats.iter().cloned().collect::<Vec<_>>();
+        let debug_active = shell_guard.debug_active;
+        std::mem::drop(shell_guard);
         let scale = output.current_scale().fractional_scale();
 
         if let Some((state, timings)) = _fps {
-            let debug_active = shell_guard.debug_active;
             vec![fps_ui(
                 _gpu,
                 debug_active,
@@ -601,6 +602,7 @@ where
         }
     };
 
+    let shell_guard = shell.read().unwrap();
     let Some((previous_workspace, workspace)) = shell_guard.workspaces.active(output) else {
         #[cfg(not(feature = "debug"))]
         return Ok(Vec::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,9 +127,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     logger::init_logger()?;
     info!("Cosmic starting up!");
 
-    #[cfg(feature = "profile-with-tracy")]
-    profiling::tracy_client::Client::start();
     profiling::register_thread!("Main Thread");
+    #[cfg(feature = "profile-with-tracy")]
+    tracy_client::Client::start();
 
     utils::rlimit::increase_nofile_limit();
 

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -381,7 +381,6 @@ impl CosmicStack {
         if update {
             self.0
                 .resize(Size::from((self.active().geometry().size.w, TAB_HEIGHT)));
-            self.0.force_update();
         }
 
         result
@@ -436,7 +435,6 @@ impl CosmicStack {
         if !matches!(result, MoveResult::Default) {
             self.0
                 .resize(Size::from((self.active().geometry().size.w, TAB_HEIGHT)));
-            self.0.force_update();
         }
 
         result
@@ -1208,7 +1206,6 @@ impl SpaceElement for CosmicStack {
         })
     }
     fn refresh(&self) {
-        SpaceElement::refresh(&self.0);
         self.0.with_program(|p| {
             let mut windows = p.windows.lock().unwrap();
 
@@ -1245,6 +1242,7 @@ impl SpaceElement for CosmicStack {
                 SpaceElement::refresh(w)
             });
         });
+        SpaceElement::refresh(&self.0);
     }
 }
 

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -635,9 +635,12 @@ impl SpaceElement for CosmicWindow {
     }
     #[profiling::function]
     fn refresh(&self) {
-        SpaceElement::refresh(&self.0);
         if self.0.with_program(|p| {
             SpaceElement::refresh(&p.window);
+            if !p.has_ssd(true) {
+                return false;
+            }
+
             let title = p.window.title();
             let mut last_title = p.last_title.lock().unwrap();
             if *last_title != title {
@@ -648,6 +651,8 @@ impl SpaceElement for CosmicWindow {
             }
         }) {
             self.0.force_update();
+        } else {
+            SpaceElement::refresh(&self.0);
         }
     }
 }

--- a/src/utils/iced.rs
+++ b/src/utils/iced.rs
@@ -376,7 +376,6 @@ impl<P: Program + Send + 'static> IcedElement<P> {
         for (_buffer, ref mut old_primitives) in internal.buffers.values_mut() {
             *old_primitives = None;
         }
-        internal.update(true);
     }
 
     pub fn current_size(&self) -> Size<i32, Logical> {
@@ -405,13 +404,12 @@ impl<P: Program + Send + 'static + Clone> IcedElement<P> {
 
 impl<P: Program + Send + 'static> IcedElementInternal<P> {
     #[profiling::function]
-    fn update(&mut self, mut force: bool) {
+    fn update(&mut self, force: bool) {
         while let Ok(Some(message)) = self.rx.try_recv() {
             self.state.queue_message(message);
-            force = true;
         }
 
-        if !force {
+        if self.state.is_queue_empty() && !force {
             return;
         }
 
@@ -469,7 +467,7 @@ impl<P: Program + Send + 'static> PointerTarget<crate::state::State> for IcedEle
         // TODO: Update iced widgets to handle touch using event position, not cursor_pos
         internal.cursor_pos = Some(event_location);
         *internal.last_seat.lock().unwrap() = Some((seat.clone(), event.serial));
-        internal.update(true);
+        internal.update(false);
     }
 
     fn motion(
@@ -486,7 +484,7 @@ impl<P: Program + Send + 'static> PointerTarget<crate::state::State> for IcedEle
             .queue_event(Event::Mouse(MouseEvent::CursorMoved { position }));
         internal.cursor_pos = Some(event_location);
         *internal.last_seat.lock().unwrap() = Some((seat.clone(), event.serial));
-        internal.update(true);
+        internal.update(false);
     }
 
     fn relative_motion(
@@ -515,7 +513,7 @@ impl<P: Program + Send + 'static> PointerTarget<crate::state::State> for IcedEle
             ButtonState::Released => MouseEvent::ButtonReleased(button),
         }));
         *internal.last_seat.lock().unwrap() = Some((seat.clone(), event.serial));
-        internal.update(true);
+        internal.update(false);
     }
 
     fn axis(
@@ -540,7 +538,7 @@ impl<P: Program + Send + 'static> PointerTarget<crate::state::State> for IcedEle
                     }
                 },
             }));
-        internal.update(true);
+        internal.update(false);
     }
 
     fn frame(&self, _seat: &Seat<crate::state::State>, _data: &mut crate::state::State) {}
@@ -556,7 +554,7 @@ impl<P: Program + Send + 'static> PointerTarget<crate::state::State> for IcedEle
         internal
             .state
             .queue_event(Event::Mouse(MouseEvent::CursorLeft));
-        internal.update(true);
+        internal.update(false);
     }
 
     fn gesture_swipe_begin(
@@ -635,7 +633,7 @@ impl<P: Program + Send + 'static> TouchTarget<crate::state::State> for IcedEleme
         internal.touch_map.insert(id, position);
         internal.cursor_pos = Some(event_location);
         *internal.last_seat.lock().unwrap() = Some((seat.clone(), seq));
-        let _ = internal.update(true);
+        let _ = internal.update(false);
     }
 
     fn up(
@@ -652,7 +650,7 @@ impl<P: Program + Send + 'static> TouchTarget<crate::state::State> for IcedEleme
             internal
                 .state
                 .queue_event(Event::Touch(TouchEvent::FingerLifted { id, position }));
-            let _ = internal.update(true);
+            let _ = internal.update(false);
         }
     }
 
@@ -673,7 +671,7 @@ impl<P: Program + Send + 'static> TouchTarget<crate::state::State> for IcedEleme
             .queue_event(Event::Touch(TouchEvent::FingerMoved { id, position }));
         internal.touch_map.insert(id, position);
         internal.cursor_pos = Some(event_location);
-        let _ = internal.update(true);
+        let _ = internal.update(false);
     }
 
     fn frame(
@@ -696,7 +694,7 @@ impl<P: Program + Send + 'static> TouchTarget<crate::state::State> for IcedEleme
                 .state
                 .queue_event(Event::Touch(TouchEvent::FingerLost { id, position }));
         }
-        let _ = internal.update(true);
+        let _ = internal.update(false);
     }
 
     fn shape(
@@ -774,7 +772,7 @@ impl<P: Program + Send + 'static> KeyboardTarget<crate::state::State> for IcedEl
         internal
             .state
             .queue_event(Event::Keyboard(KeyboardEvent::ModifiersChanged(mods)));
-        let _ = internal.update(true);
+        let _ = internal.update(false);
     }
 }
 
@@ -807,7 +805,7 @@ impl<P: Program + Send + 'static> SpaceElement for IcedElement<P> {
         } else {
             WindowEvent::Unfocused
         }));
-        let _ = internal.update(true); // TODO
+        let _ = internal.update(false);
     }
 
     fn output_enter(&self, output: &Output, _overlap: Rectangle<i32, Logical>) {
@@ -881,7 +879,7 @@ impl<P: Program + Send + 'static> SpaceElement for IcedElement<P> {
                 ),
             );
         }
-        internal.update(true);
+        internal.update(false);
     }
 }
 


### PR DESCRIPTION
Draft as this needs more testing on different systems.

This touches the frame scheduling logic again, but this time all profiled with tracy, so that we actually have some data:

1. According to kwin, mesa drivers return from `page_flip`/`commit` once the commit is staged for the next vblank. So we can use the time until submission (not presentation) to optimize our latency by moving closer, if we finish submission early. Waiting for presentation was somewhat borked anyway, as that depends on the refresh rate, so most likely we were rendering asap anyway.
2. This also introduces a workaround for nvidia cards, where this doesn't seem to help at all. Especially on multi-gpu setups submission might take ages, while we wait for the render operation to complete and we don't have a feedback channel. (I guess we might start putting the composited dmabuf into our event-loop to figure out the render time at least, but that is difficult to setup with our `DrmCompositor`.) So lets bail on the whole scheduling logic and just render asap
  Note: This should check for the driver rather than the vendor, given how good nouveau has gotten.
3. At the same time we also increase the safety margins a bit as we know are much closer to the deadline potentially running into kernel scheduling weirdness.
4. We also fix the vrr-deadline calculation for the min-refresh-rate. I assume this is what people described as stuttering, as we were basically guaranteed to miss the deadline for cursor updates with the old code. Now the cursor operates at *at least* 30fps, while still allowing content to drive the FPS in fullscreen. Feels very nice in game.

Other than that the tracing showed `refresh` on the main thread of frequently block the render-threads from acquiring the shell-lock, due to `IcedElement::refresh` taking ages. We can't easily fix this as most of the time in spent in `UserInterface::build` (specifically `diff_children`) and `layout` (not `draw` as one would expect, so finally switching to the wgpu renderer wouldn't help much), but we can reduce how often we need to call this as it turns out.

Doesn't fully eliminate the problem, but we are able to hit high refresh rates (>=120) much more reliably now.

This is all tested on an `oryp7` with integrated Intel and dedicated nvidia 3070 gpu with an external 120hz, 4k, VRR display. So in some ways the most problematic device (limited multi-gpu bandwidth, 4k, high refresh rate, vrr and nvidia...), but I would still want to give this some tests on other systems with tracy attached - mainly an AMD system - before merging.