### PR TITLE
WIP Inihibit logind power button behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ dependencies = [
  "egui",
  "egui_plot",
  "futures-executor",
+ "futures-util",
  "i18n-embed",
  "i18n-embed-fl",
  "iced_tiny_skia",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "cosmic-text",
  "egui",
  "egui_plot",
+ "futures-executor",
  "i18n-embed",
  "i18n-embed-fl",
  "iced_tiny_skia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ reis = { version = "0.5", features = ["calloop"] }
 clap_lex = "0.7"
 parking_lot = "0.12.3"
 futures-executor = { version = "0.3.31", features = ["thread-pool"] }
+futures-util = "0.3.31"
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ reis = { version = "0.5", features = ["calloop"] }
 # CLI arguments
 clap_lex = "0.7"
 parking_lot = "0.12.3"
+futures-executor = { version = "0.3.31", features = ["thread-pool"] }
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"

--- a/src/dbus/login1_manager.rs
+++ b/src/dbus/login1_manager.rs
@@ -1,0 +1,32 @@
+use zbus::{zvariant, Connection};
+
+#[zbus::proxy(
+    interface = "org.freedesktop.login1.Manager",
+    default_service = "org.freedesktop.login1",
+    default_path = "/org/freedesktop/login1"
+)]
+pub trait Login1Manager {
+    fn inhibit(
+        &self,
+        what: &str,
+        who: &str,
+        why: &str,
+        mode: &str,
+    ) -> zbus::Result<zvariant::OwnedFd>;
+}
+
+pub async fn inhibit_buttons() {
+    let conn = Connection::system().await.unwrap();
+    let manager = Login1ManagerProxy::new(&conn).await.unwrap();
+    // XXX
+    let pipe = manager
+        .inhibit(
+            "handle-power-key",
+            "cosmic",
+            "cosmic-comp handling power button",
+            "block",
+        )
+        .await
+        .unwrap();
+    std::mem::forget(pipe); // XXX
+}

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -1,15 +1,20 @@
 use crate::state::{BackendData, Common, State};
 use anyhow::{Context, Result};
 use calloop::{InsertError, LoopHandle, RegistrationToken};
+use futures_executor::{block_on, ThreadPool};
+use futures_util::stream::StreamExt;
 use std::collections::HashMap;
 use zbus::blocking::{fdo::DBusProxy, Connection};
 
 mod power;
 
-pub fn init(evlh: &LoopHandle<'static, State>) -> Result<Vec<RegistrationToken>> {
+pub fn init(
+    evlh: &LoopHandle<'static, State>,
+    executor: &ThreadPool,
+) -> Result<Vec<RegistrationToken>> {
     let mut tokens = Vec::new();
 
-    match power::init() {
+    match block_on(power::init()) {
         Ok(power_daemon) => {
             let (tx, rx) = calloop::channel::channel();
 
@@ -35,29 +40,17 @@ pub fn init(evlh: &LoopHandle<'static, State>) -> Result<Vec<RegistrationToken>>
                 .with_context(|| "Failed to add channel to event_loop")?;
 
             // start helper thread
-            let result = std::thread::Builder::new()
-                .name("system76-power-hotplug".to_string())
-                .spawn(move || {
-                    if let Ok(mut msg_iter) = power_daemon.receive_hot_plug_detect() {
-                        while let Some(msg) = msg_iter.next() {
-                            if tx.send(msg).is_err() {
-                                break;
-                            }
+            executor.spawn_ok(async move {
+                if let Ok(mut msg_iter) = power_daemon.receive_hot_plug_detect().await {
+                    while let Some(msg) = msg_iter.next().await {
+                        if tx.send(msg).is_err() {
+                            break;
                         }
                     }
-                })
-                .with_context(|| "Failed to start helper thread");
+                }
+            });
 
-            match result {
-                Ok(_handle) => {
-                    tokens.push(token);
-                    // detach thread
-                }
-                Err(err) => {
-                    evlh.remove(token);
-                    return Err(err);
-                }
-            }
+            tokens.push(token);
         }
         Err(err) => {
             tracing::info!(?err, "Failed to connect to com.system76.PowerDaemon");

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -6,6 +6,7 @@ use futures_util::stream::StreamExt;
 use std::collections::HashMap;
 use zbus::blocking::{fdo::DBusProxy, Connection};
 
+mod login1_manager;
 mod power;
 
 pub fn init(
@@ -13,6 +14,8 @@ pub fn init(
     executor: &ThreadPool,
 ) -> Result<Vec<RegistrationToken>> {
     let mut tokens = Vec::new();
+
+    executor.spawn_ok(login1_manager::inhibit_buttons());
 
     match block_on(power::init()) {
         Ok(power_daemon) => {

--- a/src/dbus/power.rs
+++ b/src/dbus/power.rs
@@ -18,7 +18,7 @@
 //!
 //! …consequently `zbus-xmlgen` did not generate code for the above interfaces.
 
-use zbus::blocking::Connection;
+use zbus::Connection;
 
 #[zbus::proxy(
     interface = "com.system76.PowerDaemon",
@@ -79,9 +79,9 @@ pub trait PowerDaemon {
     fn power_profile_switch(&self, profile: &str) -> zbus::Result<()>;
 }
 
-pub fn init() -> anyhow::Result<PowerDaemonProxyBlocking<'static>> {
-    let conn = Connection::system()?;
-    let proxy = PowerDaemonProxyBlocking::new(&conn)?;
-    proxy.0.introspect()?;
+pub async fn init() -> anyhow::Result<PowerDaemonProxy<'static>> {
+    let conn = Connection::system().await?;
+    let proxy = PowerDaemonProxy::new(&conn).await?;
+    proxy.0.introspect().await?;
     Ok(proxy)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -592,7 +592,9 @@ impl State {
         );
         let workspace_state = WorkspaceState::new(dh, client_is_privileged);
 
-        if let Err(err) = crate::dbus::init(&handle) {
+        let async_executor = ThreadPool::builder().pool_size(1).create().unwrap();
+
+        if let Err(err) = crate::dbus::init(&handle, &async_executor) {
             tracing::warn!(?err, "Failed to initialize dbus handlers");
         }
 
@@ -608,7 +610,7 @@ impl State {
                 display_handle: dh.clone(),
                 event_loop_handle: handle,
                 event_loop_signal: signal,
-                async_executor: ThreadPool::builder().pool_size(1).create().unwrap(),
+                async_executor,
 
                 popups: PopupManager::default(),
                 shell,

--- a/src/state.rs
+++ b/src/state.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 use anyhow::Context;
 use calloop::RegistrationToken;
+use futures_executor::ThreadPool;
 use i18n_embed::{
     fluent::{fluent_language_loader, FluentLanguageLoader},
     DesktopLanguageRequester,
@@ -193,6 +194,7 @@ pub struct Common {
     pub display_handle: DisplayHandle,
     pub event_loop_handle: LoopHandle<'static, State>,
     pub event_loop_signal: LoopSignal,
+    pub async_executor: ThreadPool,
 
     pub popups: PopupManager,
     pub shell: Arc<parking_lot::RwLock<Shell>>,
@@ -606,6 +608,7 @@ impl State {
                 display_handle: dh.clone(),
                 event_loop_handle: handle,
                 event_loop_signal: signal,
+                async_executor: ThreadPool::builder().pool_size(1).create().unwrap(),
 
                 popups: PopupManager::default(),
                 shell,


### PR DESCRIPTION
Gnome sets inhibitors in https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/blob/main/plugins/media-keys/gsd-media-keys-manager.c?ref_type=heads. But as long as we handle the bindings entirely in cosmic-comp, it makes sense to register inhibitors in the same place. This has some quick hacky code that works to inhibit just the power button.

I want to do a bit more to clean up how we handle zbus and futures in cosmic-comp. Which is also needed by https://github.com/pop-os/cosmic-comp/pull/1412. Using the calloop executor is probably ideal, but I've had issues with that in cosmic-workspaces (maybe that's all working after https://github.com/Smithay/calloop/pull/227?).

Since https://github.com/pop-os/cosmic-comp/pull/1465 and https://github.com/pop-os/cosmic-comp/pull/1466, I also see the shutdown dialog when waking from suspend with the power button. We need to do something to prevent that (I don't know if the button press is waking the system, but button release is then seen by the OS?)