### PR TITLE
Fixes for `frame` callbacks, and surface redraw queing, for dnd and cursor surfaces

### DIFF
--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -20,8 +20,7 @@ use smithay::{
     reexports::wayland_server::protocol::wl_surface,
     render_elements,
     utils::{
-        Buffer as BufferCoords, IsAlive, Logical, Monotonic, Physical, Point, Scale, Size, Time,
-        Transform,
+        Buffer as BufferCoords, Logical, Monotonic, Physical, Point, Scale, Size, Time, Transform,
     },
     wayland::compositor::{get_role, with_states},
 };
@@ -266,20 +265,7 @@ where
     R::TextureId: Send + Clone + 'static,
 {
     // draw the cursor as relevant
-    // reset the cursor if the surface is no longer alive
-    let cursor_status = seat
-        .user_data()
-        .get::<Mutex<CursorImageStatus>>()
-        .map(|lock| {
-            let mut cursor_status = lock.lock().unwrap();
-            if let CursorImageStatus::Surface(ref surface) = *cursor_status {
-                if !surface.alive() {
-                    *cursor_status = CursorImageStatus::default_named();
-                }
-            }
-            cursor_status.clone()
-        })
-        .unwrap_or(CursorImageStatus::default_named());
+    let cursor_status = seat.cursor_image_status();
 
     let seat_userdata = seat.user_data();
     let mut state_ref = seat_userdata.get::<CursorState>().unwrap().lock().unwrap();

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -1333,8 +1333,7 @@ impl PointerTarget<State> for CosmicStack {
                 .lock()
                 .unwrap();
             cursor_state.set_shape(next.cursor_shape());
-            let cursor_status = seat.user_data().get::<Mutex<CursorImageStatus>>().unwrap();
-            *cursor_status.lock().unwrap() = CursorImageStatus::default_named();
+            seat.set_cursor_image_status(CursorImageStatus::default_named());
         });
 
         event.location -= self.0.with_program(|p| {
@@ -1363,8 +1362,7 @@ impl PointerTarget<State> for CosmicStack {
                 .lock()
                 .unwrap();
             cursor_state.set_shape(next.cursor_shape());
-            let cursor_status = seat.user_data().get::<Mutex<CursorImageStatus>>().unwrap();
-            *cursor_status.lock().unwrap() = CursorImageStatus::default_named();
+            seat.set_cursor_image_status(CursorImageStatus::default_named());
         });
 
         let active_window_geo = self.0.with_program(|p| {

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -711,8 +711,7 @@ impl PointerTarget<State> for CosmicWindow {
 
                 let cursor_state = seat.user_data().get::<CursorState>().unwrap();
                 cursor_state.lock().unwrap().set_shape(next.cursor_shape());
-                let cursor_status = seat.user_data().get::<Mutex<CursorImageStatus>>().unwrap();
-                *cursor_status.lock().unwrap() = CursorImageStatus::default_named();
+                seat.set_cursor_image_status(CursorImageStatus::default_named());
             }
         });
 
@@ -736,8 +735,7 @@ impl PointerTarget<State> for CosmicWindow {
 
                 let cursor_state = seat.user_data().get::<CursorState>().unwrap();
                 cursor_state.lock().unwrap().set_shape(next.cursor_shape());
-                let cursor_status = seat.user_data().get::<Mutex<CursorImageStatus>>().unwrap();
-                *cursor_status.lock().unwrap() = CursorImageStatus::default_named();
+                seat.set_cursor_image_status(CursorImageStatus::default_named());
             }
         });
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1427,12 +1427,7 @@ impl Common {
             }
 
             let is_cursor_image = shell.seats.iter().any(|seat| {
-                seat.user_data()
-                .get::<Mutex<CursorImageStatus>>()
-                .map(|guard| {
-                    matches!(*guard.lock().unwrap(), CursorImageStatus::Surface(ref cursor_surface) if cursor_surface == surface)
-                })
-                .unwrap_or(false)
+                    matches!(seat.cursor_image_status(), CursorImageStatus::Surface(ref cursor_surface) if cursor_surface == surface)
             });
 
             if is_cursor_image {

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -377,19 +377,15 @@ impl SeatExt for Seat<State> {
     }
 
     fn cursor_image_status(&self) -> CursorImageStatus {
-        self.user_data()
-            .get::<Mutex<CursorImageStatus>>()
-            // Reset the cursor if the surface is no longer alive
-            .map(|lock| {
-                let mut cursor_status = lock.lock().unwrap();
-                if let CursorImageStatus::Surface(ref surface) = *cursor_status {
-                    if !surface.alive() {
-                        *cursor_status = CursorImageStatus::default_named();
-                    }
-                }
-                cursor_status.clone()
-            })
-            .unwrap_or(CursorImageStatus::default_named())
+        let lock = self.user_data().get::<Mutex<CursorImageStatus>>().unwrap();
+        // Reset the cursor if the surface is no longer alive
+        let mut cursor_status = lock.lock().unwrap();
+        if let CursorImageStatus::Surface(ref surface) = *cursor_status {
+            if !surface.alive() {
+                *cursor_status = CursorImageStatus::default_named();
+            }
+        }
+        cursor_status.clone()
     }
 
     fn set_cursor_image_status(&self, status: CursorImageStatus) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -70,7 +70,7 @@ use smithay::{
             Client, DisplayHandle, Resource,
         },
     },
-    utils::{Clock, IsAlive, Monotonic, Point},
+    utils::{Clock, Monotonic, Point},
     wayland::{
         alpha_modifier::AlphaModifierState,
         compositor::{CompositorClientState, CompositorState, SurfaceData},
@@ -118,7 +118,7 @@ use std::{
     collections::HashSet,
     ffi::OsString,
     process::Child,
-    sync::{atomic::AtomicBool, Arc, Mutex, Once},
+    sync::{atomic::AtomicBool, Arc, Once},
     time::{Duration, Instant},
 };
 
@@ -729,19 +729,7 @@ impl Common {
             .iter()
             .filter(|seat| &seat.active_output() == output)
         {
-            let cursor_status = seat
-                .user_data()
-                .get::<Mutex<CursorImageStatus>>()
-                .map(|lock| {
-                    let mut cursor_status = lock.lock().unwrap();
-                    if let CursorImageStatus::Surface(ref surface) = *cursor_status {
-                        if !surface.alive() {
-                            *cursor_status = CursorImageStatus::default_named();
-                        }
-                    }
-                    cursor_status.clone()
-                })
-                .unwrap_or(CursorImageStatus::default_named());
+            let cursor_status = seat.cursor_image_status();
 
             // cursor ...
             if let CursorImageStatus::Surface(wl_surface) = cursor_status {
@@ -1021,19 +1009,7 @@ impl Common {
             .iter()
             .filter(|seat| &seat.active_output() == output)
         {
-            let cursor_status = seat
-                .user_data()
-                .get::<Mutex<CursorImageStatus>>()
-                .map(|lock| {
-                    let mut cursor_status = lock.lock().unwrap();
-                    if let CursorImageStatus::Surface(ref surface) = *cursor_status {
-                        if !surface.alive() {
-                            *cursor_status = CursorImageStatus::default_named();
-                        }
-                    }
-                    cursor_status.clone()
-                })
-                .unwrap_or(CursorImageStatus::default_named());
+            let cursor_status = seat.cursor_image_status();
 
             if let CursorImageStatus::Surface(wl_surface) = cursor_status {
                 send_frames_surface_tree(

--- a/src/state.rs
+++ b/src/state.rs
@@ -756,6 +756,10 @@ impl Common {
                     }
                 }
             }
+
+            if let Some(icon) = get_dnd_icon(seat) {
+                with_surfaces_surface_tree(&icon.surface, processor);
+            }
         }
 
         // sticky window

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,7 +12,7 @@ use crate::{
     shell::{grabs::SeatMoveGrabState, CosmicSurface, SeatExt, Shell},
     utils::prelude::OutputExt,
     wayland::{
-        handlers::screencopy::SessionHolder,
+        handlers::{data_device::get_dnd_icon, screencopy::SessionHolder},
         protocols::{
             a11y::A11yState,
             atspi::AtspiState,
@@ -1047,6 +1047,16 @@ impl Common {
                         window.send_frame(output, time, throttle(&window), should_send);
                     }
                 }
+            }
+
+            if let Some(icon) = get_dnd_icon(seat) {
+                send_frames_surface_tree(
+                    &icon.surface,
+                    output,
+                    time,
+                    Some(Duration::ZERO),
+                    should_send,
+                )
             }
         }
 

--- a/src/wayland/handlers/seat.rs
+++ b/src/wayland/handlers/seat.rs
@@ -4,12 +4,12 @@ use crate::{
     shell::focus::target::{KeyboardFocusTarget, PointerFocusTarget},
     shell::Devices,
     state::State,
+    utils::prelude::SeatExt,
 };
 use smithay::{
     delegate_cursor_shape, delegate_seat,
     input::{keyboard::LedState, pointer::CursorImageStatus, SeatHandler, SeatState},
 };
-use std::sync::Mutex;
 
 impl SeatHandler for State {
     type KeyboardFocus = KeyboardFocusTarget;
@@ -20,17 +20,8 @@ impl SeatHandler for State {
         &mut self.common.seat_state
     }
 
-    fn cursor_image(
-        &mut self,
-        seat: &smithay::input::Seat<Self>,
-        image: smithay::input::pointer::CursorImageStatus,
-    ) {
-        *seat
-            .user_data()
-            .get::<Mutex<CursorImageStatus>>()
-            .unwrap()
-            .lock()
-            .unwrap() = image;
+    fn cursor_image(&mut self, seat: &smithay::input::Seat<Self>, image: CursorImageStatus) {
+        seat.set_cursor_image_status(image);
     }
 
     fn focus_changed(


### PR DESCRIPTION
It would be nice if some of this code iterating over all surfaces could be shared (it's partly similar to `render_input_order`; but not exactly). But that isn't changed here.

(It would probably also be nice to avoid having to iterate through everything so often in so many places, if possible. No specific suggestions for that though.)

Perhaps `visible_output_for_surface` should also return multiple outputs, when a surfaces overlaps multiple. To queue redraws on every output that's overlapped.