### PR TITLE
Use `DropableFrame` in kms frame udata to make sure `failed` is sent

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -5,7 +5,7 @@ use crate::{
     config::{AdaptiveSync, EdidProduct, OutputConfig, OutputState, ScreenFilter},
     shell::Shell,
     utils::prelude::*,
-    wayland::protocols::screencopy::Frame as ScreencopyFrame,
+    wayland::handlers::screencopy::DropableFrame,
 };
 
 use anyhow::{Context, Result};
@@ -65,7 +65,7 @@ pub type GbmDrmOutputManager = DrmOutputManager<
     GbmFramebufferExporter<DrmDeviceFd>,
     Option<(
         OutputPresentationFeedback,
-        Receiver<(ScreencopyFrame, Vec<Rectangle<i32, BufferCoords>>)>,
+        Receiver<(DropableFrame, Vec<Rectangle<i32, BufferCoords>>)>,
         Duration,
     )>,
     DrmDeviceFd,

--- a/src/wayland/handlers/screencopy/mod.rs
+++ b/src/wayland/handlers/screencopy/mod.rs
@@ -37,7 +37,9 @@ mod render;
 mod user_data;
 pub use self::render::*;
 use self::user_data::*;
-pub use self::user_data::{FrameHolder, ScreencopySessions, SessionData, SessionHolder};
+pub use self::user_data::{
+    DropableFrame, FrameHolder, ScreencopySessions, SessionData, SessionHolder,
+};
 
 impl ScreencopyHandler for State {
     fn screencopy_state(&mut self) -> &mut ScreencopyState {

--- a/src/wayland/handlers/screencopy/user_data.rs
+++ b/src/wayland/handlers/screencopy/user_data.rs
@@ -334,7 +334,7 @@ impl Drop for DropableCursorSession {
 }
 
 #[derive(Debug)]
-pub struct DropableFrame(Option<Frame>);
+pub struct DropableFrame(pub Option<Frame>);
 impl Deref for DropableFrame {
     type Target = Frame;
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
This seems to fix https://github.com/pop-os/cosmic-comp/issues/1305. xdg-desktop-portal-cosmic prints an error, buy retries (as it should for an `Unknown` error; though maybe there should be a retry limit) and the session continues working.

Not sure if it should be sending `failed`, or queing it with the next frame so it can send `success` to the client, but this works and is desirable as a failsafe anyway.