### PR TITLE
Filter overlay plane candidates

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -289,7 +289,7 @@ impl State {
                 gbm.clone(),
                 GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT,
             ),
-            GbmFramebufferExporter::new(gbm.clone(), drm_node.into()),
+            GbmFramebufferExporter::new(gbm.clone(), render_node.into()),
             Some(gbm.clone()),
             [
                 Fourcc::Abgr2101010,

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -671,10 +671,11 @@ impl SurfaceThreadState {
             Duration::from_secs_f64(1_000. / drm_helpers::calculate_refresh_rate(mode) as f64);
         self.timings.set_refresh_interval(Some(interval));
 
+        const SAFETY_MARGIN: u32 = 2; // Magic two frames margin taken from kwin to not trigger low-framerate-compensation
         let min_min_refresh_interval = Duration::from_secs_f64(1. / 30.); // 30Hz
         self.timings.set_min_refresh_interval(Some(
             min_hz
-                .map(|min| Duration::from_secs_f64(1. / min as f64))
+                .map(|min| Duration::from_secs_f64(1. / (min + SAFETY_MARGIN) as f64))
                 .unwrap_or(min_min_refresh_interval) // alternatively use 30Hz
                 .max(min_min_refresh_interval),
         ));

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::utils::prelude::*;
+use crate::{utils::prelude::*, wayland::handlers::compositor::FRAME_TIME_FILTER};
 use smithay::{
     backend::{
         allocator::Fourcc,
@@ -182,7 +182,7 @@ where
         location.to_physical(scale).to_i32_round(),
         scale,
         1.0,
-        Kind::Unspecified,
+        FRAME_TIME_FILTER,
     )
 }
 

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -618,6 +618,7 @@ impl CosmicMapped {
         location: smithay::utils::Point<i32, smithay::utils::Physical>,
         scale: smithay::utils::Scale<f64>,
         alpha: f32,
+        scanout_override: Option<bool>,
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem + AsGlowRenderer,
@@ -803,11 +804,19 @@ impl CosmicMapped {
         #[cfg_attr(not(feature = "debug"), allow(unused_mut))]
         elements.extend(match &self.element {
             CosmicMappedInternal::Stack(s) => s.render_elements::<R, CosmicMappedRenderElement<R>>(
-                renderer, location, scale, alpha,
+                renderer,
+                location,
+                scale,
+                alpha,
+                scanout_override,
             ),
             CosmicMappedInternal::Window(w) => w
                 .render_elements::<R, CosmicMappedRenderElement<R>>(
-                    renderer, location, scale, alpha,
+                    renderer,
+                    location,
+                    scale,
+                    alpha,
+                    scanout_override,
                 ),
             _ => unreachable!(),
         });

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -649,6 +649,7 @@ impl CosmicStack {
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
+        scanout_override: Option<bool>,
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem,
@@ -675,7 +676,11 @@ impl CosmicStack {
             let active = p.active.load(Ordering::SeqCst);
 
             windows[active].render_elements::<R, CosmicStackRenderElement<R>>(
-                renderer, window_loc, scale, alpha,
+                renderer,
+                window_loc,
+                scale,
+                alpha,
+                scanout_override,
             )
         }));
 

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -350,6 +350,7 @@ impl CosmicWindow {
         location: Point<i32, Physical>,
         scale: Scale<f64>,
         alpha: f32,
+        scanout_override: Option<bool>,
     ) -> Vec<C>
     where
         R: Renderer + ImportAll + ImportMem,
@@ -368,7 +369,11 @@ impl CosmicWindow {
 
         elements.extend(self.0.with_program(|p| {
             p.window.render_elements::<R, CosmicWindowRenderElement<R>>(
-                renderer, window_loc, scale, alpha,
+                renderer,
+                window_loc,
+                scale,
+                alpha,
+                scanout_override,
             )
         }));
 

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -187,6 +187,7 @@ impl MoveGrabState {
                     .to_physical_precise_round(output_scale),
                 output_scale,
                 alpha,
+                Some(false),
             );
         let p_elements = self
             .window

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1468,6 +1468,7 @@ impl FloatingLayout {
                     .to_physical_precise_round(output_scale),
                 output_scale.into(),
                 alpha,
+                None,
             );
 
             if let Some(anim) = self.animations.get(elem) {

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -4983,6 +4983,7 @@ where
                 geo.loc.as_logical().to_physical_precise_round(output_scale) - elem_geometry.loc,
                 Scale::from(output_scale),
                 alpha,
+                None,
             );
 
             elements.extend(window_elements.into_iter().flat_map(|element| {
@@ -5470,6 +5471,7 @@ where
                         - elem_geometry.loc,
                     Scale::from(output_scale),
                     alpha,
+                    None,
                 );
 
                 if swap_desc

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1556,6 +1556,7 @@ impl Workspace {
                     render_loc,
                     output_scale.into(),
                     alpha,
+                    Some(true),
                 )
                 .into_iter()
                 .map(|elem| RescaleRenderElement::from_element(elem, render_loc, scale))


### PR DESCRIPTION
An attempt at smarter plane usage.

If we end up compositing on the gpu anyway, it rarely makes sense to use hardware compositing as well, given the render time will be basically the same no matter if we composite 6 or 5 surfaces.

However if only a handful of elements are actually updating, we could potentially skip software composition all together if those would be placed on hardware planes. This ends up happening very rarely though, as from cosmic-comp's perspective the shell components are usually the first in the render-order, making them hug the hardware composition chain.

To fix this, lets introduce some filtering for viable scanout targets. We expect targets with a rather constant or high refresh rate to be good candidates as frequent updates would frequently require re-rendering otherwise.

As such we start tracking the refresh rate of new surfaces (f82864a) and then start filtering surfaces for scanout to those hitting at least 20 fps (e.g. movie players with potentially only 24 FPS) (d646992).

Additionally we fix normal desktop applications in fullscreen mode with vrr set to "automatic" by only skipping cursor updates, if the application in question hits at least 30fps consistently (d493151).

Last but not least we also save on atomic tests by skipping overlay plane usage during animations (93c5d2b) (and moving windows - 1287f32) as re-positioning planes can be quite costly in terms of time for the atomic checks. Together with not testing as many candidates in the first place this brings down our frame times, hopefully addressing the flickering issues some people are seeing at higher refresh rates, while more consistently hitting the scanout paths for applications that actually make good use of it.

Draft while more testing is happening and while the required smithay changes are still work in progress.