### PR TITLE
DRM debugging / profling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "log-panics",
  "once_cell",
  "ordered-float",
+ "parking_lot 0.12.3",
  "png",
  "profiling",
  "rand 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,9 +1056,9 @@ checksum = "1f791803201ab277ace03903de1594460708d2d54df6053f2d9e82f592b19e3b"
 
 [[package]]
 name = "cursor-icon"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "d3d12"
@@ -4729,7 +4729,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 [[package]]
 name = "smithay"
 version = "0.6.0"
-source = "git+https://github.com/smithay/smithay//?rev=c1f13a6#c1f13a6b9605c9f7009122a7b2b34f210255dac3"
+source = "git+https://github.com/smithay/smithay.git?rev=7ad90b5#7ad90b55df53bf9066211d1e64f276e88c41eb00"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -4758,8 +4758,9 @@ dependencies = [
  "pkg-config",
  "profiling",
  "rand 0.9.1",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "scopeguard",
+ "sha2",
  "smallvec",
  "tempfile",
  "thiserror 2.0.12",
@@ -4819,7 +4820,8 @@ dependencies = [
 [[package]]
 name = "smithay-egui"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay-egui.git?rev=e720136#e7201366b88e4fb20d0c6618a6cac9acc6299e07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f69e928bd02c12d7b66ba74fc68b984d77181be4309dd969ed4ef141c150241"
 dependencies = [
  "cgmath",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ branch = "feature/copy_clone"
 git = "https://github.com/Drakulix/id-tree.git"
 
 [dependencies.smithay]
+version = "0.6.0"
 default-features = false
 features = [
   "backend_drm",
@@ -89,14 +90,11 @@ features = [
   "wayland_frontend",
   "xwayland",
 ]
-git = "https://github.com/smithay/smithay"
-rev = "a503d98"
 
 [dependencies.smithay-egui]
+version = "0.1.0"
 features = ["svg"]
-git = "https://github.com/Smithay/smithay-egui.git"
 optional = true
-rev = "e720136"
 
 [features]
 debug = ["egui", "egui_plot", "smithay-egui", "anyhow/backtrace"]
@@ -124,5 +122,5 @@ lto = "fat"
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
-[patch."https://github.com/smithay/smithay"]
-smithay = { git = "https://github.com/smithay/smithay//", rev = "c1f13a6" }
+[patch.crates-io]
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "7ad90b5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ rand = "0.9.0"
 reis = { version = "0.5", features = ["calloop"] }
 # CLI arguments
 clap_lex = "0.7"
+parking_lot = "0.12.3"
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -307,7 +307,7 @@ impl State {
 
         let connectors = device.enumerate_surfaces()?.added; // There are no removed outputs on newly added devices
         let mut wl_outputs = Vec::new();
-        let mut w = self.common.shell.read().unwrap().global_space().size.w as u32;
+        let mut w = self.common.shell.read().global_space().size.w as u32;
 
         {
             for (conn, maybe_crtc) in connectors {
@@ -380,7 +380,7 @@ impl State {
             if let Some(device) = backend.drm_devices.get_mut(&drm_node) {
                 let changes = device.enumerate_surfaces()?;
 
-                let mut w = self.common.shell.read().unwrap().global_space().size.w as u32;
+                let mut w = self.common.shell.read().global_space().size.w as u32;
                 for conn in changes.removed {
                     // contains conns with updated crtcs, just drop the surface and re-create
                     if let Some(pos) = device
@@ -577,7 +577,7 @@ impl Device {
         position: (u32, u32),
         evlh: &LoopHandle<'static, State>,
         screen_filter: ScreenFilter,
-        shell: Arc<RwLock<Shell>>,
+        shell: Arc<parking_lot::RwLock<Shell>>,
         startup_done: Arc<AtomicBool>,
     ) -> Result<(Output, bool)> {
         let output = self
@@ -676,7 +676,7 @@ impl Device {
         flags: FrameFlags,
         renderer: &mut GlMultiRenderer,
         clock: &Clock<Monotonic>,
-        shell: &Arc<RwLock<Shell>>,
+        shell: &Arc<parking_lot::RwLock<Shell>>,
     ) -> Result<()> {
         for surface in self.surfaces.values_mut() {
             surface.allow_frame_flags(flag, flags);
@@ -733,7 +733,7 @@ impl Device {
         flag: bool,
         renderer: &mut GlMultiRenderer,
         clock: &Clock<Monotonic>,
-        shell: &Arc<RwLock<Shell>>,
+        shell: &Arc<parking_lot::RwLock<Shell>>,
     ) -> Result<()> {
         self.allow_frame_flags(
             flag,
@@ -749,7 +749,7 @@ impl Device {
         flag: bool,
         renderer: &mut GlMultiRenderer,
         clock: &Clock<Monotonic>,
-        shell: &Arc<RwLock<Shell>>,
+        shell: &Arc<parking_lot::RwLock<Shell>>,
     ) -> Result<()> {
         self.allow_frame_flags(
             flag,

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -169,7 +169,7 @@ fn init_libinput(
 
         state.process_input_event(event);
 
-        for output in state.common.shell.read().unwrap().outputs() {
+        for output in state.common.shell.read().outputs() {
             state.backend.kms().schedule_render(output);
         }
     })
@@ -592,7 +592,7 @@ impl KmsState {
         test_only: bool,
         loop_handle: &LoopHandle<'static, State>,
         screen_filter: &ScreenFilter,
-        shell: Arc<RwLock<Shell>>,
+        shell: Arc<parking_lot::RwLock<Shell>>,
         startup_done: Arc<AtomicBool>,
         clock: &Clock<Monotonic>,
     ) -> Result<Vec<Output>, anyhow::Error> {
@@ -683,7 +683,7 @@ impl KmsState {
             }
 
             // add new ones
-            let mut w = shell.read().unwrap().global_space().size.w as u32;
+            let mut w = shell.read().global_space().size.w as u32;
             if !test_only {
                 for (conn, crtc) in new_pairings {
                     let (output, _) = device.connector_added(

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -847,9 +847,8 @@ impl SurfaceThreadState {
             self.vblank_frame = Some(vblank_frame);
 
             self.queue_redraw(false);
-        } else {
-            self.send_frame_callbacks();
         }
+        self.send_frame_callbacks();
     }
 
     #[profiling::function]
@@ -870,9 +869,8 @@ impl SurfaceThreadState {
 
         if force || self.shell.read().animations_going() {
             self.queue_redraw(false);
-        } else {
-            self.send_frame_callbacks();
         }
+        self.send_frame_callbacks();
     }
 
     fn queue_redraw(&mut self, force: bool) {

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -725,6 +725,7 @@ impl SurfaceThreadState {
         //self.software_api.as_mut().remove_node(node);
     }
 
+    #[profiling::function]
     fn on_vblank(&mut self, metadata: Option<DrmEventMetadata>) {
         let Some(compositor) = self.compositor.as_mut() else {
             return;
@@ -851,6 +852,7 @@ impl SurfaceThreadState {
         }
     }
 
+    #[profiling::function]
     fn on_estimated_vblank(&mut self, force: bool) {
         match mem::replace(&mut self.state, QueueState::Idle) {
             QueueState::Idle => unreachable!(),
@@ -949,6 +951,7 @@ impl SurfaceThreadState {
         }
     }
 
+    #[profiling::function]
     fn redraw(&mut self, estimated_presentation: Duration) -> Result<()> {
         let Some(compositor) = self.compositor.as_mut() else {
             return Ok(());
@@ -1826,6 +1829,7 @@ fn source_node_for_surface(w: &WlSurface) -> Option<DrmNode> {
 
 // TODO: Introduce can_shared_dmabuf_framebuffer for cases where we might select another gpu
 //  and composite on target if not possible to finally get rid of "primary"
+#[profiling::function]
 fn render_node_for_output(
     output: &Output,
     primary_node: &DrmNode,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -47,7 +47,6 @@ pub fn init_backend_auto(
             .common
             .shell
             .read()
-            .unwrap()
             .outputs()
             .next()
             .with_context(|| "Backend initialized without output")
@@ -68,7 +67,6 @@ pub fn init_backend_auto(
             .common
             .shell
             .write()
-            .unwrap()
             .seats
             .add_seat(initial_seat.clone());
 
@@ -79,7 +77,7 @@ pub fn init_backend_auto(
             .accessibility_zoom
             .start_on_login
         {
-            state.common.shell.write().unwrap().trigger_zoom(
+            state.common.shell.write().trigger_zoom(
                 &initial_seat,
                 None,
                 1.0 + (state.common.config.cosmic_conf.accessibility_zoom.increment as f64 / 100.),
@@ -117,7 +115,7 @@ pub fn init_backend_auto(
                     .common
                     .startup_done
                     .store(true, std::sync::atomic::Ordering::SeqCst);
-                for output in state.common.shell.read().unwrap().outputs() {
+                for output in state.common.shell.read().outputs() {
                     state.backend.schedule_render(&output);
                 }
             }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -76,7 +76,6 @@ impl WinitState {
                     let mut output_presentation_feedback = state
                         .shell
                         .read()
-                        .unwrap()
                         .take_presentation_feedback(&self.output, &states);
                     output_presentation_feedback.presented(
                         state.clock.now(),
@@ -297,7 +296,7 @@ impl State {
         // here we can handle special cases for winit inputs
         match event {
             WinitEvent::Focus(true) => {
-                for seat in self.common.shell.read().unwrap().seats.iter() {
+                for seat in self.common.shell.read().seats.iter() {
                     let devices = seat.user_data().get::<Devices>().unwrap();
                     if devices.has_device(&WinitVirtualDevice) {
                         seat.set_active_output(&self.backend.winit().output);

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -240,7 +240,6 @@ impl Surface {
                     let mut output_presentation_feedback = state
                         .shell
                         .read()
-                        .unwrap()
                         .take_presentation_feedback(&self.output, &states);
                     output_presentation_feedback.presented(
                         state.clock.now(),
@@ -520,7 +519,7 @@ impl State {
                         .unwrap();
 
                     let device = event.device();
-                    for seat in self.common.shell.read().unwrap().seats.iter() {
+                    for seat in self.common.shell.read().seats.iter() {
                         let devices = seat.user_data().get::<Devices>().unwrap();
                         if devices.has_device(&device) {
                             seat.set_active_output(&output);
@@ -534,7 +533,7 @@ impl State {
 
         self.process_input_event(event);
         // TODO actually figure out the output
-        for output in self.common.shell.read().unwrap().outputs() {
+        for output in self.common.shell.read().outputs() {
             self.backend.x11().schedule_render(output);
         }
     }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -122,6 +122,7 @@ impl State {
         }
     }
 
+    #[profiling::function]
     pub fn handle_shortcut_action(
         &mut self,
         action: shortcuts::Action,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -170,7 +170,7 @@ impl State {
         use smithay::backend::input::Event;
         match event {
             InputEvent::DeviceAdded { device } => {
-                let shell = self.common.shell.read().unwrap();
+                let shell = self.common.shell.read();
                 let seat = shell.seats.last_active();
                 let led_state = seat.get_keyboard().unwrap().led_state();
                 seat.devices().add_device(&device, led_state);
@@ -182,7 +182,7 @@ impl State {
                 }
             }
             InputEvent::DeviceRemoved { device } => {
-                for seat in &mut self.common.shell.read().unwrap().seats.iter() {
+                for seat in &mut self.common.shell.read().seats.iter() {
                     let devices = seat.devices();
                     if devices.has_device(&device) {
                         devices.remove_device(&device);
@@ -205,7 +205,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -305,7 +304,7 @@ impl State {
             InputEvent::PointerMotion { event, .. } => {
                 use smithay::backend::input::PointerMotionEvent;
 
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 if let Some(seat) = shell.seats.for_device(&event.device()).cloned() {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     let current_output = seat.active_output();
@@ -389,7 +388,7 @@ impl State {
                         }
                         //If the pointer isn't grabbed, we should check if the focused element should be updated
                     } else if self.common.config.cosmic_conf.focus_follows_cursor {
-                        let shell = self.common.shell.read().unwrap();
+                        let shell = self.common.shell.read();
                         let old_keyboard_target =
                             State::element_under(original_position, &current_output, &*shell);
                         let new_keyboard_target = State::element_under(position, &output, &*shell);
@@ -558,7 +557,7 @@ impl State {
                         });
                     }
 
-                    let mut shell = self.common.shell.write().unwrap();
+                    let mut shell = self.common.shell.write();
                     shell.update_pointer_position(position.to_local(&output), &output);
                     shell.update_focal_point(
                         &seat,
@@ -604,7 +603,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -619,12 +617,9 @@ impl State {
                         )
                         .as_global();
                     let serial = SERIAL_COUNTER.next_serial();
-                    let under = State::surface_under(
-                        position,
-                        &output,
-                        &mut *self.common.shell.write().unwrap(),
-                    )
-                    .map(|(target, pos)| (target, pos.as_logical()));
+                    let under =
+                        State::surface_under(position, &output, &mut *self.common.shell.write())
+                            .map(|(target, pos)| (target, pos.as_logical()));
 
                     let ptr = seat.get_pointer().unwrap();
                     ptr.motion(
@@ -638,7 +633,7 @@ impl State {
                     );
                     ptr.frame(self);
 
-                    let shell = self.common.shell.read().unwrap();
+                    let shell = self.common.shell.read();
                     for session in cursor_sessions_for_output(&*shell, &output) {
                         if let Some((geometry, offset)) = seat.cursor_geometry(
                             position.as_logical().to_buffer(
@@ -673,7 +668,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned()
@@ -707,7 +701,7 @@ impl State {
                         let global_position =
                             seat.get_pointer().unwrap().current_location().as_global();
                         let under = {
-                            let shell = self.common.shell.read().unwrap();
+                            let shell = self.common.shell.read();
                             State::element_under(global_position, &output, &shell)
                         };
                         if let Some(target) = under {
@@ -747,8 +741,7 @@ impl State {
                                                 supress_button();
                                                 self.common.event_loop_handle.insert_idle(
                                                     move |state| {
-                                                        let mut shell =
-                                                            state.common.shell.write().unwrap();
+                                                        let mut shell = state.common.shell.write();
                                                         let res = shell.move_request(
                                                             &surface,
                                                             &seat_clone,
@@ -770,8 +763,7 @@ impl State {
                                                 supress_button();
                                                 self.common.event_loop_handle.insert_idle(
                                                     move |state| {
-                                                        let mut shell =
-                                                            state.common.shell.write().unwrap();
+                                                        let mut shell = state.common.shell.write();
                                                         let Some(target_elem) =
                                                             shell.element_for_surface(&surface)
                                                         else {
@@ -831,7 +823,7 @@ impl State {
                         }
                     }
                 } else {
-                    let mut shell = self.common.shell.write().unwrap();
+                    let mut shell = self.common.shell.write();
                     if let Some(Trigger::Pointer(action_button)) =
                         shell.overview_mode().0.active_trigger()
                     {
@@ -882,7 +874,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -953,7 +944,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -980,7 +970,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1053,7 +1042,7 @@ impl State {
 
                         match gesture_state.action {
                             Some(SwipeAction::NextWorkspace) | Some(SwipeAction::PrevWorkspace) => {
-                                self.common.shell.write().unwrap().update_workspace_delta(
+                                self.common.shell.write().update_workspace_delta(
                                     &seat.active_output(),
                                     gesture_state.delta,
                                 )
@@ -1081,7 +1070,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1099,7 +1087,7 @@ impl State {
                                     } else {
                                         velocity / seat.active_output().geometry().size.h as f64
                                     };
-                                let _ = self.common.shell.write().unwrap().end_workspace_swipe(
+                                let _ = self.common.shell.write().end_workspace_swipe(
                                     &seat.active_output(),
                                     norm_velocity,
                                     &mut self.common.workspace_state.update(),
@@ -1127,7 +1115,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1150,7 +1137,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1173,7 +1159,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1196,7 +1181,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1219,7 +1203,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1239,7 +1222,7 @@ impl State {
             }
 
             InputEvent::TouchDown { event, .. } => {
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 if let Some(seat) = shell.seats.for_device(&event.device()).cloned() {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     let Some(output) =
@@ -1271,7 +1254,7 @@ impl State {
                 }
             }
             InputEvent::TouchMotion { event, .. } => {
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 if let Some(seat) = shell.seats.for_device(&event.device()).cloned() {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     let Some(output) =
@@ -1301,7 +1284,7 @@ impl State {
                 }
             }
             InputEvent::TouchUp { event, .. } => {
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 if let Some(Trigger::Touch(slot)) = shell.overview_mode().0.active_trigger() {
                     if *slot == event.slot() {
                         shell.set_overview_mode(None, self.common.event_loop_handle.clone());
@@ -1329,7 +1312,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1344,7 +1326,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1356,7 +1337,7 @@ impl State {
             }
 
             InputEvent::TabletToolAxis { event, .. } => {
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 if let Some(seat) = shell.seats.for_device(&event.device()).cloned() {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     let Some(output) =
@@ -1421,7 +1402,7 @@ impl State {
                 }
             }
             InputEvent::TabletToolProximity { event, .. } => {
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 if let Some(seat) = shell.seats.for_device(&event.device()).cloned() {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     let Some(output) =
@@ -1480,7 +1461,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1503,7 +1483,6 @@ impl State {
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .seats
                     .for_device(&event.device())
                     .cloned();
@@ -1533,7 +1512,7 @@ impl State {
         handle: KeysymHandle<'_>,
         serial: Serial,
     ) -> FilterResult<Option<(Action, shortcuts::Binding)>> {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
 
         let keyboard = seat.get_keyboard().unwrap();
         let pointer = seat.get_pointer().unwrap();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -161,6 +161,7 @@ impl ModifiersShortcutQueue {
 }
 
 impl State {
+    #[profiling::function]
     pub fn process_input_event<B: InputBackend>(&mut self, event: InputEvent<B>)
     where
         <B as InputBackend>::Device: 'static,
@@ -1504,6 +1505,7 @@ impl State {
     }
 
     /// Determine is key event should be intercepted as a key binding, or forwarded to surface
+    #[profiling::function]
     pub fn filter_keyboard_input<B: InputBackend, E: KeyboardKeyEvent<B>>(
         &mut self,
         event: &E,
@@ -1958,6 +1960,7 @@ impl State {
         }
     }
 
+    #[profiling::function]
     pub fn element_under(
         global_pos: Point<f64, Global>,
         output: &Output,
@@ -2084,6 +2087,7 @@ impl State {
         .flatten()
     }
 
+    #[profiling::function]
     pub fn surface_under(
         global_pos: Point<f64, Global>,
         output: &Output,

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         // trigger routines
-        let clients = state.common.shell.write().unwrap().update_animations();
+        let clients = state.common.shell.write().update_animations();
         {
             let dh = state.common.display_handle.clone();
             for client in clients.values() {
@@ -173,7 +173,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         refresh(state);
 
         {
-            let shell = state.common.shell.read().unwrap();
+            let shell = state.common.shell.read();
             if shell.animations_going() {
                 for output in shell.outputs().cloned().collect::<Vec<_>>().into_iter() {
                     state.backend.schedule_render(&output);

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -695,7 +695,7 @@ impl CosmicStack {
                 surface.send_configure();
                 if let Some(surface) = surface.wl_surface().map(Cow::into_owned) {
                     let _ = data.common.event_loop_handle.insert_idle(move |state| {
-                        let res = state.common.shell.write().unwrap().move_request(
+                        let res = state.common.shell.write().move_request(
                             &surface,
                             &seat,
                             serial,
@@ -837,7 +837,7 @@ impl Program for CosmicStackInternal {
                         .map(Cow::into_owned)
                     {
                         loop_handle.insert_idle(move |state| {
-                            let res = state.common.shell.write().unwrap().move_request(
+                            let res = state.common.shell.write().move_request(
                                 &surface,
                                 &seat,
                                 serial,
@@ -867,12 +867,8 @@ impl Program for CosmicStackInternal {
                 *self.potential_drag.lock().unwrap() = None;
                 if let Some(surface) = self.windows.lock().unwrap().get(idx).cloned() {
                     loop_handle.insert_idle(move |state| {
-                        if let Some(mapped) = state
-                            .common
-                            .shell
-                            .read()
-                            .unwrap()
-                            .element_for_surface(&surface)
+                        if let Some(mapped) =
+                            state.common.shell.read().element_for_surface(&surface)
                         {
                             mapped.stack_ref().unwrap().set_active(&surface);
                         }
@@ -896,7 +892,7 @@ impl Program for CosmicStackInternal {
                         .map(Cow::into_owned)
                     {
                         loop_handle.insert_idle(move |state| {
-                            let shell = state.common.shell.read().unwrap();
+                            let shell = state.common.shell.read();
                             if let Some(mapped) = shell.element_for_surface(&surface).cloned() {
                                 let position = if let Some((output, set)) =
                                     shell.workspaces.sets.iter().find(|(_, set)| {
@@ -950,7 +946,7 @@ impl Program for CosmicStackInternal {
                         .map(Cow::into_owned)
                     {
                         loop_handle.insert_idle(move |state| {
-                            let shell = state.common.shell.read().unwrap();
+                            let shell = state.common.shell.read();
                             if let Some(mapped) = shell.element_for_surface(&surface).cloned() {
                                 if let Some(workspace) = shell.space_for(&mapped) {
                                     let Some(elem_geo) = workspace.element_geometry(&mapped) else {
@@ -1407,7 +1403,7 @@ impl PointerTarget<State> for CosmicStack {
                     return;
                 };
                 self.0.loop_handle().insert_idle(move |state| {
-                    let res = state.common.shell.write().unwrap().resize_request(
+                    let res = state.common.shell.write().resize_request(
                         &surface,
                         &seat,
                         serial,
@@ -1481,7 +1477,7 @@ impl PointerTarget<State> for CosmicStack {
                 surface.send_configure();
                 if let Some(surface) = surface.wl_surface().map(Cow::into_owned) {
                     let _ = data.common.event_loop_handle.insert_idle(move |state| {
-                        let res = state.common.shell.write().unwrap().move_request(
+                        let res = state.common.shell.write().move_request(
                             &surface,
                             &seat,
                             serial,

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -441,7 +441,7 @@ impl Program for CosmicWindowInternal {
                 if let Some((seat, serial)) = last_seat.cloned() {
                     if let Some(surface) = self.window.wl_surface().map(Cow::into_owned) {
                         loop_handle.insert_idle(move |state| {
-                            let res = state.common.shell.write().unwrap().move_request(
+                            let res = state.common.shell.write().move_request(
                                 &surface,
                                 &seat,
                                 serial,
@@ -467,7 +467,7 @@ impl Program for CosmicWindowInternal {
             Message::Minimize => {
                 if let Some(surface) = self.window.wl_surface().map(Cow::into_owned) {
                     loop_handle.insert_idle(move |state| {
-                        let mut shell = state.common.shell.write().unwrap();
+                        let mut shell = state.common.shell.write();
                         if let Some(mapped) = shell.element_for_surface(&surface).cloned() {
                             shell.minimize_request(&mapped)
                         }
@@ -477,7 +477,7 @@ impl Program for CosmicWindowInternal {
             Message::Maximize => {
                 if let Some(surface) = self.window.wl_surface().map(Cow::into_owned) {
                     loop_handle.insert_idle(move |state| {
-                        let mut shell = state.common.shell.write().unwrap();
+                        let mut shell = state.common.shell.write();
                         if let Some(mapped) = shell.element_for_surface(&surface).cloned() {
                             let seat = shell.seats.last_active().clone();
                             shell.maximize_toggle(&mapped, &seat)
@@ -490,7 +490,7 @@ impl Program for CosmicWindowInternal {
                 if let Some((seat, serial)) = last_seat.cloned() {
                     if let Some(surface) = self.window.wl_surface().map(Cow::into_owned) {
                         loop_handle.insert_idle(move |state| {
-                            let shell = state.common.shell.read().unwrap();
+                            let shell = state.common.shell.read();
                             if let Some(mapped) = shell.element_for_surface(&surface).cloned() {
                                 let position = if let Some((output, set)) =
                                     shell.workspaces.sets.iter().find(|(_, set)| {
@@ -763,7 +763,7 @@ impl PointerTarget<State> for CosmicWindow {
                     return;
                 };
                 self.0.loop_handle().insert_idle(move |state| {
-                    let res = state.common.shell.write().unwrap().resize_request(
+                    let res = state.common.shell.write().resize_request(
                         &surface,
                         &seat,
                         serial,

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -112,7 +112,6 @@ impl Shell {
                 .common
                 .shell
                 .read()
-                .unwrap()
                 .element_for_surface(window)
                 .cloned(),
             _ => None,
@@ -123,17 +122,12 @@ impl Shell {
                 return;
             }
 
-            state
-                .common
-                .shell
-                .write()
-                .unwrap()
-                .append_focus_stack(&mapped, seat);
+            state.common.shell.write().append_focus_stack(&mapped, seat);
         }
 
         update_focus_state(seat, target, state, serial, update_cursor);
 
-        state.common.shell.write().unwrap().update_active();
+        state.common.shell.write().update_active();
     }
 
     pub fn append_focus_stack(&mut self, mapped: &CosmicMapped, seat: &Seat<State>) {
@@ -242,7 +236,7 @@ fn update_focus_state(
         if should_update_cursor && state.common.config.cosmic_conf.cursor_follows_focus {
             if target.is_some() {
                 //need to borrow mutably for surface under
-                let shell = state.common.shell.read().unwrap();
+                let shell = state.common.shell.read();
                 // get the top left corner of the target element
                 let geometry = shell.focused_geometry(target.unwrap());
                 if let Some(geometry) = geometry {
@@ -292,7 +286,6 @@ fn update_focus_state(
                     .common
                     .shell
                     .read()
-                    .unwrap()
                     .get_output_for_focus(seat)
                     .as_ref(),
             )
@@ -339,14 +332,13 @@ impl Common {
             .common
             .shell
             .read()
-            .unwrap()
             .seats
             .iter()
             .cloned()
             .collect::<Vec<_>>();
         for seat in &seats {
             {
-                let shell = state.common.shell.read().unwrap();
+                let shell = state.common.shell.read();
                 let focused_output = seat.focused_output();
                 let active_output = seat.active_output();
 
@@ -365,7 +357,7 @@ impl Common {
             update_pointer_focus(state, &seat);
 
             let output = seat.focused_or_active_output();
-            let mut shell = state.common.shell.write().unwrap();
+            let mut shell = state.common.shell.write();
             let last_known_focus = ActiveFocus::get(&seat);
 
             if let Some(target) = last_known_focus {
@@ -454,7 +446,7 @@ impl Common {
             }
         }
 
-        state.common.shell.write().unwrap().update_active()
+        state.common.shell.write().update_active()
     }
 }
 
@@ -582,7 +574,7 @@ fn update_pointer_focus(state: &mut State, seat: &Seat<State>) {
         let output = seat.active_output();
         let position = pointer.current_location().as_global();
 
-        let mut shell = state.common.shell.write().unwrap();
+        let mut shell = state.common.shell.write();
         let under = State::surface_under(position, &output, &mut shell)
             .map(|(target, pos)| (target, pos.as_logical()));
         drop(shell);

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -99,6 +99,7 @@ impl Shell {
     /// Set the keyboard focus to the given target
     /// Note: `update_cursor` is used to determine whether to update the pointer location if cursor_follows_focus is enabled
     /// if the focus change was due to a pointer event, this should be set to false
+    #[profiling::function]
     pub fn set_focus(
         state: &mut State,
         target: Option<&KeyboardFocusTarget>,
@@ -224,6 +225,7 @@ impl Shell {
 }
 
 /// Internal, used to ensure that ActiveFocus, KeyboardFocusTarget, and FocusedOutput are all in sync
+#[profiling::function]
 fn update_focus_state(
     seat: &Seat<State>,
     target: Option<&KeyboardFocusTarget>,
@@ -327,6 +329,7 @@ fn raise_with_children(floating_layer: &mut FloatingLayout, focused: &CosmicMapp
 }
 
 impl Common {
+    #[profiling::function]
     pub fn refresh_focus(state: &mut State) {
         let seats = state
             .common

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -240,7 +240,7 @@ impl IsAlive for KeyboardFocusTarget {
 
 impl PointerTarget<State> for PointerFocusTarget {
     fn enter(&self, seat: &Seat<State>, data: &mut State, event: &PointerMotionEvent) {
-        let toplevel = self.toplevel(&*data.common.shell.read().unwrap());
+        let toplevel = self.toplevel(&*data.common.shell.read());
         if let Some(element) = toplevel {
             for session in element.cursor_sessions() {
                 session.set_cursor_pos(Some(
@@ -270,7 +270,7 @@ impl PointerTarget<State> for PointerFocusTarget {
         }
     }
     fn motion(&self, seat: &Seat<State>, data: &mut State, event: &PointerMotionEvent) {
-        let toplevel = self.toplevel(&*data.common.shell.read().unwrap());
+        let toplevel = self.toplevel(&*data.common.shell.read());
         if let Some(element) = toplevel {
             for session in element.cursor_sessions() {
                 session.set_cursor_pos(Some(
@@ -346,7 +346,7 @@ impl PointerTarget<State> for PointerFocusTarget {
         }
     }
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial, time: u32) {
-        let toplevel = self.toplevel(&*data.common.shell.read().unwrap());
+        let toplevel = self.toplevel(&*data.common.shell.read());
         if let Some(element) = toplevel {
             for session in element.cursor_sessions() {
                 session.set_cursor_pos(None);

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -16,7 +16,7 @@ use crate::{
 use super::{Item, ResizeEdge};
 
 fn toggle_stacking(state: &mut State, mapped: &CosmicMapped) {
-    let mut shell = state.common.shell.write().unwrap();
+    let mut shell = state.common.shell.write();
     let seat = shell.seats.last_active().clone();
     if let Some(new_focus) = shell.toggle_stacking(&seat, mapped) {
         std::mem::drop(shell);
@@ -25,7 +25,7 @@ fn toggle_stacking(state: &mut State, mapped: &CosmicMapped) {
 }
 
 fn move_prev_workspace(state: &mut State, mapped: &CosmicMapped) {
-    let mut shell = state.common.shell.write().unwrap();
+    let mut shell = state.common.shell.write();
     let seat = shell.seats.last_active().clone();
     let (current_handle, output) = {
         let Some(ws) = shell.space_for(mapped) else {
@@ -58,7 +58,7 @@ fn move_prev_workspace(state: &mut State, mapped: &CosmicMapped) {
 }
 
 fn move_next_workspace(state: &mut State, mapped: &CosmicMapped) {
-    let mut shell = state.common.shell.write().unwrap();
+    let mut shell = state.common.shell.write();
     let seat = shell.seats.last_active().clone();
     let (current_handle, output) = {
         let Some(ws) = shell.space_for(mapped) else {
@@ -114,7 +114,7 @@ pub fn tab_items(
                 )
                 .into();
 
-                let mut shell = state.common.shell.write().unwrap();
+                let mut shell = state.common.shell.write();
                 let seat = shell.seats.last_active().clone();
                 let output = seat.active_output();
                 let workspace = shell.workspaces.active_mut(&output).unwrap();
@@ -198,12 +198,7 @@ pub fn window_items(
             Item::new(fl!("window-menu-minimize"), move |handle| {
                 let mapped = minimize_clone.clone();
                 let _ = handle.insert_idle(move |state| {
-                    state
-                        .common
-                        .shell
-                        .write()
-                        .unwrap()
-                        .minimize_request(&mapped);
+                    state.common.shell.write().minimize_request(&mapped);
                 });
             })
             .shortcut(config.shortcut_for_action(&Action::Minimize)),
@@ -212,7 +207,7 @@ pub fn window_items(
             Item::new(fl!("window-menu-maximize"), move |handle| {
                 let mapped = maximize_clone.clone();
                 let _ = handle.insert_idle(move |state| {
-                    let mut shell = state.common.shell.write().unwrap();
+                    let mut shell = state.common.shell.write();
                     let seat = shell.seats.last_active().clone();
                     shell.maximize_toggle(&mapped, &seat);
                 });
@@ -224,7 +219,7 @@ pub fn window_items(
             Item::new(fl!("window-menu-tiled"), move |handle| {
                 let tile_clone = tile_clone.clone();
                 let _ = handle.insert_idle(move |state| {
-                    let mut shell = state.common.shell.write().unwrap();
+                    let mut shell = state.common.shell.write();
                     let seat = shell.seats.last_active().clone();
                     if let Some(ws) = shell.space_for_mut(&tile_clone) {
                         ws.toggle_floating_window(&seat, &tile_clone);
@@ -246,7 +241,7 @@ pub fn window_items(
             let move_clone = move_clone.clone();
             let _ = handle.insert_idle(move |state| {
                 if let Some(surface) = move_clone.wl_surface() {
-                    let mut shell = state.common.shell.write().unwrap();
+                    let mut shell = state.common.shell.write();
                     let seat = shell.seats.last_active().clone();
                     let res = shell.move_request(
                         &surface,
@@ -285,7 +280,7 @@ pub fn window_items(
                 Item::new(fl!("window-menu-resize-edge-top"), move |handle| {
                     let resize_clone = resize_top_clone.clone();
                     let _ = handle.insert_idle(move |state| {
-                        let mut shell = state.common.shell.write().unwrap();
+                        let mut shell = state.common.shell.write();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
                             &resize_clone,
@@ -320,7 +315,7 @@ pub fn window_items(
                 Item::new(fl!("window-menu-resize-edge-left"), move |handle| {
                     let resize_clone = resize_left_clone.clone();
                     let _ = handle.insert_idle(move |state| {
-                        let mut shell = state.common.shell.write().unwrap();
+                        let mut shell = state.common.shell.write();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
                             &resize_clone,
@@ -355,7 +350,7 @@ pub fn window_items(
                 Item::new(fl!("window-menu-resize-edge-right"), move |handle| {
                     let resize_clone = resize_right_clone.clone();
                     let _ = handle.insert_idle(move |state| {
-                        let mut shell = state.common.shell.write().unwrap();
+                        let mut shell = state.common.shell.write();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
                             &resize_clone,
@@ -390,7 +385,7 @@ pub fn window_items(
                 Item::new(fl!("window-menu-resize-edge-bottom"), move |handle| {
                     let resize_clone = resize_bottom_clone.clone();
                     let _ = handle.insert_idle(move |state| {
-                        let mut shell = state.common.shell.write().unwrap();
+                        let mut shell = state.common.shell.write();
                         let seat = shell.seats.last_active().clone();
                         let res = shell.menu_resize_request(
                             &resize_clone,
@@ -445,7 +440,7 @@ pub fn window_items(
             Item::new(fl!("window-menu-sticky"), move |handle| {
                 let mapped = sticky_clone.clone();
                 let _ = handle.insert_idle(move |state| {
-                    let mut shell = state.common.shell.write().unwrap();
+                    let mut shell = state.common.shell.write();
                     let seat = shell.seats.last_active().clone();
                     shell.toggle_sticky(&seat, &mapped);
                 });

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -522,7 +522,7 @@ impl PointerGrab<State> for MenuGrab {
             let mut guard = self.elements.lock().unwrap();
             let elements = &mut *guard;
             let event_location = if let Some(output) = self.screen_space_relative.as_ref() {
-                if state.common.shell.read().unwrap().zoom_state().is_some() {
+                if state.common.shell.read().zoom_state().is_some() {
                     event
                         .location
                         .as_global()
@@ -726,7 +726,7 @@ impl TouchGrab<State> for MenuGrab {
             let mut guard = self.elements.lock().unwrap();
             let elements = &mut *guard;
             let event_location = if let Some(output) = self.screen_space_relative.as_ref() {
-                if data.common.shell.read().unwrap().zoom_state().is_some() {
+                if data.common.shell.read().zoom_state().is_some() {
                     event
                         .location
                         .as_global()

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -347,7 +347,7 @@ pub struct MoveGrab {
 
 impl MoveGrab {
     fn update_location(&mut self, state: &mut State, location: Point<f64, Logical>) {
-        let mut shell = state.common.shell.write().unwrap();
+        let mut shell = state.common.shell.write();
 
         let Some(current_output) = shell
             .outputs()
@@ -792,7 +792,7 @@ impl Drop for MoveGrab {
                 if grab_state.window.alive() {
                     let window_location =
                         (grab_state.location.to_i32_round() + grab_state.window_offset).as_global();
-                    let mut shell = state.common.shell.write().unwrap();
+                    let mut shell = state.common.shell.write();
 
                     let workspace_handle = shell.active_space(&output).unwrap().handle;
                     for old_output in window_outputs.iter().filter(|o| *o != &output) {

--- a/src/shell/layout/tiling/grabs/resize.rs
+++ b/src/shell/layout/tiling/grabs/resize.rs
@@ -227,7 +227,7 @@ impl ResizeForkGrab {
         self.last_loc = location.as_global();
 
         if let Some(output) = self.output.upgrade() {
-            let mut shell = data.common.shell.write().unwrap();
+            let mut shell = data.common.shell.write();
             let Some(workspace) = shell.active_space_mut(&output) else {
                 return false;
             };

--- a/src/shell/layout/tiling/grabs/swap.rs
+++ b/src/shell/layout/tiling/grabs/swap.rs
@@ -39,7 +39,7 @@ impl KeyboardGrab<State> for SwapWindowGrab {
         serial: Serial,
         time: u32,
     ) {
-        if !matches!(&data.common.shell.read().unwrap().overview_mode.active_trigger(), Some(Trigger::KeyboardSwap(_, d)) if d == &self.desc)
+        if !matches!(&data.common.shell.read().overview_mode.active_trigger(), Some(Trigger::KeyboardSwap(_, d)) if d == &self.desc)
         {
             handle.unset_grab(self, data, serial, false);
             return;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1309,7 +1309,7 @@ pub struct InvalidWorkspaceIndex;
 
 impl Common {
     pub fn add_output(&mut self, output: &Output) {
-        let mut shell = self.shell.write().unwrap();
+        let mut shell = self.shell.write();
         shell
             .workspaces
             .add_output(output, &mut self.workspace_state.update());
@@ -1333,7 +1333,7 @@ impl Common {
     }
 
     pub fn remove_output(&mut self, output: &Output) {
-        let mut shell = self.shell.write().unwrap();
+        let mut shell = self.shell.write();
         let shell_ref = &mut *shell;
         shell_ref.workspaces.remove_output(
             output,
@@ -1351,7 +1351,7 @@ impl Common {
             return;
         }
 
-        let mut shell = self.shell.write().unwrap();
+        let mut shell = self.shell.write();
         shell
             .workspaces
             .migrate_workspace(from, to, handle, &mut self.workspace_state.update());
@@ -1360,7 +1360,7 @@ impl Common {
     }
 
     pub fn update_config(&mut self) {
-        let mut shell = self.shell.write().unwrap();
+        let mut shell = self.shell.write();
         let shell_ref = &mut *shell;
         shell_ref.active_hint = self.config.cosmic_conf.active_hint;
         if let Some(zoom_state) = shell_ref.zoom_state.as_mut() {
@@ -1388,7 +1388,7 @@ impl Common {
     pub fn refresh(&mut self) {
         self.xdg_activation_state
             .retain_tokens(|_, data| data.timestamp.elapsed() < ACTIVATION_TOKEN_EXPIRE_TIME);
-        self.shell.write().unwrap().refresh(
+        self.shell.write().refresh(
             &self.xdg_activation_state,
             &mut self.workspace_state.update(),
         );
@@ -1410,7 +1410,7 @@ impl Common {
 
     pub fn on_commit(&mut self, surface: &WlSurface) {
         {
-            let shell = self.shell.read().unwrap();
+            let shell = self.shell.read();
 
             for seat in shell.seats.iter() {
                 if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1408,6 +1408,7 @@ impl Common {
         self.idle_notifier_state.set_is_inhibited(is_inhibited);
     }
 
+    #[profiling::function]
     pub fn on_commit(&mut self, surface: &WlSurface) {
         {
             let shell = self.shell.read();

--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -539,14 +539,7 @@ impl Program for ZoomProgram {
         match message {
             ZoomMessage::Decrease => {
                 let _ = loop_handle.insert_idle(|state| {
-                    let seat = state
-                        .common
-                        .shell
-                        .read()
-                        .unwrap()
-                        .seats
-                        .last_active()
-                        .clone();
+                    let seat = state.common.shell.read().seats.last_active().clone();
                     let increment =
                         state.common.config.cosmic_conf.accessibility_zoom.increment as f64 / 100.0;
 
@@ -555,14 +548,7 @@ impl Program for ZoomProgram {
             }
             ZoomMessage::Increase => {
                 let _ = loop_handle.insert_idle(|state| {
-                    let seat = state
-                        .common
-                        .shell
-                        .read()
-                        .unwrap()
-                        .seats
-                        .last_active()
-                        .clone();
+                    let seat = state.common.shell.read().seats.last_active().clone();
                     let increment =
                         state.common.config.cosmic_conf.accessibility_zoom.increment as f64 / 100.0;
 
@@ -576,7 +562,7 @@ impl Program for ZoomProgram {
                         if let Some(start_data) =
                             check_grab_preconditions(&seat, Some(serial), None)
                         {
-                            let shell = state.common.shell.read().unwrap();
+                            let shell = state.common.shell.read();
                             let output = seat.active_output();
 
                             if shell.zoom_state().is_some() {
@@ -741,7 +727,7 @@ impl Program for ZoomProgram {
                         if let Some(start_data) =
                             check_grab_preconditions(&seat, Some(serial), None)
                         {
-                            let shell = state.common.shell.read().unwrap();
+                            let shell = state.common.shell.read();
                             let output = seat.active_output();
 
                             if shell.zoom_state().is_some() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -671,7 +671,7 @@ impl State {
         ClientState {
             compositor_client_state: CompositorClientState::default(),
             advertised_drm_node: match &self.backend {
-                BackendData::Kms(kms_state) => kms_state.primary_node,
+                BackendData::Kms(kms_state) => *kms_state.primary_node.read().unwrap(),
                 _ => None,
             },
             privileged: !enable_wayland_security(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -695,6 +695,7 @@ fn primary_scanout_output_compare<'a>(
 }
 
 impl Common {
+    #[profiling::function]
     pub fn update_primary_output(
         &self,
         output: &Output,
@@ -796,6 +797,7 @@ impl Common {
         }
     }
 
+    #[profiling::function]
     pub fn send_dmabuf_feedback(
         &self,
         output: &Output,
@@ -946,6 +948,7 @@ impl Common {
         }
     }
 
+    #[profiling::function]
     pub fn send_frames(&self, output: &Output, sequence: Option<usize>) {
         let time = self.clock.now();
         let should_send = |surface: &WlSurface, states: &SurfaceData| {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -33,7 +33,7 @@ pub fn watch_theme(handle: LoopHandle<'_, State>) -> Result<(), cosmic_config::E
         if theme.theme_type != new_theme.theme_type {
             *theme = new_theme;
             let mut workspace_guard = state.common.workspace_state.update();
-            state.common.shell.write().unwrap().set_theme(
+            state.common.shell.write().set_theme(
                 theme.clone(),
                 &state.common.xdg_activation_state,
                 &mut workspace_guard,

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -1,6 +1,167 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use smithay::backend::drm::{DrmNode, NodeType};
+use tracing::{info, warn};
+
 pub fn bool_var(name: &str) -> Option<bool> {
     let value = std::env::var(name).ok()?.to_lowercase();
     Some(["1", "true", "yes", "y"].contains(&value.as_str()))
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DeviceIdentifier {
+    Id { vendor: u32, device: u32 },
+    Node(DrmNode),
+}
+
+impl DeviceIdentifier {
+    pub fn matches(&self, dev_node: &DrmNode) -> bool {
+        match self {
+            DeviceIdentifier::Node(id_node) => id_node == dev_node,
+            DeviceIdentifier::Id { vendor, device } => {
+                let (major, minor) = (dev_node.major(), dev_node.minor());
+                let Some(dev_vendor) = std::fs::read_to_string(format!(
+                    "/sys/dev/char/{}:{}/device/vendor",
+                    major, minor
+                ))
+                .ok()
+                .and_then(|ven| u32::from_str_radix(ven[2..].trim(), 16).ok()) else {
+                    return false;
+                };
+                let Some(dev_device) = std::fs::read_to_string(format!(
+                    "/sys/dev/char/{}:{}/device/device",
+                    major, minor
+                ))
+                .ok()
+                .and_then(|dev| u32::from_str_radix(dev[2..].trim(), 16).ok()) else {
+                    return false;
+                };
+                info!(
+                    "{:x}:{:x} == {:x}:{:x}",
+                    *vendor, *device, dev_vendor, dev_device
+                );
+                dev_vendor == *vendor && dev_device == *device
+            }
+        }
+    }
+}
+
+pub fn dev_var(name: &str) -> Option<DeviceIdentifier> {
+    let value = std::env::var(name).ok()?;
+    try_parse_dev_from_str(&value)
+}
+
+pub fn dev_list_var(name: &str) -> Option<Vec<DeviceIdentifier>> {
+    let value = std::env::var(name).ok()?;
+    Some(value.split(',').flat_map(try_parse_dev_from_str).collect())
+}
+
+fn try_parse_dev_from_str(val: &str) -> Option<DeviceIdentifier> {
+    let val = val.trim();
+    if val.starts_with("0x") && val.contains(':') {
+        let (vendor, device) = val.split_once(':').unwrap();
+        if !device.starts_with("0x") {
+            warn!(
+                "Failed to parse device entry {}, device id doesn't start with '0x'. Skipping",
+                val
+            );
+            return None;
+        }
+        let vendor = u32::from_str_radix(&vendor[2..], 16)
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, vendor_id is no hex integer: {}. Skipping",
+                    val, err
+                );
+            })
+            .ok()?;
+        let device = u32::from_str_radix(&device[2..], 16)
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, device_id is no hex integer: {}. Skipping",
+                    val, err
+                );
+            })
+            .ok()?;
+        Some(DeviceIdentifier::Id { vendor, device })
+    } else if val.starts_with("pci-") {
+        let path = std::fs::read_link(format!("/dev/dri/by-path/{}-render", val))
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, no known pci path: {}. Skipping",
+                    val, err
+                );
+            })
+            .ok()?;
+        let node = DrmNode::from_path(&path)
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, failed to get node from path {}: {}",
+                    val,
+                    path.display(),
+                    err
+                )
+            })
+            .ok()?;
+
+        let node = node
+            .node_with_type(NodeType::Render)
+            .map(|res| res.ok())
+            .flatten()
+            .unwrap_or(node);
+        Some(DeviceIdentifier::Node(node))
+    } else if val.contains(':') {
+        let (major, minor) = val.split_once(':').unwrap();
+        let major = str::parse::<u32>(major)
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, major is no integer: {}. Skipping",
+                    val, err
+                )
+            })
+            .ok()?;
+        let minor = str::parse::<u32>(minor)
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, minor is no integer: {}. Skipping",
+                    val, err
+                )
+            })
+            .ok()?;
+        let dev = rustix::fs::makedev(major, minor);
+        let node = DrmNode::from_dev_id(dev)
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, failed to get node from dev_t {}: {}",
+                    val, dev, err
+                );
+            })
+            .ok()?;
+
+        let node = node
+            .node_with_type(NodeType::Render)
+            .map(|res| res.ok())
+            .flatten()
+            .unwrap_or(node);
+        Some(DeviceIdentifier::Node(node))
+    } else {
+        // try to parse as device path
+
+        let path = format!("/dev/dri/{}", val);
+        let node = DrmNode::from_path(&path)
+            .inspect_err(|err| {
+                warn!(
+                    "Failed to parse device entry {}, failed to get node from path {}: {}",
+                    val, path, err
+                );
+            })
+            .ok()?;
+
+        let node = node
+            .node_with_type(NodeType::Render)
+            .map(|res| res.ok())
+            .flatten()
+            .unwrap_or(node);
+        Some(DeviceIdentifier::Node(node))
+    }
 }

--- a/src/utils/screenshot.rs
+++ b/src/utils/screenshot.rs
@@ -104,7 +104,7 @@ pub fn screenshot_window(state: &mut State, surface: &CosmicSurface) {
             .backend
             .offscreen_renderer(|kms| {
                 advertised_node_for_surface(&wl_surface, &state.common.display_handle)
-                    .or(kms.primary_node)
+                    .or(*kms.primary_node.read().unwrap())
             })
             .with_context(|| "Failed to get renderer for screenshot")
             .and_then(|renderer| match renderer {

--- a/src/wayland/handlers/a11y.rs
+++ b/src/wayland/handlers/a11y.rs
@@ -12,7 +12,7 @@ impl A11yHandler for State {
     }
 
     fn request_screen_magnifier(&mut self, enabled: bool) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
 
         if shell
             .zoom_state()

--- a/src/wayland/handlers/buffer.rs
+++ b/src/wayland/handlers/buffer.rs
@@ -12,7 +12,7 @@ impl BufferHandler for State {
         if let BackendData::Kms(kms_state) = &mut self.backend {
             for device in kms_state.drm_devices.values_mut() {
                 if device.active_buffers.remove(&buffer.downgrade()) {
-                    if !device.in_use(kms_state.primary_node.as_ref()) {
+                    if !device.in_use(kms_state.primary_node.read().unwrap().as_ref()) {
                         if let Err(err) = kms_state.refresh_used_devices() {
                             warn!(?err, "Failed to init devices.");
                         };

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -173,7 +173,7 @@ impl CompositorHandler for State {
         // handle initial configure events and map windows if necessary
         let mapped = self.send_initial_configure_and_map(surface);
 
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
 
         // schedule a new render
         if let Some(output) = shell.visible_output_for_surface(surface) {
@@ -277,7 +277,7 @@ impl CompositorHandler for State {
 
 impl State {
     fn send_initial_configure_and_map(&mut self, surface: &WlSurface) -> bool {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
 
         if let Some(pending) = shell
             .pending_windows

--- a/src/wayland/handlers/decoration.rs
+++ b/src/wayland/handlers/decoration.rs
@@ -114,14 +114,14 @@ pub fn unset_mode(mapped: &CosmicMapped, surface: &WlSurface) {
 
 impl XdgDecorationHandler for State {
     fn new_decoration(&mut self, toplevel: ToplevelSurface) {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         if let Some(mapped) = shell.element_for_surface(toplevel.wl_surface()) {
             new_decoration(mapped, toplevel.wl_surface());
         }
     }
 
     fn request_mode(&mut self, toplevel: ToplevelSurface, mode: XdgMode) {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         if let Some(mapped) = shell.element_for_surface(toplevel.wl_surface()) {
             request_mode(mapped, toplevel.wl_surface(), mode);
         } else {
@@ -130,7 +130,7 @@ impl XdgDecorationHandler for State {
     }
 
     fn unset_mode(&mut self, toplevel: ToplevelSurface) {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         if let Some(mapped) = shell.element_for_surface(toplevel.wl_surface()) {
             unset_mode(mapped, toplevel.wl_surface())
         }
@@ -143,7 +143,7 @@ impl KdeDecorationHandler for State {
     }
 
     fn new_decoration(&mut self, surface: &WlSurface, decoration: &OrgKdeKwinServerDecoration) {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         if let Some(mapped) = shell.element_for_surface(surface) {
             let mode = new_decoration(mapped, surface);
             decoration.mode(mode);
@@ -157,7 +157,7 @@ impl KdeDecorationHandler for State {
         mode: WEnum<KdeMode>,
     ) {
         if let WEnum::Value(mode) = mode {
-            let shell = self.common.shell.read().unwrap();
+            let shell = self.common.shell.read();
             // TODO: We need to store this value until it gets mapped and apply it then, if it is not mapped yet.
             if let Some(mapped) = shell.element_for_surface(surface) {
                 request_mode(
@@ -174,7 +174,7 @@ impl KdeDecorationHandler for State {
     }
 
     fn release(&mut self, _decoration: &OrgKdeKwinServerDecoration, surface: &WlSurface) {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         if let Some(mapped) = shell.element_for_surface(surface) {
             unset_mode(mapped, surface)
         }

--- a/src/wayland/handlers/drm_syncobj.rs
+++ b/src/wayland/handlers/drm_syncobj.rs
@@ -7,12 +7,12 @@ use smithay::{
 };
 
 impl DrmSyncobjHandler for State {
-    fn drm_syncobj_state(&mut self) -> &mut DrmSyncobjState {
+    fn drm_syncobj_state(&mut self) -> Option<&mut DrmSyncobjState> {
         let kms = match &mut self.backend {
             BackendData::Kms(kms) => kms,
             _ => unreachable!(),
         };
-        kms.syncobj_state.as_mut().unwrap()
+        kms.syncobj_state.as_mut()
     }
 }
 

--- a/src/wayland/handlers/fractional_scale.rs
+++ b/src/wayland/handlers/fractional_scale.rs
@@ -42,20 +42,11 @@ impl FractionalScaleHandler for State {
                     self.common
                         .shell
                         .read()
-                        .unwrap()
                         .visible_output_for_surface(&surface)
                         .cloned()
                 })
         })
-        .unwrap_or_else(|| {
-            self.common
-                .shell
-                .read()
-                .unwrap()
-                .seats
-                .last_active()
-                .active_output()
-        });
+        .unwrap_or_else(|| self.common.shell.read().seats.last_active().active_output());
 
         with_states(&surface, |states| {
             with_fractional_scale(states, |fractional_scale| {

--- a/src/wayland/handlers/input_method.rs
+++ b/src/wayland/handlers/input_method.rs
@@ -27,7 +27,6 @@ impl InputMethodHandler for State {
         self.common
             .shell
             .read()
-            .unwrap()
             .element_for_surface(parent)
             .map(|e| e.geometry())
             .unwrap_or_default()

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -26,7 +26,7 @@ impl WlrLayerShellHandler for State {
         _layer: Layer,
         namespace: String,
     ) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         let seat = shell.seats.last_active().clone();
         let output = wl_output
             .as_ref()
@@ -40,7 +40,7 @@ impl WlrLayerShellHandler for State {
     }
 
     fn new_popup(&mut self, _parent: WlrLayerSurface, popup: PopupSurface) {
-        self.common.shell.read().unwrap().unconstrain_popup(&popup);
+        self.common.shell.read().unconstrain_popup(&popup);
 
         if popup.send_configure().is_ok() {
             self.common
@@ -51,7 +51,7 @@ impl WlrLayerShellHandler for State {
     }
 
     fn layer_destroyed(&mut self, surface: WlrLayerSurface) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         let maybe_output = shell
             .outputs()
             .find(|o| {

--- a/src/wayland/handlers/overlap_notify.rs
+++ b/src/wayland/handlers/overlap_notify.rs
@@ -22,7 +22,7 @@ impl OverlapNotifyHandler for State {
             .layer_surfaces()
             .find(|l| l.shell_surface() == &resource)
             .and_then(|l| {
-                let shell = self.common.shell.read().unwrap();
+                let shell = self.common.shell.read();
                 let outputs = shell.outputs();
                 let ret = outputs.map(|o| layer_map_for_output(o)).find_map(|s| {
                     s.layer_for_surface(l.wl_surface(), WindowSurfaceType::ALL)
@@ -34,14 +34,14 @@ impl OverlapNotifyHandler for State {
     }
 
     fn outputs(&self) -> impl Iterator<Item = Output> {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         shell.outputs().cloned().collect::<Vec<_>>().into_iter()
     }
 
     fn active_workspaces(
         &self,
     ) -> impl Iterator<Item = crate::wayland::protocols::workspace::WorkspaceHandle> {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         shell
             .workspaces
             .sets

--- a/src/wayland/handlers/screencopy/mod.rs
+++ b/src/wayland/handlers/screencopy/mod.rs
@@ -355,7 +355,10 @@ fn constraints_for_output(output: &Output, backend: &mut BackendData) -> Option<
     };
 
     let mut renderer = backend
-        .offscreen_renderer(|kms| kms.target_node_for_output(&output).or(kms.primary_node))
+        .offscreen_renderer(|kms| {
+            kms.target_node_for_output(&output)
+                .or(*kms.primary_node.read().unwrap())
+        })
         .unwrap();
     Some(constraints_for_renderer(mode, renderer.as_mut()))
 }
@@ -376,7 +379,7 @@ fn constraints_for_toplevel(
             })
             .flatten();
 
-            dma_node.or(kms.primary_node)
+            dma_node.or(*kms.primary_node.read().unwrap())
         })
         .unwrap();
 

--- a/src/wayland/handlers/screencopy/mod.rs
+++ b/src/wayland/handlers/screencopy/mod.rs
@@ -51,7 +51,7 @@ impl ScreencopyHandler for State {
                 .upgrade()
                 .and_then(|output| constraints_for_output(&output, &mut self.backend)),
             ImageCaptureSourceData::Workspace(handle) => {
-                let shell = self.common.shell.read().unwrap();
+                let shell = self.common.shell.read();
                 let output = shell.workspaces.space_for_handle(&handle)?.output();
                 constraints_for_output(output, &mut self.backend)
             }
@@ -69,7 +69,6 @@ impl ScreencopyHandler for State {
             .common
             .shell
             .read()
-            .unwrap()
             .seats
             .last_active()
             .cursor_geometry((0.0, 0.0), self.common.clock.now())
@@ -103,7 +102,7 @@ impl ScreencopyHandler for State {
                 output.add_session(session);
             }
             ImageCaptureSourceData::Workspace(handle) => {
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 let Some(workspace) = shell.workspaces.space_for_handle_mut(&handle) else {
                     session.stop();
                     return;
@@ -132,14 +131,7 @@ impl ScreencopyHandler for State {
     }
     fn new_cursor_session(&mut self, session: CursorSession) {
         let (pointer_loc, pointer_size, hotspot) = {
-            let seat = self
-                .common
-                .shell
-                .read()
-                .unwrap()
-                .seats
-                .last_active()
-                .clone();
+            let seat = self.common.shell.read().seats.last_active().clone();
 
             let pointer = seat.get_pointer().unwrap();
             let pointer_loc = pointer.current_location().to_i32_round().as_global();
@@ -194,7 +186,7 @@ impl ScreencopyHandler for State {
                 output.add_cursor_session(session);
             }
             ImageCaptureSourceData::Workspace(handle) => {
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 let Some(workspace) = shell.workspaces.space_for_handle_mut(&handle) else {
                     return;
                 };
@@ -225,7 +217,7 @@ impl ScreencopyHandler for State {
                 workspace.add_cursor_session(session);
             }
             ImageCaptureSourceData::Toplevel(mut toplevel) => {
-                let shell = self.common.shell.read().unwrap();
+                let shell = self.common.shell.read();
                 if let Some(element) = shell.element_for_surface(&toplevel) {
                     if element.has_active_window(&toplevel) {
                         if let Some(workspace) = shell.space_for(element) {
@@ -277,19 +269,12 @@ impl ScreencopyHandler for State {
             return;
         }
 
-        let seat = self
-            .common
-            .shell
-            .read()
-            .unwrap()
-            .seats
-            .last_active()
-            .clone();
+        let seat = self.common.shell.read().seats.last_active().clone();
         render_cursor_to_buffer(self, &session, frame, &seat);
     }
 
     fn frame_aborted(&mut self, frame: FrameRef) {
-        let shell = self.common.shell.read().unwrap();
+        let shell = self.common.shell.read();
         for mut output in shell.outputs().cloned() {
             output.remove_frame(&frame);
         }
@@ -307,7 +292,6 @@ impl ScreencopyHandler for State {
                     .common
                     .shell
                     .write()
-                    .unwrap()
                     .workspaces
                     .space_for_handle_mut(&handle)
                 {
@@ -331,7 +315,6 @@ impl ScreencopyHandler for State {
                     .common
                     .shell
                     .write()
-                    .unwrap()
                     .workspaces
                     .space_for_handle_mut(&handle)
                 {

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -337,7 +337,9 @@ pub fn render_workspace_to_buffer(
     let common = &mut state.common;
 
     let renderer = match state.backend.offscreen_renderer(|kms| {
-        let render_node = kms.target_node_for_output(&output).or(kms.primary_node)?;
+        let render_node = kms
+            .target_node_for_output(&output)
+            .or(*kms.primary_node.read().unwrap())?;
         let target_node = get_dmabuf(&buffer)
             .ok()
             .and_then(|dma| dma.node())
@@ -591,7 +593,7 @@ pub fn render_window_to_buffer(
                     })
                     .flatten()
             })
-            .or(kms.primary_node)
+            .or(*kms.primary_node.read().unwrap())
     }) {
         Ok(renderer) => renderer,
         Err(err) => {
@@ -745,7 +747,10 @@ pub fn render_cursor_to_buffer(
     }
 
     let common = &mut state.common;
-    let renderer = match state.backend.offscreen_renderer(|kms| kms.primary_node) {
+    let renderer = match state
+        .backend
+        .offscreen_renderer(|kms| *kms.primary_node.read().unwrap())
+    {
         Ok(renderer) => renderer,
         Err(err) => {
             warn!(?err, "Couldn't use node for screencopy");

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -209,7 +209,7 @@ pub fn render_workspace_to_buffer(
     frame: Frame,
     handle: WorkspaceHandle,
 ) {
-    let shell = state.common.shell.read().unwrap();
+    let shell = state.common.shell.read();
     let Some(workspace) = shell.workspaces.space_for_handle(&handle) else {
         return;
     };
@@ -509,7 +509,7 @@ pub fn render_window_to_buffer(
                 .map(Into::<WindowCaptureElement<R>>::into),
         );
 
-        let shell = common.shell.read().unwrap();
+        let shell = common.shell.read();
         let seat = shell.seats.last_active().clone();
         let location = if let Some(mapped) = shell.element_for_surface(window) {
             mapped.cursor_position(&seat).and_then(|mut p| {

--- a/src/wayland/handlers/session_lock.rs
+++ b/src/wayland/handlers/session_lock.rs
@@ -18,7 +18,7 @@ impl SessionLockHandler for State {
     }
 
     fn lock(&mut self, locker: SessionLocker) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
 
         // Reject lock if sesion lock exists and is still valid
         if let Some(session_lock) = shell.session_lock.as_ref() {
@@ -45,7 +45,7 @@ impl SessionLockHandler for State {
     }
 
     fn unlock(&mut self) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         shell.session_lock = None;
 
         for output in shell.outputs() {
@@ -54,7 +54,7 @@ impl SessionLockHandler for State {
     }
 
     fn new_surface(&mut self, lock_surface: LockSurface, wl_output: WlOutput) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(session_lock) = &mut shell.session_lock {
             if let Some(output) = Output::from_resource(&wl_output) {
                 lock_surface.with_pending_state(|states| {

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -34,7 +34,7 @@ impl ToplevelManagementHandler for State {
     ) {
         self.unminimize(dh, window);
 
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         for output in shell.outputs().cloned().collect::<Vec<_>>().iter() {
             let maybe = shell
                 .workspaces
@@ -120,7 +120,7 @@ impl ToplevelManagementHandler for State {
         to_handle: WorkspaceHandle,
         _output: Output,
     ) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mut mapped) = shell.element_for_surface(window).cloned() {
             if let Some(from_workspace) = shell.space_for_mut(&mapped) {
                 // If window is part of a stack, remove it and map it outside the stack
@@ -168,7 +168,7 @@ impl ToplevelManagementHandler for State {
         window: &<Self as ToplevelInfoHandler>::Window,
         output: Option<Output>,
     ) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         let seat = shell.seats.last_active().clone();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             if let Some((output, workspace)) =
@@ -195,7 +195,7 @@ impl ToplevelManagementHandler for State {
         _dh: &DisplayHandle,
         window: &<Self as ToplevelInfoHandler>::Window,
     ) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             if let Some(workspace) = shell.space_for_mut(&mapped) {
                 if let Some((layer, previous_workspace)) = workspace.unfullscreen_request(window) {
@@ -219,7 +219,7 @@ impl ToplevelManagementHandler for State {
     }
 
     fn maximize(&mut self, _dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             let seat = shell.seats.last_active().clone();
             shell.maximize_request(&mapped, &seat, true);
@@ -227,14 +227,14 @@ impl ToplevelManagementHandler for State {
     }
 
     fn unmaximize(&mut self, _dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             shell.unmaximize_request(&mapped);
         }
     }
 
     fn minimize(&mut self, _dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             if !mapped.is_stack() || &mapped.active_window() == window {
                 shell.minimize_request(&mapped);
@@ -243,7 +243,7 @@ impl ToplevelManagementHandler for State {
     }
 
     fn unminimize(&mut self, _dh: &DisplayHandle, window: &<Self as ToplevelInfoHandler>::Window) {
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             let seat = shell.seats.last_active().clone();
             shell.unminimize_request(&mapped, &seat);
@@ -258,7 +258,7 @@ impl ToplevelManagementHandler for State {
             return;
         }
 
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             let seat = shell.seats.last_active().clone();
             shell.toggle_sticky(&seat, &mapped);
@@ -274,7 +274,7 @@ impl ToplevelManagementHandler for State {
             return;
         }
 
-        let mut shell = self.common.shell.write().unwrap();
+        let mut shell = self.common.shell.write();
         if let Some(mapped) = shell.element_for_surface(window).cloned() {
             let seat = shell.seats.last_active().clone();
             shell.toggle_sticky(&seat, &mapped);

--- a/src/wayland/handlers/workspace.rs
+++ b/src/wayland/handlers/workspace.rs
@@ -22,7 +22,7 @@ impl WorkspaceHandler for State {
         for request in requests.into_iter() {
             match request {
                 Request::Activate(handle) => {
-                    let mut shell = self.common.shell.write().unwrap();
+                    let mut shell = self.common.shell.write();
                     let maybe = shell.workspaces.iter().find_map(|(o, set)| {
                         set.workspaces
                             .iter()
@@ -41,7 +41,7 @@ impl WorkspaceHandler for State {
                     }
                 }
                 Request::SetTilingState { workspace, state } => {
-                    let mut shell = self.common.shell.write().unwrap();
+                    let mut shell = self.common.shell.write();
                     let seat = shell.seats.last_active().clone();
                     if let Some(workspace) = shell.workspaces.space_for_handle_mut(&workspace) {
                         let mut guard = self.common.workspace_state.update();
@@ -56,7 +56,7 @@ impl WorkspaceHandler for State {
                     }
                 }
                 Request::SetPin { workspace, pinned } => {
-                    let mut shell = self.common.shell.write().unwrap();
+                    let mut shell = self.common.shell.write();
                     if let Some(workspace) = shell.workspaces.space_for_handle_mut(&workspace) {
                         workspace.pinned = pinned;
                         let mut update = self.common.workspace_state.update();
@@ -78,7 +78,7 @@ impl WorkspaceHandler for State {
                     if axis != 0 {
                         continue;
                     }
-                    let mut shell = self.common.shell.write().unwrap();
+                    let mut shell = self.common.shell.write();
                     let mut update = self.common.workspace_state.update();
                     shell.workspaces.move_workspace(
                         &workspace,
@@ -95,7 +95,7 @@ impl WorkspaceHandler for State {
                     if axis != 0 {
                         continue;
                     }
-                    let mut shell = self.common.shell.write().unwrap();
+                    let mut shell = self.common.shell.write();
                     let mut update = self.common.workspace_state.update();
                     shell.workspaces.move_workspace(
                         &workspace,

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -43,7 +43,7 @@ impl XdgActivationHandler for State {
         {
             if let Some(seat) = data.serial.and_then(|(_, seat)| Seat::from_resource(&seat)) {
                 let output = seat.active_output();
-                let mut shell = self.common.shell.write().unwrap();
+                let mut shell = self.common.shell.write();
                 let workspace = shell.active_space_mut(&output).unwrap();
                 let handle = workspace.handle;
                 data.user_data
@@ -86,7 +86,7 @@ impl XdgActivationHandler for State {
 
         if valid {
             let output = seat.active_output();
-            let mut shell = self.common.shell.write().unwrap();
+            let mut shell = self.common.shell.write();
             let workspace = shell.active_space_mut(&output).unwrap();
             let handle = workspace.handle;
             data.user_data
@@ -107,7 +107,7 @@ impl XdgActivationHandler for State {
         surface: WlSurface,
     ) {
         if let Some(context) = token_data.user_data.get::<ActivationContext>() {
-            let mut shell = self.common.shell.write().unwrap();
+            let mut shell = self.common.shell.write();
             if let Some(element) = shell.element_for_surface(&surface).cloned() {
                 match context {
                     ActivationContext::UrgentOnly => {

--- a/src/wayland/handlers/xwayland_keyboard_grab.rs
+++ b/src/wayland/handlers/xwayland_keyboard_grab.rs
@@ -12,7 +12,6 @@ impl XWaylandKeyboardGrabHandler for State {
             .common
             .shell
             .read()
-            .unwrap()
             .workspaces
             .spaces()
             .find_map(|x| x.element_for_surface(surface).cloned())?;

--- a/src/wayland/protocols/overlap_notify.rs
+++ b/src/wayland/protocols/overlap_notify.rs
@@ -71,6 +71,7 @@ impl OverlapNotifyState {
         self.global.clone()
     }
 
+    #[profiling::function]
     pub fn refresh<D, W>(state: &mut D)
     where
         D: GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData>

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -317,6 +317,7 @@ impl Common {
         }
     }
 
+    #[profiling::function]
     pub fn xwayland_notify_key_event(
         &mut self,
         sym: Keysym,
@@ -400,6 +401,7 @@ impl Common {
         }
     }
 
+    #[profiling::function]
     pub fn xwayland_notify_pointer_button_event(
         &mut self,
         button: u32,
@@ -449,6 +451,7 @@ impl Common {
         }
     }
 
+    #[profiling::function]
     pub fn update_x11_stacking_order(&mut self) {
         let shell = self.shell.read();
         let active_output = shell.seats.last_active().active_output();


### PR DESCRIPTION
Series of commits currently blocked on https://github.com/Smithay/smithay/pull/1739.

- Adds new env-variables (and common helpers) to parse various device identifiers to make testing with multi-gpu setups easier
- Updates the code to select the primary-gpu to prefer devices with built-in connectors (eDP, LVDS). (Should address https://github.com/pop-os/cosmic-comp/issues/913)
- Makes the primary node properly dynamic, allowing runtime switches as good as possible, when the device disappears as well as keeping the same device as long as possible. Can still be over-written with an env var and potentially switched at runtime for debugging purposes in the future.
- More profiling, which revealed:
  - Some threads can hog the shell-lock, breaking our timing for the KMS threads. Lets use parking-lot, which has a concept of eventual fairness. In practice this means much more consistent timings
  - Profiling revealed that while we do render at e.g. 120Hz without issues, programs can end up having their refresh rate halved. Turns out this was an oversight from before we limited the frame-callbacks of each surface to one per vblank. Uppps.