### PR TITLE
kms/surface: Call `cleanup_texture_cache` for each device at end of draw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4730,7 +4730,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 [[package]]
 name = "smithay"
 version = "0.6.0"
-source = "git+https://github.com/smithay/smithay.git?rev=7ad90b5#7ad90b55df53bf9066211d1e64f276e88c41eb00"
+source = "git+https://github.com/smithay/smithay.git?rev=bc19fd6#bc19fd67675268a08c05105e3b099d9aa2bebd02"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,4 +124,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "7ad90b5" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "bc19fd6" }

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -45,7 +45,7 @@ use smithay::{
                 element::TextureShaderElement, GlesRenderbuffer, GlesRenderer, GlesTexture, Uniform,
             },
             glow::GlowRenderer,
-            multigpu::{Error as MultiError, GpuManager},
+            multigpu::{ApiDevice, Error as MultiError, GpuManager},
             sync::SyncPoint,
             utils::with_renderer_surface_state,
             Bind, Blit, Frame, ImportDma, Offscreen, Renderer, RendererSuper, Texture,
@@ -1749,6 +1749,10 @@ impl SurfaceThreadState {
                 compositor.reset_buffers();
                 anyhow::bail!("Rendering failed: {}", err);
             }
+        }
+
+        for device in self.api.devices_mut()? {
+            device.renderer_mut().cleanup_texture_cache()?;
         }
 
         Ok(())


### PR DESCRIPTION
Fixes an issue where a dual GPU system would keep allocating dGPU PBOs in `cpu_copy()` every frame, but `cleanup()` was not being called, since the surface thread for the builtin output was rendered on the primary/integrated GPU, targeting the same GPU.

Even if a different monitor was compositing on the dGPU, That wouldn't help since that thread has it's own `GpuManager` with it's own renderer and cache.

Running cleanup at the end (or start) of each frame seems like a good idea. Not sure if it would be best to avoid additional calls, or if that's desirable/fine.