### PR TITLE
Update dependencies and migrate to Rust 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
  "cosmic-protocols",
  "cosmic-settings-config",
  "cosmic-text",
- "egui 0.32.0",
+ "egui",
  "egui_plot",
  "i18n-embed",
  "i18n-embed-fl",
@@ -1340,16 +1340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
- "emath 0.31.1",
-]
-
-[[package]]
-name = "ecolor"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a631732d995184114016fab22fc7e3faf73d6841c2d7650395fe251fbcd9285"
-dependencies = [
- "emath 0.32.0",
+ "emath",
 ]
 
 [[package]]
@@ -1360,26 +1351,10 @@ checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
 dependencies = [
  "ahash",
  "bitflags 2.9.1",
- "emath 0.31.1",
- "epaint 0.31.1",
+ "emath",
+ "epaint",
  "nohash-hasher",
  "profiling",
-]
-
-[[package]]
-name = "egui"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8470210c95a42cc985d9ffebfd5067eea55bdb1c3f7611484907db9639675e28"
-dependencies = [
- "ahash",
- "bitflags 2.9.1",
- "emath 0.32.0",
- "epaint 0.32.0",
- "nohash-hasher",
- "profiling",
- "smallvec",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1389,7 +1364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624659a2e972a46f4d5f646557906c55f1cd5a0836eddbe610fdf1afba1b4226"
 dependencies = [
  "ahash",
- "egui 0.31.1",
+ "egui",
  "enum-map",
  "log",
  "mime_guess2",
@@ -1405,7 +1380,7 @@ checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
 dependencies = [
  "ahash",
  "bytemuck",
- "egui 0.31.1",
+ "egui",
  "glow 0.16.0",
  "log",
  "memoffset",
@@ -1416,13 +1391,13 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.33.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524318041a8ea90c81c738e8985f8ad9e3f9bed636b03c2ff37b218113ed5121"
+checksum = "1794c66fb727dac28dffed2e4b548e5118d1cccc331d368a35411d68725dde71"
 dependencies = [
  "ahash",
- "egui 0.32.0",
- "emath 0.32.0",
+ "egui",
+ "emath",
 ]
 
 [[package]]
@@ -1433,12 +1408,6 @@ checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "emath"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f057b141e7e46340c321400be74b793543b1b213036f0f989c35d35957c32e"
 
 [[package]]
 name = "encoding_rs"
@@ -1506,25 +1475,9 @@ dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor 0.31.1",
- "emath 0.31.1",
- "epaint_default_fonts 0.31.1",
- "nohash-hasher",
- "parking_lot 0.12.4",
- "profiling",
-]
-
-[[package]]
-name = "epaint"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cca02195f0552c17cabdc02f39aa9ab6fbd815dac60ab1cd3d5b0aa6f9551c"
-dependencies = [
- "ab_glyph",
- "ahash",
- "ecolor 0.32.0",
- "emath 0.32.0",
- "epaint_default_fonts 0.32.0",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
  "nohash-hasher",
  "parking_lot 0.12.4",
  "profiling",
@@ -1535,12 +1488,6 @@ name = "epaint_default_fonts"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
-
-[[package]]
-name = "epaint_default_fonts"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8495e11ed527dff39663b8c36b6c2b2799d7e4287fb90556e455d72eca0b4d3"
 
 [[package]]
 name = "equivalent"
@@ -4904,7 +4851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6794c95b83518f9f91ae8c2faee52302d521c0d541d016b4ed632374041d9c42"
 dependencies = [
  "cgmath",
- "egui 0.31.1",
+ "egui",
  "egui_extras",
  "egui_glow",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
+checksum = "e074464580a518d16a7126262fffaaa47af89d4099d4cb403f8ed938ba12ee7d"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "ab_glyph_rasterizer"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
+checksum = "b2187590a23ab1e3df8681afdf0987c48504d80291f002fcdb651f0ef5e25169"
 
 [[package]]
 name = "addr2line"
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -232,10 +232,9 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -251,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
  "async-io",
@@ -264,8 +263,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 0.38.44",
- "tracing",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -276,14 +274,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -291,10 +289,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -311,7 +309,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -345,14 +343,14 @@ dependencies = [
  "derive_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -446,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -459,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "by_address"
@@ -471,22 +469,22 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -543,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -560,9 +558,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34e221e91c7eb5e8315b5c9cf1a61670938c0626451f954a51693ed44b37f45"
+checksum = "0d0390889d58f934f01cd49736275b4c2da15bcfc328c78ff2349907e6cabf22"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -570,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -613,15 +611,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clipboard-win"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
@@ -803,7 +801,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#1425bd44ed2b318a552201cc752ae11f2f483ef5"
+source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#4f053317cc9a0e776bc24610df91ff84dfd6cc7b"
 dependencies = [
  "bitflags 2.9.1",
  "cosmic-protocols",
@@ -827,31 +825,29 @@ dependencies = [
  "cosmic-protocols",
  "cosmic-settings-config",
  "cosmic-text",
- "egui",
+ "egui 0.32.0",
  "egui_plot",
  "i18n-embed",
  "i18n-embed-fl",
  "iced_tiny_skia",
  "id_tree",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "keyframe",
- "lazy_static",
  "libc",
  "libcosmic",
  "libdisplay-info",
  "libsystemd",
  "log-panics",
- "once_cell",
  "ordered-float",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "png",
  "profiling",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "reis",
- "ron",
+ "ron 0.10.1",
  "rust-embed",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "sanitize-filename",
  "sendfd",
  "serde",
@@ -865,11 +861,11 @@ dependencies = [
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
- "tracy-client 0.18.0",
+ "tracy-client",
  "wayland-backend",
  "wayland-scanner",
  "xcursor",
- "xdg",
+ "xdg 3.0.0",
  "xdg-user",
  "xkbcommon 0.8.0",
  "zbus",
@@ -888,7 +884,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "atomicwrites",
  "calloop 0.14.2",
@@ -898,19 +894,19 @@ dependencies = [
  "known-folders",
  "notify",
  "once_cell",
- "ron",
+ "ron 0.9.0",
  "serde",
  "tracing",
- "xdg",
+ "xdg 2.5.2",
 ]
 
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -920,16 +916,16 @@ source = "git+https://github.com/pop-os/freedesktop-icons#8a05c322c482ff3c69cf34
 dependencies = [
  "dirs 5.0.1",
  "ini_core",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "thiserror 2.0.12",
  "tracing",
- "xdg",
+ "xdg 2.5.2",
 ]
 
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#1425bd44ed2b318a552201cc752ae11f2f483ef5"
+source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#4f053317cc9a0e776bc24610df91ff84dfd6cc7b"
 dependencies = [
  "bitflags 2.9.1",
  "wayland-backend",
@@ -943,10 +939,10 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#54b4418e1e7757d965166ae9dc00c522aebf4451"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon#a36683fd5b7dea4011da278c91d0645117dc39f8"
 dependencies = [
  "cosmic-config",
- "ron",
+ "ron 0.9.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -957,7 +953,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#bcfb05a3909b04f76aa954058d06939535010dcb"
+source = "git+https://github.com/pop-os/cosmic-text.git#7646989d6f5b0d2bfe32a123e10fe13693d7c89c"
 dependencies = [
  "bitflags 2.9.1",
  "fontdb 0.23.0",
@@ -965,7 +961,7 @@ dependencies = [
  "rangemap",
  "rustc-hash 1.1.0",
  "rustybuzz",
- "self_cell 1.2.0",
+ "self_cell",
  "smol_str",
  "swash",
  "sys-locale",
@@ -979,7 +975,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -987,7 +983,7 @@ dependencies = [
  "dirs 6.0.0",
  "lazy_static",
  "palette",
- "ron",
+ "ron 0.9.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1004,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1019,9 +1015,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1041,9 +1037,9 @@ checksum = "42aaeae719fd78ce501d77c6cdf01f7e96f26bcd5617a4903a1c2b97e388543a"
 
 [[package]]
 name = "csscolorparser"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148247664b27bf6bf5041b46cf1e8c4872f70e75e3281348deb88abd75c915ab"
+checksum = "5fda6aace1fbef3aa217b27f4c8d7d071ef2a70a5ca51050b1f17d40299d3f16"
 dependencies = [
  "phf",
  "serde",
@@ -1093,7 +1089,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1104,7 +1100,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1125,14 +1121,14 @@ dependencies = [
 
 [[package]]
 name = "derive_setters"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c848e86c87e5cc305313041c5677d4d95d60baa71cf95e5f6ea2554bb629ff"
+checksum = "ae5c625eda104c228c06ecaf988d1c60e542176bd7a490e60eeda3493244c0c9"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1143,7 +1139,7 @@ checksum = "ccfae181bab5ab6c5478b2ccb69e4c68a02f8c3ec72f6616bfec9dbc599d2ee0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1196,7 +1192,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1213,7 +1209,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1332,13 +1328,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "ecolor"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
- "emath",
+ "emath 0.31.1",
+]
+
+[[package]]
+name = "ecolor"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a631732d995184114016fab22fc7e3faf73d6841c2d7650395fe251fbcd9285"
+dependencies = [
+ "emath 0.32.0",
 ]
 
 [[package]]
@@ -1349,10 +1360,26 @@ checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
 dependencies = [
  "ahash",
  "bitflags 2.9.1",
- "emath",
- "epaint",
+ "emath 0.31.1",
+ "epaint 0.31.1",
  "nohash-hasher",
  "profiling",
+]
+
+[[package]]
+name = "egui"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8470210c95a42cc985d9ffebfd5067eea55bdb1c3f7611484907db9639675e28"
+dependencies = [
+ "ahash",
+ "bitflags 2.9.1",
+ "emath 0.32.0",
+ "epaint 0.32.0",
+ "nohash-hasher",
+ "profiling",
+ "smallvec",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1362,7 +1389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624659a2e972a46f4d5f646557906c55f1cd5a0836eddbe610fdf1afba1b4226"
 dependencies = [
  "ahash",
- "egui",
+ "egui 0.31.1",
  "enum-map",
  "log",
  "mime_guess2",
@@ -1378,7 +1405,7 @@ checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
 dependencies = [
  "ahash",
  "bytemuck",
- "egui",
+ "egui 0.31.1",
  "glow 0.16.0",
  "log",
  "memoffset",
@@ -1389,13 +1416,13 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1794c66fb727dac28dffed2e4b548e5118d1cccc331d368a35411d68725dde71"
+checksum = "524318041a8ea90c81c738e8985f8ad9e3f9bed636b03c2ff37b218113ed5121"
 dependencies = [
  "ahash",
- "egui",
- "emath",
+ "egui 0.32.0",
+ "emath 0.32.0",
 ]
 
 [[package]]
@@ -1406,6 +1433,12 @@ checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "emath"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f057b141e7e46340c321400be74b793543b1b213036f0f989c35d35957c32e"
 
 [[package]]
 name = "encoding_rs"
@@ -1440,14 +1473,14 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -1455,13 +1488,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1473,11 +1506,27 @@ dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor",
- "emath",
- "epaint_default_fonts",
+ "ecolor 0.31.1",
+ "emath 0.31.1",
+ "epaint_default_fonts 0.31.1",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
+ "profiling",
+]
+
+[[package]]
+name = "epaint"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94cca02195f0552c17cabdc02f39aa9ab6fbd815dac60ab1cd3d5b0aa6f9551c"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "ecolor 0.32.0",
+ "emath 0.32.0",
+ "epaint_default_fonts 0.32.0",
+ "nohash-hasher",
+ "parking_lot 0.12.4",
  "profiling",
 ]
 
@@ -1488,6 +1537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
+name = "epaint_default_fonts"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8495e11ed527dff39663b8c36b6c2b2799d7e4287fb90556e455d72eca0b4d3"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,12 +1550,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1571,18 +1626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "find-crate"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1615,9 +1658,9 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluent"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
 dependencies = [
  "fluent-bundle",
  "unic-langid",
@@ -1625,16 +1668,16 @@ dependencies = [
 
 [[package]]
 name = "fluent-bundle"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
 dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
+ "rustc-hash 2.1.1",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -1650,11 +1693,12 @@ dependencies = [
 
 [[package]]
 name = "fluent-syntax"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
- "thiserror 1.0.69",
+ "memchr",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1695,7 +1739,7 @@ checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "slotmap",
  "tinyvec",
  "ttf-parser 0.21.1",
@@ -1709,7 +1753,7 @@ checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "slotmap",
  "tinyvec",
  "ttf-parser 0.25.1",
@@ -1733,7 +1777,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1830,7 +1874,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1896,7 +1940,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows 0.61.1",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -1927,7 +1971,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1944,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2042,13 +2086,13 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf29e94d6d243368b7a56caa16bc213e4f9f8ed38c4d9557069527b5d5281ca"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags 2.9.1",
  "gpu-descriptor-types",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -2094,9 +2138,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "foldhash",
 ]
@@ -2136,9 +2180,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2172,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-config"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e88074831c0be5b89181b05e6748c4915f77769ecc9a4c372f88b169a8509c9"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
 dependencies = [
  "basic-toml",
  "log",
@@ -2186,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
 dependencies = [
  "arc-swap",
  "fluent",
@@ -2196,10 +2240,10 @@ dependencies = [
  "fluent-syntax",
  "i18n-embed-impl",
  "intl-memoizer",
- "locale_config",
  "log",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "rust-embed",
+ "sys-locale",
  "thiserror 1.0.69",
  "unic-langid",
  "walkdir",
@@ -2207,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed-fl"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+checksum = "e598ed73b67db92f61e04672e599eef2991a262a40e1666735b8a86d2e7e9f30"
 dependencies = [
  "find-crate",
  "fluent",
@@ -2220,7 +2264,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unic-langid",
 ]
 
@@ -2234,7 +2278,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2264,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2280,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -2303,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "futures",
  "iced_core",
@@ -2328,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -2350,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2362,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "bytes",
  "dnd",
@@ -2376,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2392,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.9.1",
@@ -2423,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2592,12 +2636,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -2728,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -2844,14 +2888,14 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic/#a85b3693994ef2b8275eca6a9eccc86a2d7e9f86"
+source = "git+https://github.com/pop-os/libcosmic/#7748e59ae6576d93fc8b9594b1e159682e8ab844"
 dependencies = [
  "apply",
  "auto_enums",
@@ -2903,7 +2947,7 @@ checksum = "ea1cd31036b732a546d845f9485c56b1b606b5e476b0821c680dd66c8cd6fcee"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2918,12 +2962,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2934,13 +2978,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.14",
 ]
 
 [[package]]
@@ -3022,23 +3066,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
-name = "locale_config"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
-dependencies = [
- "lazy_static",
- "objc",
- "objc-foundation",
- "regex",
- "winapi",
-]
-
-[[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -3151,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -3166,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -3225,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3241,14 +3272,14 @@ checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3269,7 +3300,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
@@ -3360,12 +3391,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
  "bitflags 2.9.1",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3374,7 +3404,7 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3411,33 +3441,34 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3751,7 +3782,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3791,7 +3822,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3813,12 +3844,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -3837,13 +3868,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.14",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3890,7 +3921,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unicase",
 ]
 
@@ -3927,7 +3958,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3992,17 +4023,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 0.38.44",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4063,7 +4093,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4083,29 +4113,29 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 dependencies = [
  "profiling-procmacros",
- "tracy-client 0.17.6",
+ "tracy-client",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4128,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -4143,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
@@ -4202,9 +4232,9 @@ checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
 
 [[package]]
 name = "read-fonts"
-version = "0.29.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e85935612710191461ec9df47b4b5880dd6359d4fad3b2f2ed696215f6f3146"
+checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -4230,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4257,6 +4287,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4351,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 dependencies = [
  "bytemuck",
 ]
@@ -4363,6 +4413,19 @@ name = "ron"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.9.1",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ron"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -4403,7 +4466,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.101",
+ "syn 2.0.104",
  "walkdir",
 ]
 
@@ -4419,9 +4482,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -4450,15 +4513,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4509,6 +4572,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,15 +4606,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.2.0",
-]
 
 [[package]]
 name = "self_cell"
@@ -4567,16 +4645,16 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -4591,29 +4669,31 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4623,14 +4703,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4697,9 +4777,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
-version = "0.31.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c3bb8cab5196b98d70c866ce1ea81ab516104d5b396f84ae80f8766b5d5b4e"
+checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -4707,12 +4787,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "slotmap"
@@ -4725,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smithay"
@@ -4752,7 +4829,7 @@ dependencies = [
  "gbm",
  "gl_generator",
  "glow 0.16.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "input",
  "libc",
  "libloading",
@@ -4760,8 +4837,8 @@ dependencies = [
  "pixman",
  "pkg-config",
  "profiling",
- "rand 0.9.1",
- "rustix 1.0.7",
+ "rand 0.9.2",
+ "rustix 1.0.8",
  "scopeguard",
  "sha2",
  "smallvec",
@@ -4794,7 +4871,7 @@ dependencies = [
  "cursor-icon",
  "libc",
  "log",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "pkg-config",
  "rustix 0.38.44",
  "thiserror 1.0.69",
@@ -4827,7 +4904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6794c95b83518f9f91ae8c2faee52302d521c0d541d016b4ed632374041d9c42"
 dependencies = [
  "cgmath",
- "egui",
+ "egui 0.31.1",
  "egui_extras",
  "egui_glow",
  "image",
@@ -4867,7 +4944,7 @@ dependencies = [
  "foreign-types",
  "js-sys",
  "log",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "objc",
  "raw-window-handle",
  "redox_syscall 0.4.1",
@@ -4952,9 +5029,9 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dce3f0af95643c855cdc449fbaa17d8c2cd08e0b00a49a6babcbe6e71667f3d"
+checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
 dependencies = [
  "skrifa",
  "yazi",
@@ -4974,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4991,7 +5068,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5012,7 +5089,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.8.22",
+ "toml 0.8.23",
  "version-compare",
 ]
 
@@ -5042,7 +5119,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -5081,7 +5158,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5092,17 +5169,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -5213,9 +5289,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -5225,20 +5301,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5259,20 +5335,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5320,20 +5396,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.17.6"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73202d787346a5418f8222eddb5a00f29ea47caf3c7d38a8f2f69f8455fa7c7e"
-dependencies = [
- "loom",
- "once_cell",
- "tracy-client-sys",
-]
-
-[[package]]
-name = "tracy-client"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
+checksum = "ef54005d3d760186fd662dad4b7bb27ecd5531cdef54d1573ebd3f20a9205ed7"
 dependencies = [
  "loom",
  "once_cell",
@@ -5342,9 +5407,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.24.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
+checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
  "windows-targets 0.52.6",
@@ -5623,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -5658,7 +5723,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -5693,7 +5758,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5907,7 +5972,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5931,11 +5996,11 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
@@ -5976,7 +6041,7 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -6065,9 +6130,9 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
@@ -6126,7 +6191,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6137,14 +6202,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-numerics"
@@ -6211,6 +6276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6258,9 +6332,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -6482,7 +6556,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "ndk",
  "objc2",
  "objc2-app-kit",
@@ -6514,9 +6588,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -6570,15 +6644,21 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xcursor"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xdg-user"
@@ -6608,7 +6688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
 dependencies = [
  "libc",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "xkeysym",
 ]
 
@@ -6636,9 +6716,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "xmlwriter"
@@ -6678,15 +6758,15 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.7.1"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
+checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6717,14 +6797,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.7.1"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a"
+checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6750,22 +6830,22 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6785,7 +6865,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6819,7 +6899,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6830,18 +6910,18 @@ checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.14"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028"
+checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
 dependencies = [
  "zune-core",
 ]
 
 [[package]]
 name = "zvariant"
-version = "5.5.3"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
+checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
 dependencies = [
  "endi",
  "enumflags2",
@@ -6853,14 +6933,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.5.3"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
+checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "zvariant_utils",
 ]
 
@@ -6874,6 +6954,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.101",
+ "syn 2.0.104",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,65 +7,83 @@ version = "0.1.0"
 rust-version = "1.85"
 
 [workspace]
-members = [
-  "cosmic-comp-config",
-]
+members = ["cosmic-comp-config"]
 
 [dependencies]
-anyhow = {version = "1.0.51", features = ["backtrace"]}
-bitflags = "2.4"
-bytemuck = "1.12"
-calloop = {version = "0.14.1", features = ["executor"]}
-cosmic-comp-config = {path = "cosmic-comp-config", features = ["libdisplay-info"]}
-cosmic-config = {git = "https://github.com/pop-os/libcosmic/", features = ["calloop", "macro"]}
-cosmic-protocols = {git = "https://github.com/pop-os/cosmic-protocols", rev = "e706814", default-features = false, features = ["server"]}
+anyhow = { version = "1.0.98", features = ["backtrace"] }
+bitflags = "2.9.1"
+bytemuck = "1.23"
+calloop = { version = "0.14.2", features = ["executor"] }
+cosmic-comp-config = { path = "cosmic-comp-config", features = [
+    "libdisplay-info",
+] }
+cosmic-config = { git = "https://github.com/pop-os/libcosmic/", features = [
+    "calloop",
+    "macro",
+] }
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "e706814", default-features = false, features = [
+    "server",
+] }
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
-cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", features = ["shape-run-cache"] }
-libdisplay-info = "0.2.0"
-egui = {version = "0.31.0", optional = true}
-egui_plot = {version = "0.31.0", optional = true}
-i18n-embed = {version = "0.15", features = ["fluent-system", "desktop-requester"]}
-i18n-embed-fl = "0.9"
-iced_tiny_skia = {git = "https://github.com/pop-os/libcosmic/"}
-indexmap = "2.0"
+cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", features = [
+    "shape-run-cache",
+] }
+libdisplay-info = "0.2.2"
+egui = { version = "0.32.0", optional = true }
+egui_plot = { version = "0.33.0", optional = true }
+i18n-embed = { version = "0.16", features = [
+    "fluent-system",
+    "desktop-requester",
+] }
+i18n-embed-fl = "0.10"
+iced_tiny_skia = { git = "https://github.com/pop-os/libcosmic/" }
+indexmap = "2.10"
 keyframe = "1.1.1"
-lazy_static = "1.4.0"
-libc = "0.2.149"
-libcosmic = {git = "https://github.com/pop-os/libcosmic/", default-features = false}
-libsystemd = {version = "0.7", optional = true}
-log-panics = {version = "2", features = ["with-backtrace"]}
-once_cell = "1.18.0"
+libc = "0.2.174"
+libcosmic = { git = "https://github.com/pop-os/libcosmic/", default-features = false }
+libsystemd = { version = "0.7", optional = true }
+log-panics = { version = "2", features = ["with-backtrace"] }
 ordered-float = "5.0"
-png = "0.17.5"
+png = "0.17.16"
 regex = "1"
-ron = "0.9.0-alpha.0"
-rust-embed = {version = "8.0", features = ["debug-embed"]}
+ron = "0.10.1"
+rust-embed = { version = "8.7", features = ["debug-embed"] }
 sanitize-filename = "0.6.0"
-sendfd = "0.4.1"
-serde = {version = "1", features = ["derive"]}
+sendfd = "0.4.4"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0.12"
-time = {version = "0.3.41", features = ["macros", "formatting", "local-offset"]}
+time = { version = "0.3.41", features = [
+    "macros",
+    "formatting",
+    "local-offset",
+] }
 tiny-skia = "0.11"
-tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
-tracing-journald = "0.3.0"
-tracing-subscriber = {version = "0.3.16", features = ["env-filter", "tracing-log"]}
-tracy-client = { version = "0.18.0", default-features = false }
-wayland-backend = "0.3.3"
-wayland-scanner = "0.31.1"
-xcursor = "0.3.3"
-xdg = "^2.1"
+tracing = { version = "0.1.41", features = [
+    "max_level_debug",
+    "release_max_level_info",
+] }
+tracing-journald = "0.3.1"
+tracing-subscriber = { version = "0.3.19", features = [
+    "env-filter",
+    "tracing-log",
+] }
+tracy-client = { version = "0.18.2", default-features = false }
+wayland-backend = "0.3.10"
+wayland-scanner = "0.31.6"
+xcursor = "0.3.10"
+xdg = "^3.0"
 xdg-user = "0.2.1"
 xkbcommon = "0.8"
-zbus = "5.7.1"
+zbus = "5.9.0"
 profiling = { version = "1.0" }
-rustix = { version = "0.38.32", features = ["process"] }
-smallvec = "1.13.2"
-rand = "0.9.0"
+rustix = { version = "1.0.8", features = ["process"] }
+smallvec = "1.15.1"
+rand = "0.9.2"
 reis = { version = "0.5", features = ["calloop"] }
 # CLI arguments
 clap_lex = "0.7"
-parking_lot = "0.12.3"
+parking_lot = "0.12.4"
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"
@@ -75,21 +93,21 @@ git = "https://github.com/Drakulix/id-tree.git"
 version = "0.7.0"
 default-features = false
 features = [
-  "backend_drm",
-  "backend_gbm",
-  "backend_egl",
-  "backend_libinput",
-  "backend_session_libseat",
-  "backend_udev",
-  "backend_winit",
-  "backend_vulkan",
-  "backend_x11",
-  "desktop",
-  "renderer_glow",
-  "renderer_multi",
-  "renderer_pixman",
-  "wayland_frontend",
-  "xwayland",
+    "backend_drm",
+    "backend_gbm",
+    "backend_egl",
+    "backend_libinput",
+    "backend_session_libseat",
+    "backend_udev",
+    "backend_winit",
+    "backend_vulkan",
+    "backend_x11",
+    "desktop",
+    "renderer_glow",
+    "renderer_multi",
+    "renderer_pixman",
+    "wayland_frontend",
+    "xwayland",
 ]
 
 [dependencies.smithay-egui]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Victoria Brekenfeld"]
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0-only"
 name = "cosmic-comp"
 version = "0.1.0"
@@ -29,8 +29,8 @@ cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", features = [
     "shape-run-cache",
 ] }
 libdisplay-info = "0.2.2"
-egui = { version = "0.32.0", optional = true }
-egui_plot = { version = "0.33.0", optional = true }
+egui = { version = "0.31.0", optional = true }
+egui_plot = { version = "0.31.0", optional = true }
 i18n-embed = { version = "0.16", features = [
     "fluent-system",
     "desktop-requester",

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
-    backend::render::{output_elements, CursorMode, GlMultiRenderer, CLEAR_COLOR},
+    backend::render::{CLEAR_COLOR, CursorMode, GlMultiRenderer, output_elements},
     config::{AdaptiveSync, EdidProduct, OutputConfig, OutputState, ScreenFilter},
     shell::Shell,
     utils::{env::dev_list_var, prelude::*},
@@ -13,27 +13,27 @@ use libc::dev_t;
 use smithay::{
     backend::{
         allocator::{
+            Format, Fourcc,
             format::FormatSet,
             gbm::{GbmAllocator, GbmDevice},
-            Format, Fourcc,
         },
         drm::{
+            DrmDevice, DrmDeviceFd, DrmEvent, DrmNode, NodeType,
             compositor::{FrameError, FrameFlags},
             exporter::gbm::GbmFramebufferExporter,
             output::DrmOutputManager,
-            DrmDevice, DrmDeviceFd, DrmEvent, DrmNode, NodeType,
         },
-        egl::{context::ContextPriority, EGLContext, EGLDevice, EGLDisplay},
+        egl::{EGLContext, EGLDevice, EGLDisplay, context::ContextPriority},
         session::Session,
     },
     desktop::utils::OutputPresentationFeedback,
     output::{Mode as OutputMode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::{
         calloop::{LoopHandle, RegistrationToken},
-        drm::control::{connector, crtc, Device as ControlDevice, ModeTypeFlags},
+        drm::control::{Device as ControlDevice, ModeTypeFlags, connector, crtc},
         gbm::BufferObjectFlags as GbmBufferFlags,
         rustix::fs::OFlags,
-        wayland_server::{protocol::wl_buffer::WlBuffer, DisplayHandle, Weak},
+        wayland_server::{DisplayHandle, Weak, protocol::wl_buffer::WlBuffer},
     },
     utils::{
         Buffer as BufferCoords, Clock, DevPath, DeviceFd, Monotonic, Point, Rectangle, Transform,
@@ -47,7 +47,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     path::Path,
-    sync::{atomic::AtomicBool, mpsc::Receiver, Arc, RwLock},
+    sync::{Arc, RwLock, atomic::AtomicBool, mpsc::Receiver},
     time::Duration,
 };
 

--- a/src/backend/kms/drm_helpers.rs
+++ b/src/backend/kms/drm_helpers.rs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use libdisplay_info::{edid::DisplayDescriptorTag, info::Info};
 use smithay::{
     reexports::drm::control::{
+        AtomicCommitFlags, Device as ControlDevice, Mode, ModeFlags, PlaneType, ResourceHandle,
         atomic::AtomicModeReq,
         connector::{self, State as ConnectorState},
         crtc,
         dumbbuffer::DumbBuffer,
-        property, AtomicCommitFlags, Device as ControlDevice, Mode, ModeFlags, PlaneType,
-        ResourceHandle,
+        property,
     },
     utils::Transform,
 };

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -14,24 +14,24 @@ use render::gles::GbmGlowBackend;
 use smithay::{
     backend::{
         allocator::{
+            Buffer,
             dmabuf::Dmabuf,
             gbm::{GbmAllocator, GbmBufferFlags},
-            Buffer,
         },
-        drm::{output::DrmOutputRenderElements, DrmDeviceFd, DrmNode, NodeType},
-        egl::{context::ContextPriority, EGLContext, EGLDevice, EGLDisplay},
+        drm::{DrmDeviceFd, DrmNode, NodeType, output::DrmOutputRenderElements},
+        egl::{EGLContext, EGLDevice, EGLDisplay, context::ContextPriority},
         input::InputEvent,
         libinput::{LibinputInputBackend, LibinputSessionInterface},
         renderer::{glow::GlowRenderer, multigpu::GpuManager},
-        session::{libseat::LibSeatSession, Event as SessionEvent, Session},
-        udev::{primary_gpu, UdevBackend, UdevEvent},
+        session::{Event as SessionEvent, Session, libseat::LibSeatSession},
+        udev::{UdevBackend, UdevEvent, primary_gpu},
     },
     output::Output,
     reexports::{
         calloop::{Dispatcher, EventLoop, LoopHandle},
         drm::{
-            control::{connector::Interface, crtc, Device as _},
             Device as _,
+            control::{Device as _, connector::Interface, crtc},
         },
         input::{self, Libinput},
         wayland_server::{Client, DisplayHandle},
@@ -39,7 +39,7 @@ use smithay::{
     utils::{Clock, DevPath, Monotonic, Size},
     wayland::{
         dmabuf::DmabufGlobal,
-        drm_syncobj::{supports_syncobj_eventfd, DrmSyncobjState},
+        drm_syncobj::{DrmSyncobjState, supports_syncobj_eventfd},
         relative_pointer::RelativePointerManagerState,
     },
 };
@@ -50,7 +50,7 @@ use std::{
     borrow::BorrowMut,
     collections::{HashMap, HashSet},
     path::Path,
-    sync::{atomic::AtomicBool, Arc, RwLock},
+    sync::{Arc, RwLock, atomic::AtomicBool},
 };
 
 mod device;
@@ -63,7 +63,7 @@ pub(crate) use surface::Surface;
 use device::*;
 pub use surface::Timings;
 
-use super::render::{init_shaders, output_elements, CursorMode, CLEAR_COLOR};
+use super::render::{CLEAR_COLOR, CursorMode, init_shaders, output_elements};
 
 #[derive(Debug)]
 pub struct KmsState {
@@ -161,7 +161,7 @@ fn init_libinput(
     let libinput_backend = LibinputInputBackend::new(libinput_context.clone());
 
     evlh.insert_source(libinput_backend, move |mut event, _, state| {
-        if let InputEvent::DeviceAdded { ref mut device } = &mut event {
+        if let InputEvent::DeviceAdded { device } = &mut event {
             state.common.config.read_device(device);
             state
                 .backend

--- a/src/backend/kms/render/gles.rs
+++ b/src/backend/kms/render/gles.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use smithay::backend::{
+    SwapBuffersError,
     allocator::{
+        Allocator,
         dmabuf::{AnyError, Dmabuf, DmabufAllocator},
         gbm::GbmAllocator,
-        Allocator,
     },
     drm::{CreateDrmNodeError, DrmNode},
     renderer::{
+        RendererSuper,
         gles::GlesError,
         glow::GlowRenderer,
         multigpu::{ApiDevice, Error as MultiError, GraphicsApi},
-        RendererSuper,
     },
-    SwapBuffersError,
 };
 use std::cell::Cell;
 use std::{

--- a/src/backend/kms/render/pixman.rs
+++ b/src/backend/kms/render/pixman.rs
@@ -7,9 +7,9 @@ use std::{
 
 use smithay::backend::{
     allocator::{
+        Allocator,
         dmabuf::{AnyError, Dmabuf, DmabufAllocator},
         gbm::{GbmAllocator, GbmBufferFlags, GbmDevice},
-        Allocator,
     },
     drm::DrmNode,
     renderer::{

--- a/src/backend/kms/socket.rs
+++ b/src/backend/kms/socket.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use smithay::{
     backend::{
         allocator::format::FormatSet,
@@ -8,7 +8,7 @@ use smithay::{
     },
     reexports::{
         calloop::RegistrationToken,
-        wayland_server::{backend::GlobalId, Client, DisplayHandle},
+        wayland_server::{Client, DisplayHandle, backend::GlobalId},
     },
     wayland::{
         dmabuf::{DmabufFeedbackBuilder, DmabufGlobal},
@@ -18,7 +18,7 @@ use smithay::{
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use crate::state::{advertised_node_for_client, ClientState, State};
+use crate::state::{ClientState, State, advertised_node_for_client};
 
 #[derive(Debug)]
 pub struct Socket {

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -2,16 +2,17 @@
 
 use crate::{
     backend::render::{
+        CLEAR_COLOR, CursorMode, GlMultiError, GlMultiRenderer, PostprocessOutputConfig,
+        PostprocessShader, PostprocessState,
         element::{CosmicElement, DamageElement},
-        init_shaders, output_elements, CursorMode, GlMultiError, GlMultiRenderer,
-        PostprocessOutputConfig, PostprocessShader, PostprocessState, CLEAR_COLOR,
+        init_shaders, output_elements,
     },
     config::{AdaptiveSync, ScreenFilter},
     shell::Shell,
     state::SurfaceDmabufFeedback,
     utils::prelude::*,
     wayland::{
-        handlers::screencopy::{submit_buffer, FrameHolder, SessionData},
+        handlers::screencopy::{FrameHolder, SessionData, submit_buffer},
         protocols::screencopy::{
             FailureReason, Frame as ScreencopyFrame, SessionRef as ScreencopySessionRef,
         },
@@ -23,11 +24,12 @@ use calloop::channel::Channel;
 use smithay::{
     backend::{
         allocator::{
+            Fourcc,
             format::FormatSet,
             gbm::{GbmAllocator, GbmBuffer},
-            Fourcc,
         },
         drm::{
+            DrmDeviceFd, DrmEventMetadata, DrmEventTime, DrmNode, VrrSupport,
             compositor::{
                 BlitFrameResultError, FrameError, FrameFlags, PrimaryPlaneElement,
                 RenderFrameResult,
@@ -35,38 +37,36 @@ use smithay::{
             exporter::gbm::GbmFramebufferExporter,
             gbm::GbmFramebuffer,
             output::DrmOutput,
-            DrmDeviceFd, DrmEventMetadata, DrmEventTime, DrmNode, VrrSupport,
         },
         egl::EGLContext,
         renderer::{
-            buffer_dimensions, buffer_type,
+            Bind, Blit, BufferType, Frame, ImportDma, Offscreen, Renderer, RendererSuper, Texture,
+            TextureFilter, buffer_dimensions, buffer_type,
             damage::Error as RenderError,
             element::{
+                Element, Kind, RenderElementStates,
                 texture::TextureRenderElement,
                 utils::{
-                    constrain_render_elements, ConstrainAlign, ConstrainScaleBehavior, Relocate,
-                    RelocateRenderElement,
+                    ConstrainAlign, ConstrainScaleBehavior, Relocate, RelocateRenderElement,
+                    constrain_render_elements,
                 },
-                Element, Kind, RenderElementStates,
             },
             gles::{
-                element::TextureShaderElement, GlesRenderbuffer, GlesRenderer, GlesTexture, Uniform,
+                GlesRenderbuffer, GlesRenderer, GlesTexture, Uniform, element::TextureShaderElement,
             },
             glow::GlowRenderer,
             multigpu::{ApiDevice, Error as MultiError, GpuManager},
             sync::SyncPoint,
             utils::with_renderer_surface_state,
-            Bind, Blit, BufferType, Frame, ImportDma, Offscreen, Renderer, RendererSuper, Texture,
-            TextureFilter,
         },
     },
     desktop::utils::OutputPresentationFeedback,
     output::{Output, OutputNoMode},
     reexports::{
         calloop::{
-            channel::{channel, Event, Sender},
-            timer::{TimeoutAction, Timer},
             EventLoop, LoopHandle, RegistrationToken,
+            channel::{Event, Sender, channel},
+            timer::{TimeoutAction, Timer},
         },
         drm::control::{connector, crtc},
         wayland_protocols::wp::{
@@ -77,7 +77,7 @@ use smithay::{
     },
     utils::{Buffer as BufferCoords, Clock, Monotonic, Physical, Point, Rectangle, Transform},
     wayland::{
-        dmabuf::{get_dmabuf, DmabufFeedbackBuilder},
+        dmabuf::{DmabufFeedbackBuilder, get_dmabuf},
         presentation::Refresh,
         seat::WaylandFocus,
         shm::{shm_format_to_fourcc, with_buffer_contents},
@@ -87,12 +87,12 @@ use tracing::{error, trace, warn};
 
 use std::{
     borrow::{Borrow, BorrowMut},
-    collections::{hash_map, HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map},
     mem,
     sync::{
+        Arc, RwLock,
         atomic::{AtomicBool, Ordering},
         mpsc::{Receiver, SyncSender},
-        Arc, RwLock,
     },
     time::Duration,
 };

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cosmic_comp_config::NumlockState;
 use smithay::reexports::{calloop::EventLoop, wayland_server::DisplayHandle};
 use tracing::{info, warn};

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -5,17 +5,17 @@ use smithay::{
     backend::{
         allocator::Fourcc,
         renderer::{
-            element::{
-                memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
-                surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
-                Kind,
-            },
             ImportAll, ImportMem, Renderer,
+            element::{
+                Kind,
+                memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
+                surface::{WaylandSurfaceRenderElement, render_elements_from_surface_tree},
+            },
         },
     },
     input::{
-        pointer::{CursorIcon, CursorImageAttributes, CursorImageStatus},
         Seat,
+        pointer::{CursorIcon, CursorImageAttributes, CursorImageStatus},
     },
     reexports::wayland_server::protocol::wl_surface,
     render_elements,
@@ -27,8 +27,8 @@ use smithay::{
 use std::{collections::HashMap, io::Read, sync::Mutex};
 use tracing::warn;
 use xcursor::{
-    parser::{parse_xcursor, Image},
     CursorTheme,
+    parser::{Image, parse_xcursor},
 };
 
 static FALLBACK_CURSOR_DATA: &[u8] = include_bytes!("../../../resources/cursor.rgba");
@@ -287,10 +287,9 @@ where
         let actual_scale = (frame.size / state.size()).max(1);
 
         let pointer_images = &mut state.image_cache;
-        let maybe_image =
-            pointer_images
-                .iter()
-                .find_map(|(image, texture)| if image == &frame { Some(texture) } else { None });
+        let maybe_image = pointer_images
+            .iter()
+            .find_map(|(image, texture)| if image == &frame { Some(texture) } else { None });
         let pointer_image = match maybe_image {
             Some(image) => image,
             None => {

--- a/src/backend/render/element.rs
+++ b/src/backend/render/element.rs
@@ -4,21 +4,21 @@ use crate::shell::{CosmicMappedRenderElement, WorkspaceRenderElement};
 use smithay::backend::renderer::{element::texture::TextureRenderElement, gles::GlesTexture};
 use smithay::{
     backend::renderer::{
+        ImportAll, ImportMem, Renderer,
         element::{
+            Element, Id, Kind, RenderElement, UnderlyingStorage,
             memory::MemoryRenderBufferRenderElement,
             surface::WaylandSurfaceRenderElement,
             utils::{CropRenderElement, Relocate, RelocateRenderElement, RescaleRenderElement},
-            Element, Id, Kind, RenderElement, UnderlyingStorage,
         },
-        gles::{element::TextureShaderElement, GlesError},
+        gles::{GlesError, element::TextureShaderElement},
         glow::{GlowFrame, GlowRenderer},
         utils::{CommitCounter, DamageSet, OpaqueRegions},
-        ImportAll, ImportMem, Renderer,
     },
     utils::{Buffer as BufferCoords, Logical, Physical, Point, Rectangle, Scale},
 };
 
-use super::{cursor::CursorRenderElement, GlMultiRenderer};
+use super::{GlMultiRenderer, cursor::CursorRenderElement};
 
 pub enum CosmicElement<R>
 where

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -15,19 +15,19 @@ use crate::{
     backend::{kms::render::gles::GbmGlowBackend, render::element::DamageElement},
     config::ScreenFilter,
     shell::{
+        CosmicMappedRenderElement, OverviewMode, SeatExt, Trigger, WorkspaceDelta,
+        WorkspaceRenderElement,
         element::CosmicMappedKey,
-        focus::{render_input_order, target::WindowGroup, FocusTarget, Stage},
+        focus::{FocusTarget, Stage, render_input_order, target::WindowGroup},
         grabs::{SeatMenuGrabState, SeatMoveGrabState},
         layout::tiling::ANIMATION_DURATION,
         zoom::ZoomState,
-        CosmicMappedRenderElement, OverviewMode, SeatExt, Trigger, WorkspaceDelta,
-        WorkspaceRenderElement,
     },
     utils::{prelude::*, quirks::workspace_overview_is_open},
     wayland::{
         handlers::{
             data_device::get_dnd_icon,
-            screencopy::{render_session, FrameHolder, SessionData},
+            screencopy::{FrameHolder, SessionData, render_session},
         },
         protocols::workspace::WorkspaceHandle,
     },
@@ -37,29 +37,29 @@ use cosmic::Theme;
 use element::FromGlesError;
 use smithay::{
     backend::{
-        allocator::{dmabuf::Dmabuf, Fourcc},
+        allocator::{Fourcc, dmabuf::Dmabuf},
         drm::{DrmDeviceFd, DrmNode},
         renderer::{
+            Bind, Blit, Color32F, ExportMem, ImportAll, ImportMem, Offscreen, Renderer, Texture,
+            TextureFilter,
             damage::{Error as RenderError, OutputDamageTracker, RenderOutputResult},
             element::{
-                surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
+                AsRenderElements, Element, Id, Kind, RenderElement,
+                surface::{WaylandSurfaceRenderElement, render_elements_from_surface_tree},
                 texture::{TextureRenderBuffer, TextureRenderElement},
                 utils::{
-                    constrain_render_elements, ConstrainAlign, ConstrainScaleBehavior,
-                    CropRenderElement, Relocate, RelocateRenderElement, RescaleRenderElement,
+                    ConstrainAlign, ConstrainScaleBehavior, CropRenderElement, Relocate,
+                    RelocateRenderElement, RescaleRenderElement, constrain_render_elements,
                 },
-                AsRenderElements, Element, Id, Kind, RenderElement,
             },
             gles::{
-                element::{PixelShaderElement, TextureShaderElement},
                 GlesError, GlesPixelProgram, GlesRenderer, GlesTexProgram, GlesTexture, Uniform,
                 UniformName, UniformType,
+                element::{PixelShaderElement, TextureShaderElement},
             },
             glow::GlowRenderer,
             multigpu::{Error as MultiError, MultiFrame, MultiRenderer},
             sync::SyncPoint,
-            Bind, Blit, Color32F, ExportMem, ImportAll, ImportMem, Offscreen, Renderer, Texture,
-            TextureFilter,
         },
     },
     input::Seat,
@@ -582,21 +582,23 @@ where
         let scale = output.current_scale().fractional_scale();
 
         if let Some((state, timings)) = _fps {
-            vec![fps_ui(
-                _gpu,
-                debug_active,
-                &seats,
-                renderer.glow_renderer_mut(),
-                state,
-                timings,
-                Rectangle::from_size(
-                    (output_geo.size.w.min(400), output_geo.size.h.min(800)).into(),
-                ),
-                scale,
-            )
-            .map_err(FromGlesError::from_gles_error)
-            .map_err(RenderError::Rendering)?
-            .into()]
+            vec![
+                fps_ui(
+                    _gpu,
+                    debug_active,
+                    &seats,
+                    renderer.glow_renderer_mut(),
+                    state,
+                    timings,
+                    Rectangle::from_size(
+                        (output_geo.size.w.min(400), output_geo.size.h.min(800)).into(),
+                    ),
+                    scale,
+                )
+                .map_err(FromGlesError::from_gles_error)
+                .map_err(RenderError::Rendering)?
+                .into(),
+            ]
         } else {
             Vec::new()
         }
@@ -1377,7 +1379,7 @@ where
                             elements.truncate(old_len);
                         }
 
-                        if let (Some(ref damage), _) = &res {
+                        if let (Some(damage), _) = &res {
                             let blit_to_buffer =
                                 |renderer: &mut R, blit_from: &mut R::Framebuffer<'_>| {
                                     if let Ok(dmabuf) = get_dmabuf(buffer) {

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -7,22 +7,22 @@ use crate::{
     state::{BackendData, Common},
     utils::prelude::*,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use smithay::{
     backend::{
         drm::NodeType,
         egl::EGLDevice,
         renderer::{
+            ImportDma,
             damage::{OutputDamageTracker, RenderOutputResult},
             glow::GlowRenderer,
-            ImportDma,
         },
         winit::{self, WinitEvent, WinitGraphicsBackend, WinitVirtualDevice},
     },
     desktop::layer_map_for_output,
     output::{Mode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::{
-        calloop::{ping, EventLoop},
+        calloop::{EventLoop, ping},
         wayland_protocols::wp::presentation_time::server::wp_presentation_feedback,
         wayland_server::DisplayHandle,
         winit::platform::pump_events::PumpStatus,
@@ -33,7 +33,7 @@ use smithay::{
 use std::{borrow::BorrowMut, cell::RefCell, time::Duration};
 use tracing::{error, info, warn};
 
-use super::render::{init_shaders, CursorMode, ScreenFilterStorage};
+use super::render::{CursorMode, ScreenFilterStorage, init_shaders};
 
 #[derive(Debug)]
 pub struct WinitState {

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -7,7 +7,7 @@ use crate::{
     state::{BackendData, Common},
     utils::prelude::*,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use smithay::{
     backend::{
         allocator::{
@@ -19,17 +19,17 @@ use smithay::{
         egl::{EGLContext, EGLDevice, EGLDisplay},
         input::{Event, InputEvent},
         renderer::{
+            Bind, ImportDma,
             damage::{OutputDamageTracker, RenderOutputResult},
             glow::GlowRenderer,
-            Bind, ImportDma,
         },
-        vulkan::{version::Version, Instance, PhysicalDevice},
+        vulkan::{Instance, PhysicalDevice, version::Version},
         x11::{Window, WindowBuilder, X11Backend, X11Event, X11Handle, X11Input, X11Surface},
     },
     desktop::layer_map_for_output,
     output::{Mode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::{
-        calloop::{ping, EventLoop, LoopHandle},
+        calloop::{EventLoop, LoopHandle, ping},
         gbm::Device as GbmDevice,
         wayland_protocols::wp::presentation_time::server::wp_presentation_feedback,
         wayland_server::DisplayHandle,
@@ -40,7 +40,7 @@ use smithay::{
 use std::{borrow::BorrowMut, cell::RefCell, os::unix::io::OwnedFd, time::Duration};
 use tracing::{debug, error, info, warn};
 
-use super::render::{init_shaders, ScreenFilterStorage};
+use super::render::{ScreenFilterStorage, init_shaders};
 
 #[derive(Debug)]
 enum Allocator {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,13 +10,13 @@ use crate::{
 };
 use cosmic_config::{ConfigGet, CosmicConfigEntry};
 use cosmic_settings_config::window_rules::ApplicationException;
-use cosmic_settings_config::{shortcuts, window_rules, Shortcuts};
+use cosmic_settings_config::{Shortcuts, shortcuts, window_rules};
 use serde::{Deserialize, Serialize};
 use smithay::utils::{Clock, Monotonic};
 use smithay::wayland::xdg_activation::XdgActivationState;
 pub use smithay::{
     backend::input::{self as smithay_input, KeyState},
-    input::keyboard::{keysyms as KeySyms, Keysym, ModifiersState},
+    input::keyboard::{Keysym, ModifiersState, keysyms as KeySyms},
     output::{Mode, Output},
     reexports::{
         calloop::LoopHandle,
@@ -25,7 +25,7 @@ pub use smithay::{
             TapButtonMap,
         },
     },
-    utils::{Logical, Physical, Point, Size, Transform, SERIAL_COUNTER},
+    utils::{Logical, Physical, Point, SERIAL_COUNTER, Size, Transform},
 };
 use std::{
     cell::RefCell,
@@ -33,7 +33,7 @@ use std::{
     fs::OpenOptions,
     io::Write,
     path::PathBuf,
-    sync::{atomic::AtomicBool, Arc},
+    sync::{Arc, atomic::AtomicBool},
 };
 use tracing::{error, warn};
 
@@ -45,8 +45,8 @@ pub use self::types::*;
 use cosmic::config::CosmicTk;
 pub use cosmic_comp_config::output::EdidProduct;
 use cosmic_comp_config::{
-    input::InputConfig, workspace::WorkspaceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior,
-    XkbConfig, XwaylandDescaling, XwaylandEavesdropping, ZoomConfig,
+    CosmicCompConfig, KeyboardConfig, TileBehavior, XkbConfig, XwaylandDescaling,
+    XwaylandEavesdropping, ZoomConfig, input::InputConfig, workspace::WorkspaceConfig,
 };
 
 #[derive(Debug)]
@@ -213,7 +213,7 @@ impl Config {
                 config_changed(config, keys, state);
             })
             .expect("Failed to add cosmic-config to the event loop");
-        let xdg = xdg::BaseDirectories::new().ok();
+        let xdg = xdg::BaseDirectories::new();
 
         let cosmic_comp_config =
             CosmicCompConfig::get_entry(&config).unwrap_or_else(|(errs, c)| {
@@ -341,7 +341,7 @@ impl Config {
         });
 
         Config {
-            dynamic_conf: Self::load_dynamic(xdg.as_ref()),
+            dynamic_conf: Self::load_dynamic(&xdg),
             cosmic_conf: cosmic_comp_config,
             cosmic_helper: config,
             settings_context,
@@ -351,18 +351,15 @@ impl Config {
         }
     }
 
-    fn load_dynamic(xdg: Option<&xdg::BaseDirectories>) -> DynamicConfig {
-        let output_path =
-            xdg.and_then(|base| base.place_state_file("cosmic-comp/outputs.ron").ok());
+    fn load_dynamic(xdg: &xdg::BaseDirectories) -> DynamicConfig {
+        let output_path = xdg.place_state_file("cosmic-comp/outputs.ron").ok();
         let outputs = Self::load_outputs(&output_path);
-        let numlock_path =
-            xdg.and_then(|base| base.place_state_file("cosmic-comp/numlock.ron").ok());
+        let numlock_path = xdg.place_state_file("cosmic-comp/numlock.ron").ok();
         let numlock = Self::load_numlock(&numlock_path);
 
-        let filter_path = xdg.and_then(|base| {
-            base.place_state_file("cosmic-comp/a11y_screen_filter.ron")
-                .ok()
-        });
+        let filter_path = xdg
+            .place_state_file("cosmic-comp/a11y_screen_filter.ron")
+            .ok();
         let filter = Self::load_filter_state(&filter_path);
 
         DynamicConfig {
@@ -389,11 +386,15 @@ impl Config {
                                         .find(|(_, info)| &info.connector == conn)
                                     {
                                         if config_clone[j].enabled != OutputState::Enabled {
-                                            warn!("Invalid Mirroring tag, overriding with `Enabled` instead");
+                                            warn!(
+                                                "Invalid Mirroring tag, overriding with `Enabled` instead"
+                                            );
                                             conf.enabled = OutputState::Enabled;
                                         }
                                     } else {
-                                        warn!("Invalid Mirroring tag, overriding with `Enabled` instead");
+                                        warn!(
+                                            "Invalid Mirroring tag, overriding with `Enabled` instead"
+                                        );
                                         conf.enabled = OutputState::Enabled;
                                     }
                                 }
@@ -764,7 +765,7 @@ fn get_config<T: Default + serde::de::DeserializeOwned>(
 }
 
 fn update_input(state: &mut State) {
-    if let BackendData::Kms(ref mut kms_state) = &mut state.backend {
+    if let BackendData::Kms(kms_state) = &mut state.backend {
         for device in kms_state.input_devices.values_mut() {
             state.common.config.read_device(device);
         }

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -2,7 +2,7 @@ use crate::state::{BackendData, Common, State};
 use anyhow::{Context, Result};
 use calloop::{InsertError, LoopHandle, RegistrationToken};
 use std::collections::HashMap;
-use zbus::blocking::{fdo::DBusProxy, Connection};
+use zbus::blocking::{Connection, fdo::DBusProxy};
 
 mod power;
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
+    State,
     backend::kms::Timings,
     shell::focus::target::{KeyboardFocusTarget, PointerFocusTarget, PointerFocusToplevel},
-    State,
 };
 use egui::Color32;
 use smithay::{
@@ -16,7 +16,7 @@ use smithay::{
         },
     },
     desktop::WindowSurface,
-    input::{keyboard::xkb, Seat},
+    input::{Seat, keyboard::xkb},
     reexports::wayland_server::Resource,
     utils::{Logical, Rectangle, Time},
 };

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -3,21 +3,21 @@
 use crate::{
     config::{Action, PrivateAction},
     shell::{
-        focus::{target::KeyboardFocusTarget, FocusTarget},
-        layout::tiling::SwapWindowGrab,
         FocusResult, InvalidWorkspaceIndex, MoveResult, SeatExt, Trigger, WorkspaceDelta,
+        focus::{FocusTarget, target::KeyboardFocusTarget},
+        layout::tiling::SwapWindowGrab,
     },
     utils::prelude::*,
     wayland::{
         handlers::xdg_activation::ActivationContext, protocols::workspace::WorkspaceUpdateGuard,
     },
 };
-use cosmic_comp_config::{workspace::WorkspaceLayout, TileBehavior};
+use cosmic_comp_config::{TileBehavior, workspace::WorkspaceLayout};
 use cosmic_config::ConfigSet;
 use cosmic_settings_config::shortcuts;
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection};
 use smithay::{
-    input::{pointer::MotionEvent, Seat},
+    input::{Seat, pointer::MotionEvent},
     utils::{Point, Serial},
 };
 #[cfg(not(feature = "debug"))]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3,18 +3,18 @@
 use crate::{
     backend::render::ElementFilter,
     config::{
+        Action, Config, PrivateAction,
         key_bindings::{
             cosmic_keystate_from_smithay, cosmic_modifiers_eq_smithay,
             cosmic_modifiers_from_smithay,
         },
-        Action, Config, PrivateAction,
     },
     input::gestures::{GestureState, SwipeAction},
     shell::{
+        LastModifierChange, SeatExt, Trigger,
         focus::{
-            render_input_order,
+            Stage, render_input_order,
             target::{KeyboardFocusTarget, PointerFocusTarget},
-            Stage,
         },
         grabs::{ReleaseMode, ResizeEdge},
         layout::{
@@ -22,7 +22,6 @@ use crate::{
             tiling::{NodeDesc, SwapWindowGrab, TilingLayout},
         },
         zoom::ZoomState,
-        LastModifierChange, SeatExt, Trigger,
     },
     utils::{float::NextDown, prelude::*, quirks::workspace_overview_is_open},
     wayland::{
@@ -31,10 +30,10 @@ use crate::{
     },
 };
 use calloop::{
-    timer::{TimeoutAction, Timer},
     RegistrationToken,
+    timer::{TimeoutAction, Timer},
 };
-use cosmic_comp_config::{workspace::WorkspaceLayout, NumlockState};
+use cosmic_comp_config::{NumlockState, workspace::WorkspaceLayout};
 use cosmic_settings_config::shortcuts;
 use cosmic_settings_config::shortcuts::action::{Direction, ResizeDirection};
 use smithay::{
@@ -45,8 +44,9 @@ use smithay::{
         TabletToolButtonEvent, TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent,
         TabletToolTipState, TouchEvent,
     },
-    desktop::{utils::under_from_surface_tree, PopupKeyboardGrab, WindowSurfaceType},
+    desktop::{PopupKeyboardGrab, WindowSurfaceType, utils::under_from_surface_tree},
     input::{
+        Seat,
         keyboard::{FilterResult, KeysymHandle, ModifiersState},
         pointer::{
             AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent,
@@ -55,16 +55,15 @@ use smithay::{
             PointerGrab, RelativeMotionEvent,
         },
         touch::{DownEvent, MotionEvent as TouchMotionEvent, UpEvent},
-        Seat,
     },
     output::Output,
     reexports::{
         input::Device as InputDevice, wayland_server::protocol::wl_shm::Format as ShmFormat,
     },
-    utils::{Point, Rectangle, Serial, SERIAL_COUNTER},
+    utils::{Point, Rectangle, SERIAL_COUNTER, Serial},
     wayland::{
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
-        pointer_constraints::{with_pointer_constraint, PointerConstraint},
+        pointer_constraints::{PointerConstraint, with_pointer_constraint},
         seat::WaylandFocus,
         tablet_manager::{TabletDescriptor, TabletSeatTrait},
     },
@@ -1999,7 +1998,7 @@ impl State {
                     Stage::SessionLock(lock_surface) => {
                         return ControlFlow::Break(Ok(lock_surface
                             .cloned()
-                            .map(KeyboardFocusTarget::LockSurface)))
+                            .map(KeyboardFocusTarget::LockSurface)));
                     }
                     Stage::LayerPopup {
                         layer,

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use tracing::{debug, info, warn};
 use tracing_journald as journald;
-use tracing_subscriber::{filter::Directive, fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, filter::Directive, fmt, prelude::*};
 
 pub fn init_logger() -> Result<()> {
     let level = if cfg!(debug_assertions) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use calloop::timer::{TimeoutAction, Timer};
 use smithay::{
     reexports::{
-        calloop::{generic::Generic, EventLoop, Interest, Mode, PostAction},
+        calloop::{EventLoop, Interest, Mode, PostAction, generic::Generic},
         wayland_server::{Display, DisplayHandle},
     },
     wayland::socket::ListeningSocketSource,

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use smithay::reexports::{
-    calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+    calloop::{Interest, LoopHandle, Mode, PostAction, generic::Generic},
     rustix,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use sendfd::RecvWithFd;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -54,7 +54,7 @@ unsafe fn set_cloexec(fd: RawFd) -> rustix::io::Result<()> {
     if fd == -1 {
         return Err(rustix::io::Errno::BADF);
     }
-    let fd = BorrowedFd::borrow_raw(fd);
+    let fd = unsafe { BorrowedFd::borrow_raw(fd) };
     let flags = rustix::io::fcntl_getfd(fd)?;
     rustix::io::fcntl_setfd(fd, flags | rustix::io::FdFlags::CLOEXEC)
 }

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -9,21 +9,21 @@ use smithay::{
     backend::{
         input::KeyState,
         renderer::{
+            ImportAll, ImportMem, Renderer,
             element::{
+                Element, RenderElement, UnderlyingStorage,
                 memory::MemoryRenderBufferRenderElement,
                 utils::{CropRenderElement, RelocateRenderElement, RescaleRenderElement},
-                Element, RenderElement, UnderlyingStorage,
             },
             gles::element::PixelShaderElement,
             glow::GlowRenderer,
             utils::{DamageSet, OpaqueRegions},
-            ImportAll, ImportMem, Renderer,
         },
     },
-    desktop::{space::SpaceElement, WindowSurfaceType},
+    desktop::{WindowSurfaceType, space::SpaceElement},
     input::{
-        keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         Seat,
+        keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
     },
     output::Output,
     reexports::wayland_server::{backend::ObjectId, protocol::wl_surface::WlSurface},
@@ -32,7 +32,7 @@ use smithay::{
         Buffer as BufferCoords, IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size,
     },
     wayland::seat::WaylandFocus,
-    xwayland::{xwm::X11Relatable, X11Surface},
+    xwayland::{X11Surface, xwm::X11Relatable},
 };
 use stack::CosmicStackInternal;
 use window::CosmicWindowInternal;
@@ -42,7 +42,7 @@ use std::{
     collections::HashMap,
     fmt,
     hash::Hash,
-    sync::{atomic::AtomicBool, Arc, Mutex, Weak},
+    sync::{Arc, Mutex, Weak, atomic::AtomicBool},
 };
 
 pub mod surface;
@@ -66,12 +66,12 @@ use smithay::desktop::WindowSurface;
 use tracing::debug;
 
 use super::{
+    ManagedLayer, SeatExt,
     focus::target::PointerFocusTarget,
     layout::{
         floating::{ResizeState, TiledCorners},
         tiling::NodeDesc,
     },
-    ManagedLayer, SeatExt,
 };
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection};
 
@@ -666,8 +666,7 @@ impl CosmicMapped {
                                         WindowSurface::Wayland(_) => "Protocol: Wayland",
                                         WindowSurface::X11(_) => "Protocol: X11",
                                     });
-                                    if let WindowSurface::X11(ref surf) =
-                                        window.0.underlying_surface()
+                                    if let WindowSurface::X11(surf) = window.0.underlying_surface()
                                     {
                                         let geo = surf.geometry();
                                         ui.label(format!(
@@ -834,10 +833,10 @@ impl CosmicMapped {
     pub fn key(&self) -> CosmicMappedKey {
         CosmicMappedKey(match &self.element {
             CosmicMappedInternal::Stack(stack) => {
-                CosmicMappedKeyInner::Stack(Arc::downgrade(&stack.0 .0))
+                CosmicMappedKeyInner::Stack(Arc::downgrade(&stack.0.0))
             }
             CosmicMappedInternal::Window(window) => {
-                CosmicMappedKeyInner::Window(Arc::downgrade(&window.0 .0))
+                CosmicMappedKeyInner::Window(Arc::downgrade(&window.0.0))
             }
             _ => unreachable!(),
         })

--- a/src/shell/element/resize_indicator.rs
+++ b/src/shell/element/resize_indicator.rs
@@ -9,14 +9,14 @@ use crate::{
 
 use calloop::LoopHandle;
 use cosmic::{
+    Apply,
     iced::{
-        widget::{column, container, horizontal_space, row, vertical_space},
         Alignment,
+        widget::{column, container, horizontal_space, row, vertical_space},
     },
     iced_core::{Background, Border, Color, Length},
     theme,
     widget::{icon::from_name, text},
-    Apply,
 };
 use cosmic_settings_config::shortcuts::action::{Action, ResizeDirection};
 use smithay::utils::Size;

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -1,6 +1,6 @@
 use super::{
-    window::{Focus, RESIZE_BORDER},
     CosmicSurface,
+    window::{Focus, RESIZE_BORDER},
 };
 use crate::{
     backend::render::cursor::CursorState,
@@ -17,28 +17,29 @@ use crate::{
 };
 use calloop::LoopHandle;
 use cosmic::{
-    iced::{id::Id, widget as iced_widget, Alignment},
-    iced_core::{border::Radius, Background, Border, Color, Length},
+    Apply, Element as CosmicElement, Theme,
+    iced::{Alignment, id::Id, widget as iced_widget},
+    iced_core::{Background, Border, Color, Length, border::Radius},
     iced_runtime::Task,
     iced_widget::scrollable::AbsoluteOffset,
-    theme, widget as cosmic_widget, Apply, Element as CosmicElement, Theme,
+    theme, widget as cosmic_widget,
 };
 use cosmic_settings_config::shortcuts;
-use once_cell::sync::Lazy;
 use shortcuts::action::{Direction, FocusDirection};
 use smithay::{
     backend::{
         input::KeyState,
         renderer::{
-            element::{
-                memory::MemoryRenderBufferRenderElement, surface::WaylandSurfaceRenderElement,
-                AsRenderElements,
-            },
             ImportAll, ImportMem, Renderer,
+            element::{
+                AsRenderElements, memory::MemoryRenderBufferRenderElement,
+                surface::WaylandSurfaceRenderElement,
+            },
         },
     },
-    desktop::{space::SpaceElement, WindowSurfaceType},
+    desktop::{WindowSurfaceType, space::SpaceElement},
     input::{
+        Seat,
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         pointer::{
             AxisFrame, ButtonEvent, CursorImageStatus, GestureHoldBeginEvent, GestureHoldEndEvent,
@@ -50,7 +51,6 @@ use smithay::{
             DownEvent, MotionEvent as TouchMotionEvent, OrientationEvent, ShapeEvent, TouchTarget,
             UpEvent,
         },
-        Seat,
     },
     output::Output,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
@@ -63,8 +63,8 @@ use std::{
     fmt,
     hash::Hash,
     sync::{
+        Arc, LazyLock, Mutex,
         atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
-        Arc, Mutex,
     },
 };
 
@@ -77,7 +77,7 @@ use self::{
     tabs::Tabs,
 };
 
-static SCROLLABLE_ID: Lazy<Id> = Lazy::new(|| Id::new("scrollable"));
+static SCROLLABLE_ID: LazyLock<Id> = LazyLock::new(|| Id::new("scrollable"));
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CosmicStack(pub(super) IcedElement<CosmicStackInternal>);
@@ -314,11 +314,7 @@ impl CosmicStack {
                         if let Ok(old) =
                             p.active
                                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
-                                    if val < max - 1 {
-                                        Some(val + 1)
-                                    } else {
-                                        None
-                                    }
+                                    if val < max - 1 { Some(val + 1) } else { None }
                                 })
                         {
                             p.previous_keyboard.store(old, Ordering::SeqCst);

--- a/src/shell/element/stack/tab.rs
+++ b/src/shell/element/stack/tab.rs
@@ -1,17 +1,16 @@
 use cosmic::{
+    Apply,
     font::Font,
     iced::widget::{self, container::draw_background, rule::FillMode},
     iced_core::{
-        alignment, event,
+        Border, Clipboard, Color, Length, Rectangle, Shell, Size, alignment, event,
         layout::{Layout, Limits, Node},
         mouse, overlay, renderer,
-        widget::{operation::Operation, tree::Tree, Id, Widget},
-        Border, Clipboard, Color, Length, Rectangle, Shell, Size,
+        widget::{Id, Widget, operation::Operation, tree::Tree},
     },
     iced_widget::scrollable::AbsoluteOffset,
     theme,
-    widget::{icon::from_name, Icon},
-    Apply,
+    widget::{Icon, icon::from_name},
 };
 
 use super::tab_text::tab_text;

--- a/src/shell/element/stack/tab_text.rs
+++ b/src/shell/element/stack/tab_text.rs
@@ -1,15 +1,14 @@
 use std::hash::{Hash, Hasher};
 
 use cosmic::{
-    iced::{alignment, Point},
+    iced::{Point, alignment},
     iced_core::{
-        gradient,
+        Background, Border, Color, Degrees, Gradient, Length, Rectangle, Size, Text, gradient,
         layout::{Layout, Limits, Node},
         mouse::Cursor,
         renderer::{self, Renderer as IcedRenderer},
         text::{LineHeight, Paragraph, Renderer as TextRenderer, Shaping},
-        widget::{tree, Tree, Widget},
-        Background, Border, Color, Degrees, Gradient, Length, Rectangle, Size, Text,
+        widget::{Tree, Widget, tree},
     },
 };
 

--- a/src/shell/element/stack/tabs.rs
+++ b/src/shell/element/stack/tabs.rs
@@ -1,25 +1,24 @@
-use super::tab::{Tab, TabBackgroundTheme, TabMessage, TabRuleTheme, MIN_ACTIVE_TAB_WIDTH};
+use super::tab::{MIN_ACTIVE_TAB_WIDTH, Tab, TabBackgroundTheme, TabMessage, TabRuleTheme};
 use cosmic::{
-    iced::{id::Id, widget, Element},
+    Apply,
+    iced::{Element, id::Id, widget},
     iced_core::{
-        event,
+        Background, Border, Clipboard, Color, Length, Point, Rectangle, Renderer, Shell, Size,
+        Vector, event,
         layout::{Layout, Limits, Node},
         mouse, overlay, renderer,
         widget::{
+            Widget,
             operation::{
-                scrollable::{AbsoluteOffset, RelativeOffset},
                 Operation, Scrollable,
+                scrollable::{AbsoluteOffset, RelativeOffset},
             },
             tree::{self, Tree},
-            Widget,
         },
-        Background, Border, Clipboard, Color, Length, Point, Rectangle, Renderer, Shell, Size,
-        Vector,
     },
     iced_widget::container::draw_background,
     theme,
     widget::{container::Catalog, icon::from_name},
-    Apply,
 };
 use keyframe::{
     ease,

--- a/src/shell/element/stack_hover.rs
+++ b/src/shell/element/stack_hover.rs
@@ -5,14 +5,14 @@ use crate::{
 
 use calloop::LoopHandle;
 use cosmic::{
+    Apply,
     iced::{
-        widget::{container, row},
         Alignment,
+        widget::{container, row},
     },
     iced_core::{Background, Border, Color, Length},
     theme,
     widget::{horizontal_space, icon::from_name, text},
-    Apply,
 };
 use smithay::utils::{Logical, Size};
 

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -1,29 +1,28 @@
 use std::{
     borrow::Cow,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Mutex,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
 
 use smithay::{
     backend::renderer::{
-        element::{
-            self,
-            surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
-            utils::select_dmabuf_feedback,
-            AsRenderElements, RenderElementStates,
-        },
         ImportAll, Renderer,
+        element::{
+            self, AsRenderElements, RenderElementStates,
+            surface::{WaylandSurfaceRenderElement, render_elements_from_surface_tree},
+            utils::select_dmabuf_feedback,
+        },
     },
     desktop::{
-        space::SpaceElement, utils::OutputPresentationFeedback, PopupManager, Window,
-        WindowSurface, WindowSurfaceType,
+        PopupManager, Window, WindowSurface, WindowSurfaceType, space::SpaceElement,
+        utils::OutputPresentationFeedback,
     },
     input::{
-        keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         Seat,
+        keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
     },
     output::Output,
     reexports::{
@@ -38,14 +37,14 @@ use smithay::{
         wayland_server::protocol::wl_surface::WlSurface,
     },
     utils::{
-        user_data::UserDataMap, IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size,
+        IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size, user_data::UserDataMap,
     },
     wayland::{
-        compositor::{with_states, with_surface_tree_downward, SurfaceData, TraversalAction},
+        compositor::{SurfaceData, TraversalAction, with_states, with_surface_tree_downward},
         seat::WaylandFocus,
         shell::xdg::{SurfaceCachedState, ToplevelSurface, XdgToplevelSurfaceData},
     },
-    xwayland::{xwm::X11Relatable, X11Surface},
+    xwayland::{X11Surface, xwm::X11Relatable},
 };
 use tracing::trace;
 

--- a/src/shell/element/swap_indicator.rs
+++ b/src/shell/element/swap_indicator.rs
@@ -5,11 +5,11 @@ use crate::{
 
 use calloop::LoopHandle;
 use cosmic::{
+    Apply,
     iced::widget::{container, horizontal_space, row},
     iced_core::{Alignment, Background, Border, Color, Length},
     theme,
     widget::{icon::from_name, text},
-    Apply,
 };
 use smithay::utils::Size;
 

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -16,15 +16,16 @@ use smithay::{
     backend::{
         input::KeyState,
         renderer::{
-            element::{
-                memory::MemoryRenderBufferRenderElement, surface::WaylandSurfaceRenderElement,
-                AsRenderElements,
-            },
             ImportAll, ImportMem, Renderer,
+            element::{
+                AsRenderElements, memory::MemoryRenderBufferRenderElement,
+                surface::WaylandSurfaceRenderElement,
+            },
         },
     },
-    desktop::{space::SpaceElement, WindowSurfaceType},
+    desktop::{WindowSurfaceType, space::SpaceElement},
     input::{
+        Seat,
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         pointer::{
             AxisFrame, ButtonEvent, CursorIcon, CursorImageStatus, GestureHoldBeginEvent,
@@ -36,7 +37,6 @@ use smithay::{
             DownEvent, MotionEvent as TouchMotionEvent, OrientationEvent, ShapeEvent, TouchTarget,
             UpEvent,
         },
-        Seat,
     },
     output::Output,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
@@ -49,8 +49,8 @@ use std::{
     fmt,
     hash::Hash,
     sync::{
-        atomic::{AtomicBool, AtomicU8, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, AtomicU8, Ordering},
     },
 };
 use wayland_backend::server::ObjectId;

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -1,16 +1,16 @@
 use crate::{
-    shell::{element::CosmicMapped, CosmicSurface, MinimizedWindow, Shell},
+    shell::{CosmicSurface, MinimizedWindow, Shell, element::CosmicMapped},
     state::Common,
     utils::prelude::*,
     wayland::handlers::{xdg_shell::PopupGrabData, xwayland_keyboard_grab::XWaylandGrabSeatData},
 };
 use indexmap::IndexSet;
 use smithay::{
-    desktop::{layer_map_for_output, PopupUngrabStrategy},
-    input::{pointer::MotionEvent, Seat},
+    desktop::{PopupUngrabStrategy, layer_map_for_output},
+    input::{Seat, pointer::MotionEvent},
     output::Output,
-    reexports::wayland_server::{protocol::wl_surface::WlSurface, Resource},
-    utils::{IsAlive, Point, Serial, SERIAL_COUNTER},
+    reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface},
+    utils::{IsAlive, Point, SERIAL_COUNTER, Serial},
     wayland::{
         seat::WaylandFocus,
         selection::{data_device::set_data_device_focus, primary_selection::set_primary_focus},
@@ -21,10 +21,10 @@ use std::{borrow::Cow, mem, sync::Mutex};
 
 use tracing::{debug, trace};
 
-pub use self::order::{render_input_order, Stage};
+pub use self::order::{Stage, render_input_order};
 use self::target::{KeyboardFocusTarget, WindowGroup};
 
-use super::{grabs::SeatMoveGrabState, layout::floating::FloatingLayout, SeatExt};
+use super::{SeatExt, grabs::SeatMoveGrabState, layout::floating::FloatingLayout};
 
 mod order;
 pub mod target;

--- a/src/shell/focus/order.rs
+++ b/src/shell/focus/order.rs
@@ -3,7 +3,7 @@ use std::{ops::ControlFlow, time::Instant};
 use cosmic_comp_config::workspace::WorkspaceLayout;
 use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
-    desktop::{layer_map_for_output, LayerSurface, PopupKind, PopupManager},
+    desktop::{LayerSurface, PopupKind, PopupManager, layer_map_for_output},
     output::{Output, OutputNoMode},
     utils::{Logical, Point},
     wayland::{session_lock::LockSurface, shell::wlr_layer::Layer},
@@ -13,14 +13,14 @@ use smithay::{
 use crate::{
     backend::render::ElementFilter,
     shell::{
+        SeatExt, Shell, Workspace, WorkspaceDelta,
         focus::target::KeyboardFocusTarget,
         layout::{floating::FloatingLayout, tiling::ANIMATION_DURATION},
-        SeatExt, Shell, Workspace, WorkspaceDelta,
     },
     utils::{
         geometry::*,
         prelude::OutputExt,
-        quirks::{workspace_overview_is_open, WORKSPACE_OVERVIEW_NAMESPACE},
+        quirks::{WORKSPACE_OVERVIEW_NAMESPACE, workspace_overview_is_open},
     },
     wayland::protocols::workspace::WorkspaceHandle,
 };

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -2,10 +2,10 @@ use std::{borrow::Cow, sync::Weak, time::Duration};
 
 use crate::{
     shell::{
+        CosmicSurface, SeatExt,
         element::{CosmicMapped, CosmicStack, CosmicWindow},
         layout::tiling::ResizeForkTarget,
         zoom::ZoomFocusTarget,
-        CosmicSurface, SeatExt,
     },
     utils::prelude::*,
     wayland::handlers::{screencopy::SessionHolder, xdg_shell::popup::get_popup_toplevel},
@@ -13,8 +13,9 @@ use crate::{
 use id_tree::NodeId;
 use smithay::{
     backend::input::KeyState,
-    desktop::{space::SpaceElement, LayerSurface, PopupKind, WindowSurface, WindowSurfaceType},
+    desktop::{LayerSurface, PopupKind, WindowSurface, WindowSurfaceType, space::SpaceElement},
     input::{
+        Seat,
         keyboard::{KeyboardTarget, KeysymHandle, ModifiersState},
         pointer::{
             AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent,
@@ -26,10 +27,9 @@ use smithay::{
             DownEvent, MotionEvent as TouchMotionEvent, OrientationEvent, ShapeEvent, TouchTarget,
             UpEvent,
         },
-        Seat,
     },
     reexports::wayland_server::{
-        backend::ObjectId, protocol::wl_surface::WlSurface, Client, Resource,
+        Client, Resource, backend::ObjectId, protocol::wl_surface::WlSurface,
     },
     utils::{IsAlive, Logical, Point, Serial, Transform},
     wayland::{seat::WaylandFocus, session_lock::LockSurface},

--- a/src/shell/grabs/menu/default.rs
+++ b/src/shell/grabs/menu/default.rs
@@ -8,9 +8,9 @@ use crate::{
     config::Config,
     fl,
     shell::{
+        CosmicSurface, PointGlobalExt, Shell,
         element::{CosmicMapped, CosmicWindow},
         grabs::ReleaseMode,
-        CosmicSurface, PointGlobalExt, Shell,
     },
     state::State,
     utils::{prelude::SeatExt, screenshot::screenshot_window},

--- a/src/shell/grabs/menu/item.rs
+++ b/src/shell/grabs/menu/item.rs
@@ -1,11 +1,10 @@
 use cosmic::{
     iced::Element,
     iced_core::{
-        event, layout, mouse, overlay,
-        renderer::{Quad, Style},
-        widget::{tree, Id, Tree, Widget},
         Background, Border, Clipboard, Color, Event, Layout, Length, Rectangle,
-        Renderer as IcedRenderer, Shell, Size,
+        Renderer as IcedRenderer, Shell, Size, event, layout, mouse, overlay,
+        renderer::{Quad, Style},
+        widget::{Id, Tree, Widget, tree},
     },
     widget::button::Catalog,
 };

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -1,30 +1,31 @@
 use std::{
     fmt,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
 use calloop::LoopHandle;
 use cosmic::{
+    Apply as _, Task,
     iced::{Alignment, Background},
-    iced_core::{alignment::Horizontal, Border, Length, Rectangle as IcedRectangle},
-    iced_widget::{self, text::Style as TextStyle, Column, Row},
+    iced_core::{Border, Length, Rectangle as IcedRectangle, alignment::Horizontal},
+    iced_widget::{self, Column, Row, text::Style as TextStyle},
     theme,
     widget::{button, divider, horizontal_space, icon::from_name, text},
-    Apply as _, Task,
 };
 use smithay::{
     backend::{
         input::{ButtonState, TouchSlot},
         renderer::{
-            element::{memory::MemoryRenderBufferRenderElement, AsRenderElements},
             ImportMem, Renderer,
+            element::{AsRenderElements, memory::MemoryRenderBufferRenderElement},
         },
     },
     desktop::space::SpaceElement,
     input::{
+        Seat,
         pointer::{
             AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent,
             GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -36,14 +37,13 @@ use smithay::{
             DownEvent, GrabStartData as TouchGrabStartData, MotionEvent as TouchMotionEvent,
             TouchGrab, TouchInnerHandle, TouchTarget, UpEvent,
         },
-        Seat,
     },
     output::Output,
     utils::{Logical, Point, Rectangle, Serial, Size},
 };
 
 use crate::{
-    shell::{focus::target::PointerFocusTarget, SeatExt},
+    shell::{SeatExt, focus::target::PointerFocusTarget},
     state::State,
     utils::{
         iced::{IcedElement, Program},

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -2,16 +2,16 @@
 
 use crate::{
     backend::render::{
-        cursor::CursorState, element::AsGlowRenderer, BackdropShader, IndicatorShader, Key, Usage,
+        BackdropShader, IndicatorShader, Key, Usage, cursor::CursorState, element::AsGlowRenderer,
     },
     shell::{
+        CosmicMapped, CosmicSurface, Direction, ManagedLayer,
         element::{
-            stack_hover::{stack_hover, StackHover},
             CosmicMappedRenderElement,
+            stack_hover::{StackHover, stack_hover},
         },
         focus::target::{KeyboardFocusTarget, PointerFocusTarget},
         layout::floating::TiledCorners,
-        CosmicMapped, CosmicSurface, Direction, ManagedLayer,
     },
     utils::prelude::*,
     wayland::protocols::toplevel_info::{toplevel_enter_output, toplevel_enter_workspace},
@@ -23,12 +23,13 @@ use smithay::{
     backend::{
         input::ButtonState,
         renderer::{
-            element::{utils::RescaleRenderElement, AsRenderElements, RenderElement},
             ImportAll, ImportMem, Renderer,
+            element::{AsRenderElements, RenderElement, utils::RescaleRenderElement},
         },
     },
-    desktop::{layer_map_for_output, space::SpaceElement, WindowSurfaceType},
+    desktop::{WindowSurfaceType, layer_map_for_output, space::SpaceElement},
     input::{
+        Seat,
         pointer::{
             AxisFrame, ButtonEvent, CursorIcon, GestureHoldBeginEvent, GestureHoldEndEvent,
             GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -37,14 +38,13 @@ use smithay::{
             RelativeMotionEvent,
         },
         touch::{self, GrabStartData as TouchGrabStartData, TouchGrab, TouchInnerHandle},
-        Seat,
     },
     output::Output,
-    utils::{IsAlive, Logical, Point, Rectangle, Scale, Serial, SERIAL_COUNTER},
+    utils::{IsAlive, Logical, Point, Rectangle, SERIAL_COUNTER, Scale, Serial},
 };
 use std::{
     collections::HashSet,
-    sync::{atomic::Ordering, Mutex},
+    sync::{Mutex, atomic::Ordering},
     time::Instant,
 };
 

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -13,8 +13,9 @@ use crate::{
 };
 use smithay::{
     backend::input::ButtonState,
-    desktop::{space::SpaceElement, WindowSurface},
+    desktop::{WindowSurface, space::SpaceElement},
     input::{
+        Seat,
         pointer::{
             AxisFrame, ButtonEvent, CursorIcon, GestureHoldBeginEvent, GestureHoldEndEvent,
             GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -26,7 +27,6 @@ use smithay::{
             DownEvent, GrabStartData as TouchGrabStartData, MotionEvent as TouchMotionEvent,
             OrientationEvent, ShapeEvent, TouchGrab, TouchInnerHandle, UpEvent,
         },
-        Seat,
     },
     output::Output,
     utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -10,13 +10,13 @@ use cosmic_settings_config::shortcuts::action::ResizeDirection;
 use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
     backend::renderer::{
-        element::{
-            utils::{Relocate, RelocateRenderElement, RescaleRenderElement},
-            AsRenderElements, RenderElement,
-        },
         ImportAll, ImportMem, Renderer,
+        element::{
+            AsRenderElements, RenderElement,
+            utils::{Relocate, RelocateRenderElement, RescaleRenderElement},
+        },
     },
-    desktop::{layer_map_for_output, space::SpaceElement, PopupKind, Space, WindowSurfaceType},
+    desktop::{PopupKind, Space, WindowSurfaceType, layer_map_for_output, space::SpaceElement},
     input::Seat,
     output::Output,
     utils::{IsAlive, Logical, Point, Rectangle, Scale, Size},
@@ -24,20 +24,20 @@ use smithay::{
 };
 
 use crate::{
-    backend::render::{element::AsGlowRenderer, IndicatorShader, Key, Usage},
+    backend::render::{IndicatorShader, Key, Usage, element::AsGlowRenderer},
     shell::{
+        CosmicSurface, Direction, ManagedLayer, MoveResult, ResizeMode,
         element::{
+            CosmicMapped, CosmicMappedRenderElement, CosmicWindow, MaximizedState,
             resize_indicator::ResizeIndicator,
             stack::{CosmicStackRenderElement, MoveResult as StackMoveResult, TAB_HEIGHT},
             window::CosmicWindowRenderElement,
-            CosmicMapped, CosmicMappedRenderElement, CosmicWindow, MaximizedState,
         },
         focus::{
-            target::{KeyboardFocusTarget, PointerFocusTarget},
             FocusStackMut,
+            target::{KeyboardFocusTarget, PointerFocusTarget},
         },
         grabs::{GrabStartData, ReleaseMode, ResizeEdge},
-        CosmicSurface, Direction, ManagedLayer, MoveResult, ResizeMode,
     },
     state::State,
     utils::{prelude::*, tween::EaseRectangle},

--- a/src/shell/layout/tiling/blocker.rs
+++ b/src/shell/layout/tiling/blocker.rs
@@ -1,6 +1,6 @@
 use crate::shell::element::CosmicSurface;
 use smithay::{
-    reexports::wayland_server::{backend::ClientId, Client, Resource},
+    reexports::wayland_server::{Client, Resource, backend::ClientId},
     utils::{IsAlive, Serial},
     wayland::{
         compositor::{Blocker, BlockerState},

--- a/src/shell/layout/tiling/grabs/resize.rs
+++ b/src/shell/layout/tiling/grabs/resize.rs
@@ -13,6 +13,7 @@ use id_tree::{NodeId, Tree};
 use smithay::{
     backend::input::ButtonState,
     input::{
+        Seat,
         pointer::{
             AxisFrame, ButtonEvent, CursorIcon, Focus, GestureHoldBeginEvent, GestureHoldEndEvent,
             GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -24,7 +25,6 @@ use smithay::{
             DownEvent, GrabStartData as TouchGrabStartData, MotionEvent as TouchMotionEvent,
             OrientationEvent, ShapeEvent, TouchGrab, TouchInnerHandle, TouchTarget, UpEvent,
         },
-        Seat,
     },
     output::WeakOutput,
     utils::{IsAlive, Logical, Point, Serial},

--- a/src/shell/layout/tiling/grabs/swap.rs
+++ b/src/shell/layout/tiling/grabs/swap.rs
@@ -2,18 +2,18 @@ use cosmic_settings_config::shortcuts;
 use smithay::{
     backend::input::{KeyState, Keycode},
     input::{
+        Seat, SeatHandler,
         keyboard::{
             GrabStartData as KeyboardGrabStartData, KeyboardGrab, KeyboardInnerHandle,
             ModifiersState,
         },
-        Seat, SeatHandler,
     },
     utils::Serial,
 };
 
 use crate::{
     config::key_bindings::cosmic_modifiers_from_smithay,
-    shell::{layout::tiling::NodeDesc, Trigger},
+    shell::{Trigger, layout::tiling::NodeDesc},
     state::State,
 };
 

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -2,11 +2,14 @@
 
 use crate::{
     backend::render::{
-        element::AsGlowRenderer, BackdropShader, IndicatorShader, Key, Usage, ACTIVE_GROUP_COLOR,
-        GROUP_COLOR,
+        ACTIVE_GROUP_COLOR, BackdropShader, GROUP_COLOR, IndicatorShader, Key, Usage,
+        element::AsGlowRenderer,
     },
     shell::{
+        CosmicSurface, Direction, FocusResult, MoveResult, OutputNotMapped, OverviewMode,
+        ResizeMode, Trigger,
         element::{
+            CosmicMapped, CosmicMappedRenderElement, CosmicStack, CosmicWindow,
             resize_indicator::ResizeIndicator,
             stack::{
                 CosmicStackRenderElement, MoveResult as StackMoveResult,
@@ -14,16 +17,13 @@ use crate::{
             },
             swap_indicator::SwapIndicator,
             window::CosmicWindowRenderElement,
-            CosmicMapped, CosmicMappedRenderElement, CosmicStack, CosmicWindow,
         },
         focus::{
-            target::{KeyboardFocusTarget, PointerFocusTarget, WindowGroup},
             FocusStackMut, FocusTarget,
+            target::{KeyboardFocusTarget, PointerFocusTarget, WindowGroup},
         },
         grabs::ResizeEdge,
         layout::Orientation,
-        CosmicSurface, Direction, FocusResult, MoveResult, OutputNotMapped, OverviewMode,
-        ResizeMode, Trigger,
     },
     utils::{prelude::*, tween::EaseRectangle},
     wayland::{
@@ -46,17 +46,17 @@ use keyframe::{
 };
 use smithay::{
     backend::renderer::{
+        ImportAll, ImportMem, Renderer,
         element::{
-            utils::{
-                constrain_render_elements, ConstrainAlign, ConstrainScaleBehavior,
-                RescaleRenderElement,
-            },
             AsRenderElements, Id, RenderElement,
+            utils::{
+                ConstrainAlign, ConstrainScaleBehavior, RescaleRenderElement,
+                constrain_render_elements,
+            },
         },
         glow::GlowRenderer,
-        ImportAll, ImportMem, Renderer,
     },
-    desktop::{layer_map_for_output, space::SpaceElement, PopupKind, WindowSurfaceType},
+    desktop::{PopupKind, WindowSurfaceType, layer_map_for_output, space::SpaceElement},
     input::Seat,
     output::Output,
     reexports::wayland_server::Client,
@@ -744,7 +744,7 @@ impl TilingLayout {
                     }
                 };
 
-                for (ref mut parent_id, _) in children.iter_mut() {
+                for (parent_id, _) in children.iter_mut() {
                     *parent_id = id.clone();
                 }
                 if let Data::Mapped { mapped, .. } = other_tree.get_mut(&id).unwrap().data_mut() {
@@ -2219,12 +2219,14 @@ impl TilingLayout {
                 Data::Group { alive, .. } => KeyboardFocusTarget::Group(WindowGroup {
                     node: node_id.clone(),
                     alive: Arc::downgrade(alive),
-                    focus_stack: vec![new_elements[0]
-                        .tiling_node_id
-                        .lock()
-                        .unwrap()
-                        .clone()
-                        .unwrap()],
+                    focus_stack: vec![
+                        new_elements[0]
+                            .tiling_node_id
+                            .lock()
+                            .unwrap()
+                            .clone()
+                            .unwrap(),
+                    ],
                 }),
                 Data::Mapped { mapped, .. } => KeyboardFocusTarget::Element(mapped.clone()),
                 _ => unreachable!(),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use layout::TilingExceptions;
 use std::{
     collections::HashMap,
-    sync::{atomic::Ordering, Mutex},
+    sync::{Mutex, atomic::Ordering},
     thread,
     time::{Duration, Instant},
 };
@@ -19,8 +19,8 @@ use crate::{
     },
 };
 use cosmic_comp_config::{
-    workspace::{PinnedWorkspace, WorkspaceLayout, WorkspaceMode},
     TileBehavior, ZoomConfig, ZoomMovement,
+    workspace::{PinnedWorkspace, WorkspaceLayout, WorkspaceMode},
 };
 use cosmic_config::ConfigSet;
 use cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::TilingState;
@@ -30,28 +30,27 @@ use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
     backend::{input::TouchSlot, renderer::element::RenderElementStates},
     desktop::{
-        layer_map_for_output,
+        LayerSurface, PopupKind, WindowSurface, WindowSurfaceType, layer_map_for_output,
         space::SpaceElement,
         utils::{
-            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
-            take_presentation_feedback_surface_tree, OutputPresentationFeedback,
+            OutputPresentationFeedback, surface_presentation_feedback_flags_from_states,
+            surface_primary_scanout_output, take_presentation_feedback_surface_tree,
         },
-        LayerSurface, PopupKind, WindowSurface, WindowSurfaceType,
     },
     input::{
+        Seat,
         pointer::{
             CursorImageStatus, CursorImageSurfaceData, Focus, GrabStartData as PointerGrabStartData,
         },
-        Seat,
     },
     output::{Output, WeakOutput},
     reexports::{
         wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1,
-        wayland_server::{protocol::wl_surface::WlSurface, Client},
+        wayland_server::{Client, protocol::wl_surface::WlSurface},
     },
     utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
     wayland::{
-        compositor::{with_states, SurfaceAttributes},
+        compositor::{SurfaceAttributes, with_states},
         seat::WaylandFocus,
         session_lock::LockSurface,
         shell::wlr_layer::{KeyboardInteractivity, Layer, LayerSurfaceCachedState},
@@ -73,8 +72,8 @@ use crate::{
         },
         protocols::{
             toplevel_info::{
-                toplevel_enter_output, toplevel_enter_workspace, toplevel_leave_output,
-                toplevel_leave_workspace, ToplevelInfoState,
+                ToplevelInfoState, toplevel_enter_output, toplevel_enter_workspace,
+                toplevel_leave_output, toplevel_leave_workspace,
             },
             workspace::{
                 WorkspaceGroupHandle, WorkspaceHandle, WorkspaceState, WorkspaceUpdateGuard,
@@ -97,14 +96,14 @@ use self::zoom::{OutputZoomState, ZoomState};
 
 use self::{
     element::{
-        resize_indicator::{resize_indicator, ResizeIndicator},
-        swap_indicator::{swap_indicator, SwapIndicator},
         CosmicWindow, MaximizedState,
+        resize_indicator::{ResizeIndicator, resize_indicator},
+        swap_indicator::{SwapIndicator, swap_indicator},
     },
     focus::target::{KeyboardFocusTarget, PointerFocusTarget},
     grabs::{
-        tab_items, window_items, GrabStartData, Item, MenuGrab, MoveGrab, ReleaseMode, ResizeEdge,
-        ResizeGrab,
+        GrabStartData, Item, MenuGrab, MoveGrab, ReleaseMode, ResizeEdge, ResizeGrab, tab_items,
+        window_items,
     },
     layout::{
         floating::{FloatingLayout, ResizeState},
@@ -2031,11 +2030,7 @@ impl Shell {
                     Direction::Left => current_output_geo.loc.x - origin.x,
                     Direction::Right => origin.x - current_output_geo.loc.x,
                 };
-                if res > 0 {
-                    Some((o, res))
-                } else {
-                    None
-                }
+                if res > 0 { Some((o, res)) } else { None }
             })
             .min_by_key(|(_, res)| *res)
             .map(|(o, _)| o)
@@ -3295,22 +3290,29 @@ impl Shell {
             let is_stacked = mapped.is_stack();
 
             if target_stack || !is_stacked {
-                Box::new(window_items(
-                    &mapped,
-                    is_tiled,
-                    is_stacked,
-                    is_sticky,
-                    tiling_enabled,
-                    edge,
-                    config,
-                )) as Box<dyn Iterator<Item = Item>>
+                Box::new(
+                    window_items(
+                        &mapped,
+                        is_tiled,
+                        is_stacked,
+                        is_sticky,
+                        tiling_enabled,
+                        edge,
+                        config,
+                    )
+                    .collect::<Vec<Item>>()
+                    .into_iter(),
+                ) as Box<dyn Iterator<Item = Item>>
             } else {
                 let (tab, _) = mapped
                     .windows()
                     .find(|(s, _)| s.wl_surface().as_deref() == Some(surface))
                     .unwrap();
-                Box::new(tab_items(&mapped, &tab, is_tiled, config))
-                    as Box<dyn Iterator<Item = Item>>
+                Box::new(
+                    tab_items(&mapped, &tab, is_tiled, config)
+                        .collect::<Vec<Item>>()
+                        .into_iter(),
+                ) as Box<dyn Iterator<Item = Item>>
             }
         };
 
@@ -3320,7 +3322,7 @@ impl Shell {
                     .mapped()
                     .find_map(|m| {
                         m.windows()
-                            .find(|(ref w, _)| w == surface)
+                            .find(|(w, _)| w == surface)
                             .map(|(_, loc)| (m, loc))
                     })
                     .map(|(mapped, relative_loc)| (set, mapped, relative_loc))
@@ -3766,41 +3768,25 @@ impl Shell {
                     .filter(|(_, other_geo)| other_geo.loc.y <= geometry.loc.y)
                     .min_by_key(|(_, other_geo)| {
                         let res = geometry.loc.y - other_geo.loc.y;
-                        if res.is_positive() {
-                            res
-                        } else {
-                            i32::MAX
-                        }
+                        if res.is_positive() { res } else { i32::MAX }
                     }),
                 FocusDirection::Down => elements
                     .filter(|(_, other_geo)| other_geo.loc.y > geometry.loc.y)
                     .max_by_key(|(_, other_geo)| {
                         let res = geometry.loc.y - other_geo.loc.y;
-                        if res.is_negative() {
-                            res
-                        } else {
-                            i32::MIN
-                        }
+                        if res.is_negative() { res } else { i32::MIN }
                     }),
                 FocusDirection::Left => elements
                     .filter(|(_, other_geo)| other_geo.loc.x <= geometry.loc.x)
                     .min_by_key(|(_, other_geo)| {
                         let res = geometry.loc.x - other_geo.loc.x;
-                        if res.is_positive() {
-                            res
-                        } else {
-                            i32::MAX
-                        }
+                        if res.is_positive() { res } else { i32::MAX }
                     }),
                 FocusDirection::Right => elements
                     .filter(|(_, other_geo)| other_geo.loc.x > geometry.loc.x)
                     .max_by_key(|(_, other_geo)| {
                         let res = geometry.loc.x - other_geo.loc.x;
-                        if res.is_negative() {
-                            res
-                        } else {
-                            i32::MIN
-                        }
+                        if res.is_negative() { res } else { i32::MIN }
                     }),
                 _ => return FocusResult::None,
             }

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -4,7 +4,7 @@ use std::{any::Any, cell::RefCell, collections::HashMap, sync::Mutex};
 
 use crate::{
     backend::render::cursor::CursorState,
-    config::{xkb_config_to_wl, Config},
+    config::{Config, xkb_config_to_wl},
     input::{ModifiersShortcutQueue, SupressedButtons, SupressedKeys},
     state::State,
 };
@@ -12,9 +12,9 @@ use smithay::{
     backend::input::{Device, DeviceCapability},
     desktop::utils::bbox_from_surface_tree,
     input::{
+        Seat, SeatState,
         keyboard::{LedState, XkbConfig},
         pointer::{CursorImageAttributes, CursorImageStatus},
-        Seat, SeatState,
     },
     output::Output,
     reexports::{input::Device as InputDevice, wayland_server::DisplayHandle},

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -3,12 +3,12 @@ use crate::shell::layout::tiling::RestoreTilingState;
 use crate::wayland::handlers::xdg_activation::ActivationContext;
 use crate::{
     backend::render::{
-        element::{AsGlowRenderer, FromGlesError},
         BackdropShader,
+        element::{AsGlowRenderer, FromGlesError},
     },
     shell::{
+        ANIMATION_DURATION, OverviewMode,
         layout::{floating::FloatingLayout, tiling::TilingLayout},
-        OverviewMode, ANIMATION_DURATION,
     },
     state::State,
     utils::{prelude::*, tween::EaseRectangle},
@@ -30,16 +30,16 @@ use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::output::WeakOutput;
 use smithay::{
     backend::renderer::{
+        ImportAll, ImportMem, Renderer,
         element::{
-            surface::WaylandSurfaceRenderElement, texture::TextureRenderElement,
-            utils::RescaleRenderElement, Element, Id, RenderElement,
+            Element, Id, RenderElement, surface::WaylandSurfaceRenderElement,
+            texture::TextureRenderElement, utils::RescaleRenderElement,
         },
         gles::GlesTexture,
         glow::GlowRenderer,
         utils::{DamageSet, OpaqueRegions},
-        ImportAll, ImportMem, Renderer,
     },
-    desktop::{layer_map_for_output, space::SpaceElement, WindowSurfaceType},
+    desktop::{WindowSurfaceType, layer_map_for_output, space::SpaceElement},
     input::Seat,
     output::Output,
     reexports::wayland_server::Client,
@@ -54,18 +54,18 @@ use std::{
 use wayland_backend::server::ClientId;
 
 use super::{
+    CosmicMappedRenderElement, CosmicSurface, ResizeDirection, ResizeMode,
     element::{
-        resize_indicator::ResizeIndicator, stack::CosmicStackRenderElement,
-        swap_indicator::SwapIndicator, window::CosmicWindowRenderElement, CosmicMapped,
-        MaximizedState,
+        CosmicMapped, MaximizedState, resize_indicator::ResizeIndicator,
+        stack::CosmicStackRenderElement, swap_indicator::SwapIndicator,
+        window::CosmicWindowRenderElement,
     },
     focus::{
-        target::{KeyboardFocusTarget, PointerFocusTarget, WindowGroup},
         FocusStack, FocusStackMut,
+        target::{KeyboardFocusTarget, PointerFocusTarget, WindowGroup},
     },
     grabs::ResizeEdge,
     layout::tiling::{Data, NodeDesc},
-    CosmicMappedRenderElement, CosmicSurface, ResizeDirection, ResizeMode,
 };
 
 const FULLSCREEN_ANIMATION_DURATION: Duration = Duration::from_millis(200);

--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -2,18 +2,19 @@ use std::{sync::Mutex, time::Instant};
 
 use calloop::LoopHandle;
 use cosmic::{
-    iced::{alignment::Vertical, Alignment, Background, Border, Length},
+    Apply,
+    iced::{Alignment, Background, Border, Length, alignment::Vertical},
     iced_widget, theme,
     widget::{self, icon::Named},
-    Apply,
 };
 use cosmic_comp_config::ZoomMovement;
 use cosmic_config::ConfigSet;
 use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
-    backend::renderer::{element::AsRenderElements, ImportMem, Renderer},
+    backend::renderer::{ImportMem, Renderer, element::AsRenderElements},
     desktop::space::SpaceElement,
     input::{
+        Seat,
         pointer::{
             AxisFrame, ButtonEvent, Focus, GestureHoldBeginEvent, GestureHoldEndEvent,
             GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -24,7 +25,6 @@ use smithay::{
             DownEvent, MotionEvent as TouchMotionEvent, OrientationEvent, ShapeEvent, TouchTarget,
             UpEvent,
         },
-        Seat,
     },
     output::Output,
     utils::{IsAlive, Point, Rectangle, Serial, Size},
@@ -42,10 +42,9 @@ use crate::{
 };
 
 use super::{
-    check_grab_preconditions,
+    ANIMATION_DURATION, check_grab_preconditions,
     focus::target::PointerFocusTarget,
     grabs::{ContextMenu, Item, MenuAlignment, MenuGrab},
-    ANIMATION_DURATION,
 };
 
 #[derive(Debug, Clone)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,8 +8,8 @@ use crate::{
         x11::X11State,
     },
     config::{Config, OutputConfig, OutputState, ScreenFilter},
-    input::{gestures::GestureState, PointerFocusState},
-    shell::{grabs::SeatMoveGrabState, CosmicSurface, SeatExt, Shell},
+    input::{PointerFocusState, gestures::GestureState},
+    shell::{CosmicSurface, SeatExt, Shell, grabs::SeatMoveGrabState},
     utils::prelude::OutputExt,
     wayland::{
         handlers::{data_device::get_dnd_icon, screencopy::SessionHolder},
@@ -32,42 +32,40 @@ use crate::{
 use anyhow::Context;
 use calloop::RegistrationToken;
 use i18n_embed::{
-    fluent::{fluent_language_loader, FluentLanguageLoader},
     DesktopLanguageRequester,
+    fluent::{FluentLanguageLoader, fluent_language_loader},
 };
-use once_cell::sync::Lazy;
 use rust_embed::RustEmbed;
 use smithay::{
     backend::{
-        allocator::{dmabuf::Dmabuf, Fourcc},
+        allocator::{Fourcc, dmabuf::Dmabuf},
         drm::DrmNode,
         renderer::{
-            element::{
-                default_primary_scanout_output_compare, utils::select_dmabuf_feedback,
-                RenderElementState, RenderElementStates,
-            },
             ImportDma,
+            element::{
+                RenderElementState, RenderElementStates, default_primary_scanout_output_compare,
+                utils::select_dmabuf_feedback,
+            },
         },
     },
     desktop::{
-        layer_map_for_output,
+        PopupManager, layer_map_for_output,
         utils::{
             send_dmabuf_feedback_surface_tree, send_frames_surface_tree,
             surface_primary_scanout_output, update_surface_primary_scanout_output,
             with_surfaces_surface_tree,
         },
-        PopupManager,
     },
-    input::{pointer::CursorImageStatus, SeatState},
+    input::{SeatState, pointer::CursorImageStatus},
     output::{Output, Scale, WeakOutput},
     reexports::{
         calloop::{LoopHandle, LoopSignal},
         wayland_protocols::xdg::shell::server::xdg_toplevel::WmCapabilities,
         wayland_protocols_misc::server_decoration::server::org_kde_kwin_server_decoration_manager::Mode,
         wayland_server::{
+            Client, DisplayHandle, Resource,
             backend::{ClientData, ClientId, DisconnectReason},
             protocol::{wl_shm, wl_surface::WlSurface},
-            Client, DisplayHandle, Resource,
         },
     },
     utils::{Clock, Monotonic, Point},
@@ -76,7 +74,7 @@ use smithay::{
         compositor::{CompositorClientState, CompositorState, SurfaceData},
         cursor_shape::CursorShapeManagerState,
         dmabuf::{DmabufFeedback, DmabufGlobal, DmabufState},
-        fractional_scale::{with_fractional_scale, FractionalScaleManagerState},
+        fractional_scale::{FractionalScaleManagerState, with_fractional_scale},
         idle_inhibit::IdleInhibitManagerState,
         idle_notify::IdleNotifierState,
         input_method::InputMethodManagerState,
@@ -95,7 +93,7 @@ use smithay::{
         shell::{
             kde::decoration::KdeDecorationState,
             wlr_layer::WlrLayerShellState,
-            xdg::{decoration::XdgDecorationState, XdgShellState},
+            xdg::{XdgShellState, decoration::XdgDecorationState},
         },
         shm::ShmState,
         single_pixel_buffer::SinglePixelBufferState,
@@ -118,7 +116,7 @@ use std::{
     collections::HashSet,
     ffi::OsString,
     process::Child,
-    sync::{atomic::AtomicBool, Arc, Once},
+    sync::{Arc, LazyLock, Once, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -126,7 +124,8 @@ use std::{
 #[folder = "resources/i18n"]
 struct Localizations;
 
-pub static LANG_LOADER: Lazy<FluentLanguageLoader> = Lazy::new(|| fluent_language_loader!());
+pub static LANG_LOADER: LazyLock<FluentLanguageLoader> =
+    LazyLock::new(|| fluent_language_loader!());
 
 #[macro_export]
 macro_rules! fl {
@@ -283,21 +282,21 @@ impl Default for SurfaceFrameThrottlingState {
 impl BackendData {
     pub fn kms(&mut self) -> &mut KmsState {
         match self {
-            BackendData::Kms(ref mut kms_state) => kms_state,
+            BackendData::Kms(kms_state) => kms_state,
             _ => unreachable!("Called kms in non kms backend"),
         }
     }
 
     pub fn x11(&mut self) -> &mut X11State {
         match self {
-            BackendData::X11(ref mut x11_state) => x11_state,
+            BackendData::X11(x11_state) => x11_state,
             _ => unreachable!("Called x11 in non x11 backend"),
         }
     }
 
     pub fn winit(&mut self) -> &mut WinitState {
         match self {
-            BackendData::Winit(ref mut winit_state) => winit_state,
+            BackendData::Winit(winit_state) => winit_state,
             _ => unreachable!("Called winit in non winit backend"),
         }
     }
@@ -314,7 +313,7 @@ impl BackendData {
         clock: &Clock<Monotonic>,
     ) -> Result<(), anyhow::Error> {
         let result = match self {
-            BackendData::Kms(ref mut state) => state.apply_config_for_outputs(
+            BackendData::Kms(state) => state.apply_config_for_outputs(
                 test_only,
                 loop_handle,
                 screen_filter,
@@ -322,8 +321,8 @@ impl BackendData {
                 startup_done,
                 clock,
             ),
-            BackendData::Winit(ref mut state) => state.apply_config_for_outputs(test_only),
-            BackendData::X11(ref mut state) => state.apply_config_for_outputs(test_only),
+            BackendData::Winit(state) => state.apply_config_for_outputs(test_only),
+            BackendData::X11(state) => state.apply_config_for_outputs(test_only),
             _ => unreachable!("No backend set when applying output config"),
         }?;
 
@@ -394,8 +393,8 @@ impl BackendData {
             BackendData::Winit(_) => {} // We cannot do this on the winit backend.
             // Winit has a very strict render-loop and skipping frames breaks atleast the wayland winit-backend.
             // Swapping with damage (which should be empty on these frames) is likely good enough anyway.
-            BackendData::X11(ref mut state) => state.schedule_render(output),
-            BackendData::Kms(ref mut state) => state.schedule_render(output),
+            BackendData::X11(state) => state.schedule_render(output),
+            BackendData::Kms(state) => state.schedule_render(output),
             _ => unreachable!("No backend was initialized"),
         }
     }
@@ -407,15 +406,15 @@ impl BackendData {
         dmabuf: Dmabuf,
     ) -> Result<Option<DrmNode>, anyhow::Error> {
         match self {
-            BackendData::Kms(ref mut state) => {
+            BackendData::Kms(state) => {
                 return state
                     .dmabuf_imported(client, global, dmabuf)
-                    .map(|node| Some(node))
+                    .map(|node| Some(node));
             }
-            BackendData::Winit(ref mut state) => {
+            BackendData::Winit(state) => {
                 state.backend.renderer().import_dmabuf(&dmabuf, None)?;
             }
-            BackendData::X11(ref mut state) => {
+            BackendData::X11(state) => {
                 state.renderer.import_dmabuf(&dmabuf, None)?;
             }
             _ => unreachable!("No backend set when importing dmabuf"),
@@ -457,9 +456,9 @@ impl BackendData {
 
     pub fn update_screen_filter(&mut self, screen_filter: &ScreenFilter) -> anyhow::Result<()> {
         match self {
-            BackendData::Kms(ref mut state) => state.update_screen_filter(screen_filter),
-            BackendData::Winit(ref mut state) => state.update_screen_filter(screen_filter),
-            BackendData::X11(ref mut state) => state.update_screen_filter(screen_filter),
+            BackendData::Kms(state) => state.update_screen_filter(screen_filter),
+            BackendData::Winit(state) => state.update_screen_filter(screen_filter),
+            BackendData::X11(state) => state.update_screen_filter(screen_filter),
             _ => unreachable!("No backend set when setting screen filters"),
         }
     }

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::Common;
-use libsystemd::daemon::{booted, notify, NotifyState};
+use libsystemd::daemon::{NotifyState, booted, notify};
 use std::process::Command;
 use tracing::{error, warn};
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -3,7 +3,7 @@
 // update a Arc<Mutex<Theme>> in the state on change of the theme and mark all interfaces for a redraw.
 
 use calloop::LoopHandle;
-use cosmic::cosmic_theme::{palette, Theme, ThemeMode};
+use cosmic::cosmic_theme::{Theme, ThemeMode, palette};
 
 use crate::state::State;
 

--- a/src/utils/ids.rs
+++ b/src/utils/ids.rs
@@ -4,10 +4,8 @@
 macro_rules! id_gen {
     ($func_name:ident, $id_name:ident, $ids_name:ident) => {
         static $id_name: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-        lazy_static::lazy_static! {
-            static ref $ids_name: std::sync::Mutex<std::collections::HashSet<usize>> =
-                std::sync::Mutex::new(std::collections::HashSet::new());
-        }
+        static $ids_name: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<usize>>> =
+            std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
 
         fn $func_name() -> usize {
             let mut ids = $ids_name.lock().unwrap();

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -16,8 +16,8 @@ use crate::{
 use std::{
     cell::{Ref, RefCell, RefMut},
     sync::{
-        atomic::{AtomicU8, Ordering},
         Mutex,
+        atomic::{AtomicU8, Ordering},
     },
 };
 

--- a/src/utils/rlimit.rs
+++ b/src/utils/rlimit.rs
@@ -1,4 +1,4 @@
-use rustix::process::{getrlimit, setrlimit, Resource, Rlimit};
+use rustix::process::{Resource, Rlimit, getrlimit, setrlimit};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static OLD_LIMIT: AtomicU64 = AtomicU64::new(0);

--- a/src/utils/screenshot.rs
+++ b/src/utils/screenshot.rs
@@ -3,10 +3,10 @@ use smithay::{
     backend::{
         allocator::Fourcc,
         renderer::{
-            damage::OutputDamageTracker,
-            element::{surface::WaylandSurfaceRenderElement, AsRenderElements},
-            gles::GlesRenderbuffer,
             ExportMem, ImportAll, Offscreen, Renderer,
+            damage::OutputDamageTracker,
+            element::{AsRenderElements, surface::WaylandSurfaceRenderElement},
+            gles::GlesRenderbuffer,
         },
     },
     desktop::utils::bbox_from_surface_tree,
@@ -18,7 +18,7 @@ use tracing::warn;
 use crate::{
     backend::render::RendererRef,
     shell::element::CosmicSurface,
-    state::{advertised_node_for_surface, State},
+    state::{State, advertised_node_for_surface},
 };
 
 pub fn screenshot_window(state: &mut State, surface: &CosmicSurface) {

--- a/src/utils/tween.rs
+++ b/src/utils/tween.rs
@@ -1,4 +1,4 @@
-use keyframe::{num_traits::Float, CanTween};
+use keyframe::{CanTween, num_traits::Float};
 use smithay::utils::{Coordinate, Point, Rectangle, Size};
 
 pub struct EasePoint<N: Coordinate, Kind>(pub Point<N, Kind>);

--- a/src/wayland/handlers/a11y.rs
+++ b/src/wayland/handlers/a11y.rs
@@ -3,7 +3,7 @@ use tracing::warn;
 use crate::{
     config::ColorFilter,
     state::State,
-    wayland::protocols::a11y::{delegate_a11y, A11yHandler, A11yState},
+    wayland::protocols::a11y::{A11yHandler, A11yState, delegate_a11y},
 };
 
 impl A11yHandler for State {

--- a/src/wayland/handlers/atspi.rs
+++ b/src/wayland/handlers/atspi.rs
@@ -22,7 +22,7 @@ use xkbcommon::xkb;
 
 use crate::{
     state::State,
-    wayland::protocols::atspi::{delegate_atspi, AtspiHandler},
+    wayland::protocols::atspi::{AtspiHandler, delegate_atspi},
 };
 
 #[derive(PartialEq, Debug)]

--- a/src/wayland/handlers/buffer.rs
+++ b/src/wayland/handlers/buffer.rs
@@ -2,7 +2,7 @@
 
 use crate::{state::BackendData, utils::prelude::*};
 use smithay::{
-    reexports::wayland_server::{protocol::wl_buffer::WlBuffer, Resource},
+    reexports::wayland_server::{Resource, protocol::wl_buffer::WlBuffer},
     wayland::buffer::BufferHandler,
 };
 use tracing::warn;

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -5,13 +5,13 @@ use calloop::Interest;
 use smithay::{
     backend::renderer::utils::{on_commit_buffer_handler, with_renderer_surface_state},
     delegate_compositor,
-    desktop::{layer_map_for_output, LayerSurface, PopupKind, WindowSurfaceType},
-    reexports::wayland_server::{protocol::wl_surface::WlSurface, Client, Resource},
-    utils::{Logical, Size, SERIAL_COUNTER},
+    desktop::{LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output},
+    reexports::wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
+    utils::{Logical, SERIAL_COUNTER, Size},
     wayland::{
         compositor::{
-            add_blocker, add_pre_commit_hook, with_states, BufferAssignment, CompositorClientState,
-            CompositorHandler, CompositorState, SurfaceAttributes,
+            BufferAssignment, CompositorClientState, CompositorHandler, CompositorState,
+            SurfaceAttributes, add_blocker, add_pre_commit_hook, with_states,
         },
         dmabuf::get_dmabuf,
         drm_syncobj::DrmSyncobjCachedState,
@@ -49,7 +49,7 @@ fn toplevel_ensure_initial_configure(
 }
 
 fn xdg_popup_ensure_initial_configure(popup: &PopupKind) {
-    if let PopupKind::Xdg(ref popup) = popup {
+    if let PopupKind::Xdg(popup) = popup {
         let initial_configure_sent = with_states(popup.wl_surface(), |states| {
             states
                 .data_map

--- a/src/wayland/handlers/data_device.rs
+++ b/src/wayland/handlers/data_device.rs
@@ -4,8 +4,8 @@ use crate::{state::State, utils::prelude::SeatExt};
 use smithay::{
     delegate_data_device,
     input::{
-        pointer::{CursorImageStatus, CursorImageSurfaceData},
         Seat,
+        pointer::{CursorImageStatus, CursorImageSurfaceData},
     },
     reexports::wayland_server::protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
     utils::{IsAlive, Logical, Point},

--- a/src/wayland/handlers/decoration.rs
+++ b/src/wayland/handlers/decoration.rs
@@ -15,7 +15,7 @@ use smithay::{
         seat::WaylandFocus,
         shell::{
             kde::decoration::{KdeDecorationHandler, KdeDecorationState},
-            xdg::{decoration::XdgDecorationHandler, ToplevelSurface},
+            xdg::{ToplevelSurface, decoration::XdgDecorationHandler},
         },
     },
 };

--- a/src/wayland/handlers/drm.rs
+++ b/src/wayland/handlers/drm.rs
@@ -2,11 +2,11 @@
 
 use crate::{
     state::{BackendData, State},
-    wayland::protocols::drm::{delegate_wl_drm, DrmHandler, ImportError},
+    wayland::protocols::drm::{DrmHandler, ImportError, delegate_wl_drm},
 };
 use smithay::{
     backend::{allocator::dmabuf::Dmabuf, drm::DrmNode},
-    reexports::wayland_server::{protocol::wl_buffer::WlBuffer, Resource},
+    reexports::wayland_server::{Resource, protocol::wl_buffer::WlBuffer},
     wayland::dmabuf::DmabufGlobal,
 };
 use tracing::warn;

--- a/src/wayland/handlers/fractional_scale.rs
+++ b/src/wayland/handlers/fractional_scale.rs
@@ -5,7 +5,7 @@ use smithay::{
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::{
         compositor::{get_parent, with_states},
-        fractional_scale::{with_fractional_scale, FractionalScaleHandler},
+        fractional_scale::{FractionalScaleHandler, with_fractional_scale},
     },
 };
 

--- a/src/wayland/handlers/input_method.rs
+++ b/src/wayland/handlers/input_method.rs
@@ -3,7 +3,7 @@
 use crate::state::State;
 use smithay::{
     delegate_input_method_manager,
-    desktop::{space::SpaceElement, PopupKind, PopupManager},
+    desktop::{PopupKind, PopupManager, space::SpaceElement},
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::Rectangle,
     wayland::input_method::{InputMethodHandler, PopupSurface},

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -3,7 +3,7 @@
 use crate::{shell::PendingLayer, utils::prelude::*};
 use smithay::{
     delegate_layer_shell,
-    desktop::{layer_map_for_output, LayerSurface, PopupKind, WindowSurfaceType},
+    desktop::{LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output},
     output::Output,
     reexports::wayland_server::protocol::wl_output::WlOutput,
     wayland::shell::{

--- a/src/wayland/handlers/output_configuration.rs
+++ b/src/wayland/handlers/output_configuration.rs
@@ -8,8 +8,8 @@ use crate::{
     state::State,
     utils::prelude::OutputExt,
     wayland::protocols::output_configuration::{
-        delegate_output_configuration, ModeConfiguration, OutputConfiguration,
-        OutputConfigurationHandler, OutputConfigurationState,
+        ModeConfiguration, OutputConfiguration, OutputConfigurationHandler,
+        OutputConfigurationState, delegate_output_configuration,
     },
 };
 
@@ -72,10 +72,7 @@ impl State {
 
             if offset_x > 0 || offset_y > 0 {
                 for (output, conf) in conf.iter_mut() {
-                    if let OutputConfiguration::Enabled {
-                        ref mut position, ..
-                    } = conf
-                    {
+                    if let OutputConfiguration::Enabled { position, .. } = conf {
                         let current_config = output
                             .user_data()
                             .get::<RefCell<OutputConfig>>()

--- a/src/wayland/handlers/output_power.rs
+++ b/src/wayland/handlers/output_power.rs
@@ -7,7 +7,7 @@ use crate::{
     state::{BackendData, State},
     utils::prelude::OutputExt,
     wayland::protocols::output_power::{
-        delegate_output_power, OutputPowerHandler, OutputPowerState,
+        OutputPowerHandler, OutputPowerState, delegate_output_power,
     },
 };
 
@@ -26,7 +26,7 @@ pub fn set_all_surfaces_dpms_on(state: &mut State) {
 }
 
 fn kms_surfaces(state: &mut State) -> impl Iterator<Item = &mut Surface> {
-    if let BackendData::Kms(ref mut kms_state) = &mut state.backend {
+    if let BackendData::Kms(kms_state) = &mut state.backend {
         Some(
             kms_state
                 .drm_devices

--- a/src/wayland/handlers/overlap_notify.rs
+++ b/src/wayland/handlers/overlap_notify.rs
@@ -1,5 +1,5 @@
 use smithay::{
-    desktop::{layer_map_for_output, LayerSurface, WindowSurfaceType},
+    desktop::{LayerSurface, WindowSurfaceType, layer_map_for_output},
     output::Output,
     reexports::wayland_protocols_wlr::layer_shell::v1::server::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
 };
@@ -7,7 +7,7 @@ use smithay::{
 use crate::{
     state::State,
     wayland::protocols::overlap_notify::{
-        delegate_overlap_notify, OverlapNotifyHandler, OverlapNotifyState,
+        OverlapNotifyHandler, OverlapNotifyState, delegate_overlap_notify,
     },
 };
 

--- a/src/wayland/handlers/pointer_constraints.rs
+++ b/src/wayland/handlers/pointer_constraints.rs
@@ -7,7 +7,7 @@ use smithay::{
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::{Logical, Point},
     wayland::{
-        pointer_constraints::{with_pointer_constraint, PointerConstraintsHandler},
+        pointer_constraints::{PointerConstraintsHandler, with_pointer_constraint},
         seat::WaylandFocus,
     },
 };

--- a/src/wayland/handlers/screencopy/mod.rs
+++ b/src/wayland/handlers/screencopy/mod.rs
@@ -27,9 +27,8 @@ use crate::{
     wayland::protocols::{
         image_capture_source::ImageCaptureSourceData,
         screencopy::{
-            delegate_screencopy, BufferConstraints, CursorSession, CursorSessionRef,
-            DmabufConstraints, Frame, FrameRef, ScreencopyHandler, ScreencopyState, Session,
-            SessionRef,
+            BufferConstraints, CursorSession, CursorSessionRef, DmabufConstraints, Frame, FrameRef,
+            ScreencopyHandler, ScreencopyState, Session, SessionRef, delegate_screencopy,
         },
     },
 };

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -1,18 +1,18 @@
 use smithay::{
     backend::{
-        allocator::{dmabuf::Dmabuf, format::get_transparent, Buffer, Fourcc},
+        allocator::{Buffer, Fourcc, dmabuf::Dmabuf, format::get_transparent},
         renderer::{
+            Bind, Blit, BufferType, Color32F, ExportMem, ImportAll, ImportMem, Offscreen, Renderer,
             buffer_dimensions, buffer_type,
             damage::{Error as DTError, OutputDamageTracker, RenderOutputResult},
             element::{
+                AsRenderElements, RenderElement,
                 surface::WaylandSurfaceRenderElement,
                 utils::{Relocate, RelocateRenderElement},
-                AsRenderElements, RenderElement,
             },
             gles::{GlesError, GlesRenderbuffer},
             sync::SyncPoint,
             utils::with_renderer_surface_state,
-            Bind, Blit, BufferType, Color32F, ExportMem, ImportAll, ImportMem, Offscreen, Renderer,
         },
     },
     desktop::space::SpaceElement,
@@ -34,16 +34,16 @@ use tracing::warn;
 
 use crate::{
     backend::render::{
-        cursor,
+        CursorMode, ElementFilter, RendererRef, cursor,
         element::{AsGlowRenderer, CosmicElement, DamageElement, FromGlesError},
-        render_workspace, CursorMode, ElementFilter, RendererRef,
+        render_workspace,
     },
     shell::{CosmicMappedRenderElement, CosmicSurface, WorkspaceRenderElement},
     state::{Common, KmsNodes, State},
     utils::prelude::SeatExt,
     wayland::{
         handlers::screencopy::{
-            constraints_for_output, constraints_for_toplevel, SessionData, SessionUserData,
+            SessionData, SessionUserData, constraints_for_output, constraints_for_toplevel,
         },
         protocols::{
             screencopy::{BufferConstraints, CursorSessionRef, FailureReason, Frame, SessionRef},
@@ -518,11 +518,7 @@ pub fn render_window_to_buffer(
         let location = if let Some(mapped) = shell.element_for_surface(window) {
             mapped.cursor_position(&seat).and_then(|mut p| {
                 p -= mapped.active_window_offset().to_f64();
-                if p.x < 0. || p.y < 0. {
-                    None
-                } else {
-                    Some(p)
-                }
+                if p.x < 0. || p.y < 0. { None } else { Some(p) }
             })
         } else {
             None

--- a/src/wayland/handlers/screencopy/user_data.rs
+++ b/src/wayland/handlers/screencopy/user_data.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, collections::HashMap, sync::Mutex};
 use smithay::{
     backend::renderer::{damage::OutputDamageTracker, utils::CommitCounter},
     output::Output,
-    reexports::wayland_server::{protocol::wl_buffer::WlBuffer, Resource, Weak},
+    reexports::wayland_server::{Resource, Weak, protocol::wl_buffer::WlBuffer},
 };
 
 use crate::{

--- a/src/wayland/handlers/seat.rs
+++ b/src/wayland/handlers/seat.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
-    shell::focus::target::{KeyboardFocusTarget, PointerFocusTarget},
     shell::Devices,
+    shell::focus::target::{KeyboardFocusTarget, PointerFocusTarget},
     state::State,
     utils::prelude::SeatExt,
 };
 use smithay::{
     delegate_cursor_shape, delegate_seat,
-    input::{keyboard::LedState, pointer::CursorImageStatus, SeatHandler, SeatState},
+    input::{SeatHandler, SeatState, keyboard::LedState, pointer::CursorImageStatus},
 };
 
 impl SeatHandler for State {

--- a/src/wayland/handlers/session_lock.rs
+++ b/src/wayland/handlers/session_lock.rs
@@ -4,7 +4,7 @@ use crate::{shell::SessionLock, state::State, utils::prelude::*};
 use smithay::{
     delegate_session_lock,
     output::Output,
-    reexports::wayland_server::{protocol::wl_output::WlOutput, Resource},
+    reexports::wayland_server::{Resource, protocol::wl_output::WlOutput},
     utils::Size,
     wayland::session_lock::{
         LockSurface, SessionLockHandler, SessionLockManagerState, SessionLocker,

--- a/src/wayland/handlers/toplevel_info.rs
+++ b/src/wayland/handlers/toplevel_info.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use smithay::utils::{user_data::UserDataMap, Rectangle};
+use smithay::utils::{Rectangle, user_data::UserDataMap};
 
 use crate::{
     shell::CosmicSurface,
     state::State,
     utils::prelude::Global,
     wayland::protocols::toplevel_info::{
-        delegate_toplevel_info, ToplevelInfoHandler, ToplevelInfoState, Window,
+        ToplevelInfoHandler, ToplevelInfoState, Window, delegate_toplevel_info,
     },
 };
 

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use smithay::{
-    desktop::{layer_map_for_output, WindowSurfaceType},
-    input::{pointer::MotionEvent, Seat},
+    desktop::{WindowSurfaceType, layer_map_for_output},
+    input::{Seat, pointer::MotionEvent},
     output::Output,
     reexports::wayland_server::DisplayHandle,
-    utils::{Point, Rectangle, Size, SERIAL_COUNTER},
+    utils::{Point, Rectangle, SERIAL_COUNTER, Size},
     wayland::seat::WaylandFocus,
 };
 
 use crate::{
-    shell::{focus::target::KeyboardFocusTarget, CosmicSurface, Shell, WorkspaceDelta},
+    shell::{CosmicSurface, Shell, WorkspaceDelta, focus::target::KeyboardFocusTarget},
     utils::prelude::*,
     wayland::protocols::{
         toplevel_info::ToplevelInfoHandler,
         toplevel_management::{
-            delegate_toplevel_management, toplevel_rectangle_for, ManagementWindow,
-            ToplevelManagementHandler, ToplevelManagementState,
+            ManagementWindow, ToplevelManagementHandler, ToplevelManagementState,
+            delegate_toplevel_management, toplevel_rectangle_for,
         },
         workspace::WorkspaceHandle,
     },

--- a/src/wayland/handlers/workspace.rs
+++ b/src/wayland/handlers/workspace.rs
@@ -4,7 +4,7 @@ use crate::{
     shell::WorkspaceDelta,
     utils::prelude::*,
     wayland::protocols::workspace::{
-        delegate_workspace, Request, State as WState, WorkspaceHandler, WorkspaceState,
+        Request, State as WState, WorkspaceHandler, WorkspaceState, delegate_workspace,
     },
 };
 use cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::TilingState;

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
-    shell::{focus::target::KeyboardFocusTarget, grabs::ReleaseMode, CosmicSurface, PendingWindow},
+    shell::{CosmicSurface, PendingWindow, focus::target::KeyboardFocusTarget, grabs::ReleaseMode},
     utils::prelude::*,
 };
 use smithay::{
     delegate_xdg_shell,
     desktop::{
-        find_popup_root_surface, PopupGrab, PopupKeyboardGrab, PopupKind, PopupPointerGrab,
-        PopupUngrabStrategy,
+        PopupGrab, PopupKeyboardGrab, PopupKind, PopupPointerGrab, PopupUngrabStrategy,
+        find_popup_root_surface,
     },
-    input::{pointer::Focus, Seat},
+    input::{Seat, pointer::Focus},
     output::Output,
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel,

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -3,8 +3,8 @@
 use crate::{shell::Shell, utils::prelude::*};
 use smithay::{
     desktop::{
-        get_popup_toplevel_coords, layer_map_for_output, space::SpaceElement, LayerSurface,
-        PopupKind, PopupManager, WindowSurfaceType,
+        LayerSurface, PopupKind, PopupManager, WindowSurfaceType, get_popup_toplevel_coords,
+        layer_map_for_output, space::SpaceElement,
     },
     output::Output,
     reexports::{
@@ -15,7 +15,7 @@ use smithay::{
     wayland::{
         compositor::{get_role, with_states},
         seat::WaylandFocus,
-        shell::xdg::{PopupSurface, ToplevelSurface, XdgPopupSurfaceData, XDG_POPUP_ROLE},
+        shell::xdg::{PopupSurface, ToplevelSurface, XDG_POPUP_ROLE, XdgPopupSurfaceData},
     },
 };
 use tracing::warn;

--- a/src/wayland/protocols/atspi.rs
+++ b/src/wayland/protocols/atspi.rs
@@ -5,7 +5,7 @@ use cosmic_protocols::atspi::v1::server::cosmic_atspi_manager_v1;
 use smithay::{
     backend::input::Keycode,
     reexports::wayland_server::{
-        backend::GlobalId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
+        Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, backend::GlobalId,
     },
 };
 use std::os::unix::{io::AsFd, net::UnixStream};

--- a/src/wayland/protocols/drm.rs
+++ b/src/wayland/protocols/drm.rs
@@ -23,13 +23,13 @@ mod generated {
 
 use smithay::{
     backend::allocator::{
+        Fourcc, Modifier,
         dmabuf::{Dmabuf, DmabufFlags},
         format::FormatSet,
-        Fourcc, Modifier,
     },
     reexports::wayland_server::{
-        backend::GlobalId, protocol::wl_buffer::WlBuffer, Client, DataInit, Dispatch,
-        DisplayHandle, GlobalDispatch, New, Resource,
+        Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+        backend::GlobalId, protocol::wl_buffer::WlBuffer,
     },
     wayland::{
         buffer::BufferHandler,

--- a/src/wayland/protocols/output_configuration/handlers/wlr.rs
+++ b/src/wayland/protocols/output_configuration/handlers/wlr.rs
@@ -12,8 +12,8 @@ use smithay::{
             zwlr_output_mode_v1::{self, ZwlrOutputModeV1},
         },
         wayland_server::{
-            backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
-            Resource,
+            Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+            backend::ClientId,
         },
     },
     utils::{Point, Size},

--- a/src/wayland/protocols/output_configuration/mod.rs
+++ b/src/wayland/protocols/output_configuration/mod.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use calloop::{
-    timer::{TimeoutAction, Timer},
     LoopHandle,
+    timer::{TimeoutAction, Timer},
 };
 use cosmic_protocols::output_management::v1::server::{
     zcosmic_output_configuration_head_v1::ZcosmicOutputConfigurationHeadV1,
@@ -22,8 +22,8 @@ use smithay::{
             zwlr_output_mode_v1::ZwlrOutputModeV1,
         },
         wayland_server::{
-            backend::GlobalId, protocol::wl_output::WlOutput, Client, Dispatch, DisplayHandle,
-            GlobalDispatch, Resource, Weak,
+            Client, Dispatch, DisplayHandle, GlobalDispatch, Resource, Weak, backend::GlobalId,
+            protocol::wl_output::WlOutput,
         },
     },
     utils::{Logical, Physical, Point, Size, Transform},

--- a/src/wayland/protocols/output_power.rs
+++ b/src/wayland/protocols/output_power.rs
@@ -8,8 +8,8 @@ use smithay::{
             zwlr_output_power_v1::{self, ZwlrOutputPowerV1},
         },
         wayland_server::{
-            backend::GlobalId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
-            Resource,
+            Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+            backend::GlobalId,
         },
     },
 };

--- a/src/wayland/protocols/overlap_notify.rs
+++ b/src/wayland/protocols/overlap_notify.rs
@@ -13,7 +13,7 @@ use cosmic_protocols::{
     },
 };
 use smithay::{
-    desktop::{layer_map_for_output, LayerSurface},
+    desktop::{LayerSurface, layer_map_for_output},
     output::Output,
     reexports::{
         wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -7,12 +7,12 @@ use smithay::{
     reexports::{
         wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
         wayland_server::{
+            Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
             backend::{ClientId, GlobalId},
             protocol::{wl_output::WlOutput, wl_surface::WlSurface},
-            Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
         },
     },
-    utils::{user_data::UserDataMap, IsAlive, Logical, Rectangle},
+    utils::{IsAlive, Logical, Rectangle, user_data::UserDataMap},
     wayland::foreign_toplevel_list::{
         ForeignToplevelHandle, ForeignToplevelListHandler, ForeignToplevelListState,
     },
@@ -209,7 +209,10 @@ where
                         .push((obj.downgrade(), instance));
                 } else {
                     let _ = data_init.init(cosmic_toplevel, ToplevelHandleStateInner::empty());
-                    error!(?foreign_toplevel, "Toplevel for foreign-toplevel-list not registered for cosmic-toplevel-info.");
+                    error!(
+                        ?foreign_toplevel,
+                        "Toplevel for foreign-toplevel-list not registered for cosmic-toplevel-info."
+                    );
                 }
             }
             zcosmic_toplevel_info_v1::Request::Stop => {

--- a/src/wayland/protocols/toplevel_management.rs
+++ b/src/wayland/protocols/toplevel_management.rs
@@ -4,9 +4,9 @@ use smithay::{
     input::{Seat, SeatHandler},
     output::Output,
     reexports::wayland_server::{
+        Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
         backend::{ClientId, GlobalId},
         protocol::wl_surface::WlSurface,
-        Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
     },
     utils::{Logical, Rectangle},
 };
@@ -17,7 +17,7 @@ use cosmic_protocols::toplevel_management::v1::server::zcosmic_toplevel_manager_
 };
 
 use super::{
-    toplevel_info::{window_from_handle, ToplevelInfoHandler, ToplevelState, Window},
+    toplevel_info::{ToplevelInfoHandler, ToplevelState, Window, window_from_handle},
     workspace::WorkspaceHandle,
 };
 

--- a/src/wayland/protocols/workspace/ext.rs
+++ b/src/wayland/protocols/workspace/ext.rs
@@ -11,8 +11,8 @@ use smithay::{
             ext_workspace_manager_v1::{self, ExtWorkspaceManagerV1},
         },
         wayland_server::{
-            backend::ClientId, protocol::wl_output::WlOutput, Client, DataInit, Dispatch,
-            DisplayHandle, GlobalDispatch, New, Resource, Weak,
+            Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
+            backend::ClientId, protocol::wl_output::WlOutput,
         },
     },
 };

--- a/src/wayland/protocols/workspace/mod.rs
+++ b/src/wayland/protocols/workspace/mod.rs
@@ -9,8 +9,8 @@ use smithay::{
             ext_workspace_manager_v1::ExtWorkspaceManagerV1,
         },
         wayland_server::{
-            backend::{GlobalId, ObjectId},
             Client, Dispatch, DisplayHandle, GlobalDispatch, Resource,
+            backend::{GlobalId, ObjectId},
         },
     },
 };

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -1,9 +1,9 @@
 use std::{ffi::OsString, os::unix::io::OwnedFd, process::Stdio};
 
 use crate::{
-    backend::render::cursor::{load_cursor_env, load_cursor_theme, Cursor},
+    backend::render::cursor::{Cursor, load_cursor_env, load_cursor_theme},
     shell::{
-        focus::target::KeyboardFocusTarget, grabs::ReleaseMode, CosmicSurface, PendingWindow, Shell,
+        CosmicSurface, PendingWindow, Shell, focus::target::KeyboardFocusTarget, grabs::ReleaseMode,
     },
     state::State,
     utils::prelude::*,
@@ -16,23 +16,24 @@ use smithay::{
         drm::DrmNode,
         input::{ButtonState, KeyState, Keycode},
         renderer::{
+            Bind, Frame, Offscreen, Renderer,
             element::{
-                memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
                 Kind,
+                memory::{MemoryRenderBuffer, MemoryRenderBufferRenderElement},
             },
             pixman::{PixmanError, PixmanRenderer},
             utils::draw_render_elements,
-            Bind, Frame, Offscreen, Renderer,
         },
     },
     desktop::space::SpaceElement,
     input::{keyboard::ModifiersState, pointer::CursorIcon},
     reexports::{wayland_server::Client, x11rb::protocol::xproto::Window as X11Window},
     utils::{
-        Buffer as BufferCoords, Logical, Point, Rectangle, Serial, Size, Transform, SERIAL_COUNTER,
+        Buffer as BufferCoords, Logical, Point, Rectangle, SERIAL_COUNTER, Serial, Size, Transform,
     },
     wayland::{
         selection::{
+            SelectionTarget,
             data_device::{
                 clear_data_device_selection, current_data_device_selection_userdata,
                 request_data_device_client_selection, set_data_device_selection,
@@ -41,13 +42,12 @@ use smithay::{
                 clear_primary_selection, current_primary_selection_userdata,
                 request_primary_client_selection, set_primary_selection,
             },
-            SelectionTarget,
         },
         xdg_activation::XdgActivationToken,
     },
     xwayland::{
-        xwm::{Reorder, XwmId},
         X11Surface, X11Wm, XWayland, XWaylandClientData, XWaylandEvent, XwmHandler,
+        xwm::{Reorder, XwmId},
     },
 };
 use tracing::{error, trace, warn};


### PR DESCRIPTION
Updates all dependencies, except `egui` and `egui-plot` (CI reports errors, but builds fine locally).
Removes `once_cell` and `lazy_static` in favor of using `std::sync::LazyLock`.
The `xdg` crate had breaking changes ("changed the return of most constructors from Result<BaseDirectories, Error> to just BaseDirectories"), so there were some changes needed around that.