### PR TITLE
kms: Do not attempt to import dmabuf on device not supporting format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,7 +4732,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=3017967#30179679619a317cd0f5a5d6496332fd3adcaba6"
+source = "git+https://github.com/smithay/smithay.git?rev=aaa1966#aaa19668d31cbc9d73561dc0ea8423fc41574d6c"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,4 +124,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "3017967" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "aaa1966" }

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -16,6 +16,7 @@ use smithay::{
         allocator::{
             dmabuf::Dmabuf,
             gbm::{GbmAllocator, GbmBufferFlags},
+            Buffer,
         },
         drm::{output::DrmOutputRenderElements, DrmDeviceFd, DrmNode, NodeType},
         egl::{context::ContextPriority, EGLContext, EGLDevice, EGLDisplay},
@@ -455,6 +456,17 @@ impl KmsState {
                 _egl = Some(init_egl(&device.gbm).context("Failed to initialize egl context")?);
                 &_egl.as_ref().unwrap().display
             };
+
+            if !egl_display
+                .dmabuf_texture_formats()
+                .contains(&dmabuf.format())
+            {
+                trace!(
+                    "Skipping import of dmabuf on {:?}: unsupported format",
+                    device.render_node
+                );
+                continue;
+            }
 
             let result = egl_display
                 .create_image_from_dmabuf(&dmabuf)


### PR DESCRIPTION
Previously, if `expected_node` couldn't import a buffer, it would print an error, then try the next node. There shouldn't really be a reason to attempt import if the format/modifier isn't in `dmabuf_texture_formats`.

It seems the issue I've been seeing with cosmic-workspaces crashing the Nvidia driver is fixed by removing this, and disabling `dma_shadow_copy` (which was producing the same error). Importing Nvidia buffers on the AMD GPU seems to be causing issues.

Not sure how `dma_shadow_copy` should be fixed, but a test for supported formats is easy to add here anyway.