### PR TITLE
Add `Tor Browser` as floating window exception

### DIFF
--- a/data/tiling-exceptions.ron
+++ b/data/tiling-exceptions.ron
@@ -45,6 +45,7 @@
 	(appid: "system76-driver", titles: [".*"]),
 	(appid: "tilda", titles: [".*"]),
 	(appid: "zoom", titles: [".*"]),
+	(appid: "Tor Browser", titles: [".*"]),
 	(appid: "^.*?action=join.*$", titles: [".*"]),
 
 ]


### PR DESCRIPTION
The Tor Browser launches with a specific dimension to avoid browser fingerprinting[0]. Do not tile the Tor Browser for this reason.

[0]: https://tb-manual.torproject.org/anti-fingerprinting/#letterboxing