### PR TITLE
Don't change focus on click of layer with `KeyboardInteractivity::None`

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2032,19 +2032,21 @@ impl State {
                         }
                     }
                     Stage::LayerSurface { layer, location } => {
-                        if layer.can_receive_keyboard_focus() {
-                            if under_from_surface_tree(
-                                layer.wl_surface(),
-                                global_pos.as_logical(),
-                                location.as_logical(),
-                                WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
-                            )
-                            .is_some()
-                            {
-                                return ControlFlow::Break(Ok(Some(
-                                    KeyboardFocusTarget::LayerSurface(layer),
-                                )));
-                            }
+                        if under_from_surface_tree(
+                            layer.wl_surface(),
+                            global_pos.as_logical(),
+                            location.as_logical(),
+                            WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
+                        )
+                        .is_some()
+                        {
+                            return ControlFlow::Break(Ok(if layer.can_receive_keyboard_focus() {
+                                Some(KeyboardFocusTarget::LayerSurface(layer))
+                            } else {
+                                // Don't change keyboard focus if in input region of layer shell
+                                // surface, but surface doesn't have keyboard interactivity.
+                                None
+                            }));
                         }
                     }
                     Stage::OverrideRedirect { .. } => {


### PR DESCRIPTION
Previously, a click on a client like squeekboard would give keyboard focus to the window behind it, if any.

If we are in the input region of the layer surface, we shouldn't give keyboard focus to the surface behind it on click. And should just leave the focus unchanged. Returning `None` here seems to be correct.