### PR TITLE
feature: Handle lid-switch events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "libdisplay-info",
  "libsystemd",
  "log-panics",
+ "logind-zbus",
  "once_cell",
  "ordered-float",
  "parking_lot 0.12.3",
@@ -3058,6 +3059,16 @@ checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
  "backtrace",
  "log",
+]
+
+[[package]]
+name = "logind-zbus"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469c962578b549a82f3d0cc72d0f77d1123780fa7121e2b03d78b0780f6ccac6"
+dependencies = [
+ "serde",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ reis = { version = "0.5", features = ["calloop"] }
 # CLI arguments
 clap_lex = "0.7"
 parking_lot = "0.12.3"
+logind-zbus = { version = "5.3.2", optional = true }
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"
@@ -100,7 +101,7 @@ optional = true
 [features]
 debug = ["egui", "egui_plot", "smithay-egui", "anyhow/backtrace"]
 default = ["systemd"]
-systemd = ["libsystemd"]
+systemd = ["libsystemd", "logind-zbus"]
 profile-with-tracy = ["profiling/profile-with-tracy", "tracy-client/default"]
 
 [profile.dev.package.tiny-skia]

--- a/src/dbus/logind.rs
+++ b/src/dbus/logind.rs
@@ -1,0 +1,17 @@
+use std::os::fd::OwnedFd;
+
+use logind_zbus::manager::{InhibitType::HandleLidSwitch, ManagerProxyBlocking};
+use zbus::blocking::Connection;
+
+pub fn inhibit_lid() -> anyhow::Result<OwnedFd> {
+    let conn = Connection::system()?;
+    let proxy = ManagerProxyBlocking::new(&conn)?;
+    let fd = proxy.inhibit(
+        HandleLidSwitch,
+        "cosmic-comp",
+        "External output connected",
+        "block",
+    )?;
+
+    Ok(fd.into())
+}

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -4,6 +4,8 @@ use calloop::{InsertError, LoopHandle, RegistrationToken};
 use std::collections::HashMap;
 use zbus::blocking::{fdo::DBusProxy, Connection};
 
+#[cfg(feature = "systemd")]
+pub mod logind;
 mod power;
 
 pub fn init(evlh: &LoopHandle<'static, State>) -> Result<Vec<RegistrationToken>> {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2042,10 +2042,7 @@ impl Shell {
     }
 
     pub fn builtin_output(&self) -> Option<&Output> {
-        self.outputs().find(|output| {
-            let name = output.name();
-            name.starts_with("eDP-") || name.starts_with("LVDS-") || name.starts_with("DSI-")
-        })
+        self.outputs().find(|output| output.is_internal())
     }
 
     pub fn global_space(&self) -> Rectangle<i32, Global> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -400,7 +400,7 @@ impl BackendData {
 }
 
 impl<'a> LockedBackend<'a> {
-    fn all_outputs(&self) -> Vec<Output> {
+    pub fn all_outputs(&self) -> Vec<Output> {
         match self {
             LockedBackend::Kms(state) => state.all_outputs(),
             LockedBackend::X11(state) => state.all_outputs(),

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 pub trait OutputExt {
+    fn is_internal(&self) -> bool;
     fn geometry(&self) -> Rectangle<i32, Global>;
     fn zoomed_geometry(&self) -> Option<Rectangle<i32, Global>>;
 
@@ -44,6 +45,11 @@ struct VrrSupport(AtomicU8);
 struct Mirroring(Mutex<Option<WeakOutput>>);
 
 impl OutputExt for Output {
+    fn is_internal(&self) -> bool {
+        let name = self.name();
+        name.starts_with("eDP-") || name.starts_with("LVDS-") || name.starts_with("DSI-")
+    }
+
     fn geometry(&self) -> Rectangle<i32, Global> {
         Rectangle::new(self.current_location(), {
             Transform::from(self.current_transform())


### PR DESCRIPTION
Adds logic to inhibit systemd handling lid-switches for us, if more than one output is connected.

Handles lid-switches by disabling the built-in output on all systems. (Verified this doesn't break compiling/running/closing-the-lid without the systemd-feature.)

Fixes https://github.com/pop-os/cosmic-comp/issues/1351