### PR TITLE
Add security context indicator

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -99,6 +99,7 @@ pub struct CosmicCompConfig {
     pub edge_snap_threshold: u32,
     pub accessibility_zoom: ZoomConfig,
     pub appearance_settings: AppearanceConfig,
+    pub security_context: SecurityContextConfig,
 }
 
 impl Default for CosmicCompConfig {
@@ -135,6 +136,7 @@ impl Default for CosmicCompConfig {
             edge_snap_threshold: 0,
             accessibility_zoom: ZoomConfig::default(),
             appearance_settings: AppearanceConfig::default(),
+            security_context: SecurityContextConfig::default(),
         }
     }
 }
@@ -233,4 +235,26 @@ pub enum XwaylandDescaling {
     Disabled,
     #[default]
     Fractional,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct SecurityContextRule {
+    pub app_id: String,
+    pub sandbox_engine: String,
+    pub border_color: [f32; 3],
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct SecurityContextConfig {
+    pub border_size: u8,
+    pub rules: Vec<SecurityContextRule>,
+}
+
+impl Default for SecurityContextConfig {
+    fn default() -> SecurityContextConfig {
+        SecurityContextConfig {
+            border_size: 4,
+            rules: Vec::new(),
+        }
+    }
 }

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -137,6 +137,13 @@ pub enum Usage {
     PotentialGroupIndicator,
     SnappingIndicator,
     Border,
+    SecurityContextIndicator,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SecurityContextIndicatorSettings {
+    pub border_color: [f32; 3],
+    pub border_size: u8,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This adds the ability to enable a security context indicator around floating windows similar to the focus indicator.

The security context protocol is commonly used when running applications in sandboxed environments. Being able to enable an indicator helps clearly distinguish between sandboxed and regular application windows. This is especially useful when running multiple apps with different sandbox settings. For example, a user might have a "trusted" browser running in a strict secure sandbox with a green window border and a regular one with red.

The indicator can be enabled by defining rules based on the sandbox engine and appid from the security context protocol and by specifying an indicator color in the `security_context` configuration file.

This might not be the most widely requested feature but it’s quite useful in certain scenarios. I’m sharing it here to see if there’s any interest in merging something like this or if others have thoughts or suggestions on how it could be improved.