### PR TITLE
screencopy: Fix damage tracking bug with shm screencopy of output

### DIFF
--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -39,7 +39,7 @@ use smithay::{
         },
         egl::EGLContext,
         renderer::{
-            buffer_dimensions,
+            buffer_dimensions, buffer_type,
             damage::Error as RenderError,
             element::{
                 texture::TextureRenderElement,
@@ -56,7 +56,7 @@ use smithay::{
             multigpu::{ApiDevice, Error as MultiError, GpuManager},
             sync::SyncPoint,
             utils::with_renderer_surface_state,
-            Bind, Blit, Frame, ImportDma, Offscreen, Renderer, RendererSuper, Texture,
+            Bind, Blit, BufferType, Frame, ImportDma, Offscreen, Renderer, RendererSuper, Texture,
             TextureFilter,
         },
     },
@@ -1617,7 +1617,12 @@ fn take_screencopy_frames(
             };
 
             let buffer = frame.buffer();
-            let age = damage_tracking.age_for_buffer(&buffer);
+            let age = if matches!(buffer_type(&frame.buffer()), Some(BufferType::Shm)) {
+                // TODO re-use offscreen buffer to damage track screencopy to shm
+                0
+            } else {
+                damage_tracking.age_for_buffer(&buffer)
+            };
             let res = damage_tracking.dt.damage_output(age, &elements);
 
             if let Some(old_len) = old_len {

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -172,7 +172,12 @@ where
         })
         .transpose()?;
 
-    let age = session_damage_tracking.age_for_buffer(&buffer);
+    let age = if offscreen.is_some() {
+        // TODO re-use offscreen buffer to damage track screencopy to shm
+        0
+    } else {
+        session_damage_tracking.age_for_buffer(&buffer)
+    };
     let mut fb = offscreen
         .as_mut()
         .map(|tex| renderer.bind(tex).map_err(DTError::Rendering))
@@ -242,7 +247,7 @@ pub fn render_workspace_to_buffer(
         renderer: &mut R,
         offscreen: Option<&mut R::Framebuffer<'_>>,
         dt: &'d mut OutputDamageTracker,
-        mut age: usize,
+        age: usize,
         additional_damage: Vec<Rectangle<i32, BufferCoords>>,
         draw_cursor: bool,
         common: &mut Common,
@@ -311,7 +316,6 @@ pub fn render_workspace_to_buffer(
             .map(|res| res.0)
         } else {
             let target = offscreen.expect("shm buffers should have an offscreen target");
-            age = 0;
             render_workspace(
                 None,
                 renderer,


### PR DESCRIPTION
Similar to the change in https://github.com/pop-os/cosmic-comp/pull/780, but also updates it to be a little clearer than just an uncommented `age = 0` line.

Ideally we want some robust system to re-use the offscreen buffer (but not allocate more buffers indefinitely if the client doesn't capture with the same `wl_buffer`).