### PR TITLE
protocols/screencopy: Make frame/session send stopped/fail on drop

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -5,7 +5,7 @@ use crate::{
     config::{AdaptiveSync, EdidProduct, OutputConfig, OutputState, ScreenFilter},
     shell::Shell,
     utils::prelude::*,
-    wayland::protocols::screencopy::Frame as ScreencopyFrame,
+    wayland::protocols::screencopy::Frame,
 };
 
 use anyhow::{Context, Result};
@@ -65,7 +65,7 @@ pub type GbmDrmOutputManager = DrmOutputManager<
     GbmFramebufferExporter<DrmDeviceFd>,
     Option<(
         OutputPresentationFeedback,
-        Receiver<(ScreencopyFrame, Vec<Rectangle<i32, BufferCoords>>)>,
+        Receiver<(Frame, Vec<Rectangle<i32, BufferCoords>>)>,
         Duration,
     )>,
     DrmDeviceFd,

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     wayland::{
         handlers::screencopy::{submit_buffer, FrameHolder, SessionData},
         protocols::screencopy::{
-            FailureReason, Frame as ScreencopyFrame, Session as ScreencopySession,
+            FailureReason, Frame as ScreencopyFrame, SessionRef as ScreencopySessionRef,
         },
     },
 };
@@ -1024,7 +1024,7 @@ impl SurfaceThreadState {
         // so let's collect everything we need for screencopy now
         let mut has_cursor_mode_none = false;
         let frames: Vec<(
-            ScreencopySession,
+            ScreencopySessionRef,
             ScreencopyFrame,
             Result<(Option<Vec<Rectangle<i32, Physical>>>, RenderElementStates), OutputNoMode>,
         )> = self

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     utils::{float::NextDown, prelude::*, quirks::workspace_overview_is_open},
     wayland::{
         handlers::screencopy::SessionHolder,
-        protocols::screencopy::{BufferConstraints, CursorSession},
+        protocols::screencopy::{BufferConstraints, CursorSessionRef},
     },
 };
 use calloop::{
@@ -2262,7 +2262,7 @@ impl State {
 fn cursor_sessions_for_output<'a>(
     shell: &'a Shell,
     output: &'a Output,
-) -> impl Iterator<Item = CursorSession> + 'a {
+) -> impl Iterator<Item = CursorSessionRef> + 'a {
     shell
         .active_space(&output)
         .into_iter()


### PR DESCRIPTION
This seems to fix https://github.com/pop-os/cosmic-comp/issues/1305. xdg-desktop-portal-cosmic prints an error, buy retries (as it should for an `Unknown` error; though maybe there should be a retry limit) and the session continues working.

Not sure if it should be sending `failed`, or queuing it with the next frame so it can send `success` to the client, but this works and is desirable as a failsafe anyway.