### PR TITLE
Fix workspace key bindings in workspace span outputs mode; activate workspace when it is migrated to an output

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -539,7 +539,7 @@ impl State {
                         res
                     };
 
-                    if let Ok(Some(new_pos)) = res {
+                    if let Ok(new_pos) = res {
                         let workspace = shell.workspaces.active(&next_output).unwrap().1;
                         let new_target = workspace
                             .focus_stack
@@ -1080,7 +1080,7 @@ fn to_next_workspace(
     seat: &Seat<State>,
     gesture: bool,
     workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
-) -> Result<Option<Point<i32, Global>>, InvalidWorkspaceIndex> {
+) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
     let current_output = seat.active_output();
     let workspace = shell
         .workspaces
@@ -1106,7 +1106,7 @@ fn to_previous_workspace(
     seat: &Seat<State>,
     gesture: bool,
     workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
-) -> Result<Option<Point<i32, Global>>, InvalidWorkspaceIndex> {
+) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
     let current_output = seat.active_output();
     let workspace = shell
         .workspaces

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1512,7 +1512,7 @@ impl Shell {
         idx: usize,
         workspace_delta: WorkspaceDelta,
         workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
-    ) -> Result<Option<Point<i32, Global>>, InvalidWorkspaceIndex> {
+    ) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
         match &mut self.workspaces.mode {
             WorkspaceMode::OutputBound => {
                 if let Some(set) = self.workspaces.sets.get_mut(output) {
@@ -1525,12 +1525,12 @@ impl Shell {
                     set.activate(idx, workspace_delta, workspace_state)?;
 
                     let output_geo = output.geometry();
-                    Ok(Some(
+                    Ok(
                         output_geo.loc
                             + Point::from((output_geo.size.w / 2, output_geo.size.h / 2)),
-                    ))
+                    )
                 } else {
-                    Ok(None)
+                    Err(InvalidWorkspaceIndex)
                 }
             }
             WorkspaceMode::Global => {
@@ -1538,9 +1538,7 @@ impl Shell {
                     set.activate(idx, workspace_delta, workspace_state)?;
                 }
                 let output_geo = output.geometry();
-                Ok(Some(
-                    output_geo.loc + Point::from((output_geo.size.w / 2, output_geo.size.h / 2)),
-                ))
+                Ok(output_geo.loc + Point::from((output_geo.size.w / 2, output_geo.size.h / 2)))
             }
         }
     }
@@ -1565,7 +1563,7 @@ impl Shell {
         output: &Output,
         velocity: f64,
         workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
-    ) -> Result<Option<Point<i32, Global>>, InvalidWorkspaceIndex> {
+    ) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
         match &mut self.workspaces.mode {
             WorkspaceMode::OutputBound => {
                 if let Some(set) = self.workspaces.sets.get_mut(output) {
@@ -1605,12 +1603,12 @@ impl Shell {
                     }
 
                     let output_geo = output.geometry();
-                    Ok(Some(
+                    Ok(
                         output_geo.loc
                             + Point::from((output_geo.size.w / 2, output_geo.size.h / 2)),
-                    ))
+                    )
                 } else {
-                    Ok(None)
+                    Err(InvalidWorkspaceIndex)
                 }
             }
             WorkspaceMode::Global => {
@@ -1644,7 +1642,7 @@ impl Shell {
                         }
                     }
                 }
-                Ok(None)
+                Err(InvalidWorkspaceIndex)
             }
         }
     }
@@ -2942,7 +2940,7 @@ impl Shell {
                                 WorkspaceDelta::new_shortcut(),
                                 workspace_state,
                             )
-                            .unwrap()
+                            .ok()
                         })
                 } else {
                     None
@@ -3099,7 +3097,7 @@ impl Shell {
                         WorkspaceDelta::new_shortcut(),
                         workspace_state,
                     )
-                    .unwrap()
+                    .ok()
                 })
         } else {
             None
@@ -3209,7 +3207,7 @@ impl Shell {
                         WorkspaceDelta::new_shortcut(),
                         workspace_state,
                     )
-                    .unwrap()
+                    .ok()
                 })
         } else {
             None

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -878,14 +878,14 @@ impl Workspaces {
     }
 
     // Move workspace from one output to another, explicitly by the user
-    fn migrate_workspace(
+    pub fn migrate_workspace(
         &mut self,
         from: &Output,
         to: &Output,
         handle: &WorkspaceHandle,
         workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
     ) {
-        if !self.sets.contains_key(to) {
+        if !self.sets.contains_key(to) || from == to {
             return;
         }
 
@@ -1352,19 +1352,6 @@ impl Common {
 
         std::mem::drop(shell);
         self.refresh(); // cleans up excess of workspaces and empty workspaces
-    }
-
-    pub fn migrate_workspace(&mut self, from: &Output, to: &Output, handle: &WorkspaceHandle) {
-        if from == to {
-            return;
-        }
-
-        let mut shell = self.shell.write();
-        shell
-            .workspaces
-            .migrate_workspace(from, to, handle, &mut self.workspace_state.update());
-
-        std::mem::drop(shell);
     }
 
     pub fn update_config(&mut self) {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1537,7 +1537,10 @@ impl Shell {
                 for set in self.workspaces.sets.values_mut() {
                     set.activate(idx, workspace_delta, workspace_state)?;
                 }
-                Ok(None)
+                let output_geo = output.geometry();
+                Ok(Some(
+                    output_geo.loc + Point::from((output_geo.size.w / 2, output_geo.size.h / 2)),
+                ))
             }
         }
     }

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -90,7 +90,7 @@ impl ToplevelManagementHandler for State {
 
                 if seat.active_output() != *output {
                     match res {
-                        Ok(Some(new_pos)) => {
+                        Ok(new_pos) => {
                             seat.set_active_output(&output);
                             if let Some(ptr) = seat.get_pointer() {
                                 let serial = SERIAL_COUNTER.next_serial();
@@ -105,9 +105,6 @@ impl ToplevelManagementHandler for State {
                                 );
                                 ptr.frame(self);
                             }
-                        }
-                        Ok(None) => {
-                            seat.set_active_output(&output);
                         }
                         _ => {}
                     }


### PR DESCRIPTION
The first change here seems to fix the issue described in https://github.com/pop-os/cosmic-workspaces-epoch/issues/95. Not sure if there are more keybinding-related issues with workspaces span outputs mode (there are some other sorts of issues that still need to be addressed).