### PR TITLE
flake.nix: refactor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,6 @@
         "type": "github"
       }
     },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1725067332,
@@ -46,52 +31,46 @@
         "type": "github"
       }
     },
-    "parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1725024810,
-        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
-        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "parts": "parts",
-        "rust": "rust"
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
       }
     },
-    "rust": {
+    "rust-overlay": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1724984647,
-        "narHash": "sha256-BC6MUq0CTdmAu/cueVcdWTI+S95s0mJcn19SoEgd7gU=",
+        "lastModified": 1745894113,
+        "narHash": "sha256-dxO3caQZMv/pMtcuXdi+SnAtyki6HFbSf1IpgQPXZYc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "87b6cffc276795b46ef544d7ed8d7fed6ad9c8e4",
+        "rev": "e552fe1b16ffafd678ebe061c22b117e050769ed",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,50 +2,45 @@
   description = "Compositor for the COSMIC desktop environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # <https://github.com/nix-systems/default-linux>
+    systems.url = "github:nix-systems/default-linux";
 
-    parts.url = "github:hercules-ci/flake-parts";
-    parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     crane.url = "github:ipetkov/crane";
 
-    rust.url = "github:oxalica/rust-overlay";
-    rust.inputs.nixpkgs.follows = "nixpkgs";
-
-    nix-filter.url = "github:numtide/nix-filter";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs @ {
+  outputs = {
     self,
-    nixpkgs,
-    parts,
     crane,
-    rust,
-    nix-filter,
+    nixpkgs,
+    rust-overlay,
+    systems,
     ...
-  }:
-    parts.lib.mkFlake {inherit inputs;} {
-      systems = [
-        "aarch64-linux"
-        "x86_64-linux"
-      ];
+  }: let
+    inherit (nixpkgs) lib;
 
-      perSystem = {
-        self',
-        lib,
-        system,
-        ...
-      }: let
-        pkgs = nixpkgs.legacyPackages.${system}.extend rust.overlays.default;
-        rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-        craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
+    fs = lib.fileset;
+    eachSystem = lib.genAttrs (import systems);
+    pkgsFor = eachSystem (system:
+      import nixpkgs {
+        localSystem.system = system;
+        overlays = [(import rust-overlay)];
+      });
+  in {
+    packages =
+      lib.mapAttrs (system: pkgs: let
+        craneLib = crane.mkLib pkgs;
         craneArgs = {
           pname = "cosmic-comp";
           version = self.rev or "dirty";
 
-          src = nix-filter.lib.filter {
+          src = fs.toSource {
             root = ./.;
-            include = [
+            fileset = fs.unions [
               ./src
               ./i18n.toml
               ./Cargo.toml
@@ -89,24 +84,41 @@
         };
 
         cargoArtifacts = craneLib.buildDepsOnly craneArgs;
-        cosmic-comp = craneLib.buildPackage (craneArgs // {inherit cargoArtifacts;});
       in {
-        apps.cosmic-comp = {
-          type = "app";
-          program = lib.getExe self'.packages.default;
-        };
+        cosmic-comp = craneLib.buildPackage (craneArgs // {inherit cargoArtifacts;});
 
-        checks.cosmic-comp = cosmic-comp;
-        packages.default = cosmic-comp;
+        default = self.packages.${system}.cosmic-comp;
+      })
+      pkgsFor;
 
-        devShells.default = craneLib.devShell {
-          LD_LIBRARY_PATH = lib.makeLibraryPath (
-            __concatMap (d: d.runtimeDependencies) (__attrValues self'.checks)
-          );
-
-          # include build inputs
-          inputsFrom = [cosmic-comp];
-        };
+    apps = eachSystem (system: {
+      cosmic-comp = {
+        type = "app";
+        program = lib.getExe self.packages.${system}.default;
       };
-    };
+
+      default = self.apps.${system}.cosmic-comp;
+    });
+
+    checks = eachSystem (system: {
+      inherit (self.packages.${system}) cosmic-comp;
+    });
+
+    devShells =
+      lib.mapAttrs (
+        system: pkgs: let
+          craneLib = crane.mkLib pkgs;
+        in {
+          default = craneLib.devShell {
+            LD_LIBRARY_PATH = lib.makeLibraryPath (
+              builtins.concatMap (d: d.runtimeDependencies) (builtins.attrValues self.checks.${system})
+            );
+
+            # include build inputs
+            inputsFrom = [self.packages.${system}.cosmic-comp];
+          };
+        }
+      )
+      pkgsFor;
+  };
 }


### PR DESCRIPTION
This PR:
- cleans up the flake 
- removes unneeded inputs and replaces them with a few lines of simle nix code
- adds a nix-systems input, which allows for local overriding of the systems which cosmic-comp supports.