### PR TITLE
Do not focus layer surfaces with KeyboardInteractivity::None

### DIFF
--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -115,6 +115,13 @@ impl Shell {
                 .unwrap()
                 .element_for_surface(window)
                 .cloned(),
+            Some(KeyboardFocusTarget::LayerSurface(layer)) => {
+                // Do not focus layer surfaces with KeyboardInteractivity::None
+                if !layer.can_receive_keyboard_focus() {
+                    return;
+                }
+                None
+            }
             _ => None,
         };
 


### PR DESCRIPTION
This will allow for an on-screen keyboard to provide input to other applications.

Draft until I have tested it.