### PR TITLE
kms: Fallback to first available DRM device when no primary GPU is found

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -235,8 +235,18 @@ fn determine_primary_gpu(
         }
     }
 
-    // else just take the first
-    Ok(drm_devices.values().next().map(|dev| dev.inner.render_node))
+    // else use first available render node
+    let fallback = drm_devices.values().next().map(|dev| dev.inner.render_node);
+    if fallback.is_some() {
+        warn!(
+            "Falling back to first available DRM node: {:?}",
+            fallback.unwrap()
+        );
+    } else {
+        error!("No available DRM devices to use as primary GPU");
+    }
+
+    Ok(fallback)
 }
 
 /// Create `GlowRenderer` for `EGL_MESA_device_software` device, if present


### PR DESCRIPTION
Should fix https://github.com/pop-os/cosmic-epoch/issues/1468

Specifically the issue I mentioned in my last comment.

Cosmic-comp is looking for card0 which doesn't exist. Added fallback for such cases.

Edit: Should probably add more context. So comp seems to look for card0 on boot which in my case is the integrated GPU. I disabled my integrated GPU and only use my dedicated RTX 4080. Disabling the integrated GPU didnt change the fact that its still designated as card0 from the looks of it and my dedicated GPU is card1. While Im still learning Rust this fix seems to work fine.