### PR TITLE
grabs/moving: cleanup drag in tiling layer if window doesn't exist

### DIFF
--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -783,6 +783,7 @@ impl Drop for MoveGrab {
         let previous = self.previous.clone();
         let window = self.window.clone();
         let is_touch_grab = matches!(self.start_data, GrabStartData::Touch(_));
+        let cursor_output = self.cursor_output.clone();
 
         let _ = self.evlh.0.insert_idle(move |state| {
             let position: Option<(CosmicMapped, Point<i32, Global>)> = if let Some(grab_state) =
@@ -886,6 +887,14 @@ impl Drop for MoveGrab {
                         }
                     }
                 } else {
+                    let mut shell = state.common.shell.write();
+                    shell
+                        .workspaces
+                        .active_mut(&cursor_output)
+                        .unwrap()
+                        .tiling_layer
+                        .cleanup_drag();
+                    shell.set_overview_mode(None, state.common.event_loop_handle.clone());
                     None
                 }
             } else {


### PR DESCRIPTION
It looks like https://github.com/pop-os/cosmic-comp/issues/1475 isn't happening after this, but I need to test a bit more since it's a little hard to reproduce consistently.

This is also meant to fix an issue that can be seen by closing a window (for instance `exit` in cosmic-term, or super+q) while dragging it still leaving a placeholder in the tiling layout. I'm still not entirely sure why that wasn't causing a crash, but dbeaver was.

This may not be exactly the right way to fix this. I've also noticed an issue where if an output doesn't have any windows, a placeholder isn't created when dragging a window to that output.