### PR TITLE
screencopy: Don't advertise implicit modifiers for dmabuf capture

### DIFF
--- a/src/wayland/handlers/screencopy/mod.rs
+++ b/src/wayland/handlers/screencopy/mod.rs
@@ -418,7 +418,9 @@ fn constraints_for_renderer(
                 .fold(
                     HashMap::<Fourcc, Vec<Modifier>>::new(),
                     |mut map, format| {
-                        map.entry(format.code).or_default().push(format.modifier);
+                        if format.modifier != Modifier::Invalid {
+                            map.entry(format.code).or_default().push(format.modifier);
+                        }
                         map
                     },
                 )


### PR DESCRIPTION
Too many clients just try to negotiate any shared modifier and import any dmabuf into whatever gpu they might using. Worse pipewire has no way of communicating a dmabuf node.

Given that cosmic-comp might advertise different nodes for different capture sources on the same system, we shouldn't advertise implicit modifiers as supported as cross-gpu might happen.