### PR TITLE
kms: Don't use more then 10-bit by default

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -839,7 +839,7 @@ fn populate_modes(
     position: (u32, u32),
 ) -> Result<()> {
     let conn_info = drm.get_connector(conn, false)?;
-    let max_bpc = drm_helpers::get_max_bpc(drm, conn)?.map(|(_val, range)| range.end.min(16));
+    let max_bpc = drm_helpers::get_max_bpc(drm, conn)?.map(|(_val, range)| range.end.min(10));
     let Some(mode) = conn_info
         .modes()
         .iter()


### PR DESCRIPTION
Draft because I am not sure this actually fixes anything and will be more annoying to deal with, once we might actually want to scanout XRGB16161616 with HDR content.

But there isn't really any reason this is necessary currently, we never use a format with more than 10-bits, and this might run into bandwidth issues otherwise, which currently require manual edits of `outputs.ron`.

We possibly want to tie this to the selected format in the future and downgrade step-by-step both the format and requested max_bpc, if we get atomic-commit errors.