### PR TITLE
floating/resize: Don't panic if something else cancelled the resize

### DIFF
--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -31,6 +31,7 @@ use smithay::{
     output::Output,
     utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
 };
+use tracing::debug;
 
 /// Information about the resize operation.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -582,7 +583,7 @@ impl ResizeSurfaceGrab {
         if let Some(ResizeState::Resizing(resize_data)) = *resize_state {
             *resize_state = Some(ResizeState::WaitingForCommit(resize_data));
         } else {
-            panic!("invalid resize state: {:?}", resize_state);
+            debug!("unexpected resize state: {:?}", resize_state);
         }
     }
 }


### PR DESCRIPTION
Fixes crashes like https://github.com/pop-os/cosmic-comp/issues/1526, though I am not sure, what the result of this case will be as Steam resizes perfectly fine on my system with current master.

However I was able to trigger this by starting a resize grab and then also resizing via shortcuts without releasing the pointer. Then on ungrab the `ResizeState` would already have been cleaned up by the shortcut resize.

This is a very constructed scenario where I am not sure what the user would expect anyhow, but we shouldn't crash.