### PR TITLE
protocols/workspace: Set ext workspace `id` for pinned workspace

### DIFF
--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -43,5 +43,6 @@ pub struct OutputMatch {
 pub struct PinnedWorkspace {
     pub output: OutputMatch,
     pub tiling_enabled: bool,
-    // TODO: name, id
+    pub id: Option<String>,
+    // TODO: name
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -400,8 +400,7 @@ fn create_workspace_from_pinned(
             } else {
                 TilingState::FloatingOnly
             },
-            // TODO Set id for persistent workspaces
-            None,
+            pinned.id.clone(),
         )
         .unwrap();
     state.add_workspace_state(&workspace_handle, WState::Pinned);

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -72,8 +72,7 @@ const FULLSCREEN_ANIMATION_DURATION: Duration = Duration::from_millis(200);
 
 // For stable workspace id, generate random 24-bit integer, as a hex string
 // Must be compared with existing workspaces work uniqueness.
-// TODO: Assign an id to any workspace that is pinned
-pub fn random_id() -> String {
+pub fn random_workspace_id() -> String {
     let id = rand::random_range(0..(2 << 24));
     format!("{:x}", id)
 }
@@ -106,6 +105,7 @@ pub struct Workspace {
     pub tiling_enabled: bool,
     pub fullscreen: Option<FullscreenSurface>,
     pub pinned: bool,
+    pub id: Option<String>,
 
     pub handle: WorkspaceHandle,
     pub focus_stack: FocusStacks,
@@ -362,6 +362,7 @@ impl Workspace {
             minimized_windows: Vec::new(),
             fullscreen: None,
             pinned: false,
+            id: None,
             handle,
             focus_stack: FocusStacks::default(),
             screencopy: ScreencopySessions::default(),
@@ -393,6 +394,7 @@ impl Workspace {
             minimized_windows: Vec::new(),
             fullscreen: None,
             pinned: true,
+            id: pinned.id.clone(),
             handle,
             focus_stack: FocusStacks::default(),
             screencopy: ScreencopySessions::default(),
@@ -410,6 +412,7 @@ impl Workspace {
     }
 
     pub fn to_pinned(&self) -> Option<PinnedWorkspace> {
+        debug_assert!(self.id.is_some());
         let output = self.explicit_output().clone();
         if self.pinned {
             Some(PinnedWorkspace {
@@ -418,6 +421,7 @@ impl Workspace {
                     edid: output.edid,
                 },
                 tiling_enabled: self.tiling_enabled,
+                id: self.id.clone(),
             })
         } else {
             None

--- a/src/wayland/handlers/workspace.rs
+++ b/src/wayland/handlers/workspace.rs
@@ -61,6 +61,13 @@ impl WorkspaceHandler for State {
                         workspace.pinned = pinned;
                         let mut update = self.common.workspace_state.update();
                         if pinned {
+                            if workspace.id.is_none() {
+                                let id = crate::shell::random_workspace_id();
+                                update
+                                    .set_id(&workspace.handle, &id)
+                                    .expect("workspace already has id");
+                                workspace.id = Some(id);
+                            }
                             update.add_workspace_state(&workspace.handle, WState::Pinned);
                             // TODO: Also need to update on changing other properties that are saved
                             shell.workspaces.persist(&self.common.config);

--- a/src/wayland/protocols/workspace/ext.rs
+++ b/src/wayland/protocols/workspace/ext.rs
@@ -51,6 +51,7 @@ pub struct WorkspaceDataInner {
     capabilities: Option<ext_workspace_handle_v1::WorkspaceCapabilities>,
     coordinates: Vec<u32>,
     states: Option<ext_workspace_handle_v1::State>,
+    ext_id: Option<String>,
     pub(super) cosmic_v2_handle: Option<Weak<ZcosmicWorkspaceHandleV2>>,
 }
 
@@ -404,9 +405,6 @@ where
                     },
                 ) {
                     mngr.workspace(&handle);
-                    if let Some(id) = workspace.ext_id.clone() {
-                        handle.id(id);
-                    }
                     workspace.ext_instances.push(handle);
                     workspace.ext_instances.last_mut().unwrap()
                 } else {
@@ -492,8 +490,12 @@ where
         handle_state.states = Some(states);
         changed = true;
     }
-    // TODO ext_workspace_handle_v1::id
-    // TODO send id if pinned
+
+    if handle_state.ext_id.is_none() {
+        if let Some(id) = workspace.ext_id.clone() {
+            instance.id(id);
+        }
+    }
 
     if let Some(cosmic_v2_handle) = handle_state
         .cosmic_v2_handle


### PR DESCRIPTION
The `id` is defined to be sent only once, on creation of the handle or later. And only for workspaces that are "likely to be stable across multiple sessions".

Set we add an `id` initially for pinned workspaces, and add one when the workspace is pinned.

The `id` is not supposed to be human readable, so we just use a random value.

I don't think we currently have any plans that would need this feature, but this will allow scripts to recognize that a pinned workspace is the same as a workspace from a previous session, and do things like move a certain application to that workspace.

We'll need to update clients with https://github.com/pop-os/cosmic-protocols/pull/62 before merging this.