### PR TITLE
WIP fifo and commit timing

### DIFF
--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1061,6 +1061,13 @@ impl SurfaceThreadState {
             vrr = has_active_fullscreen;
         }
 
+        // TODO commit timing `signal_until`
+        {
+            let shell = self.shell.read();
+            // XXX correct way to set time?
+            shell.signal_commit_timing(&self.output, self.clock.now() + estimated_presentation);
+        }
+
         let mut elements = output_elements(
             Some(&render_node),
             &mut renderer,
@@ -1375,6 +1382,9 @@ impl SurfaceThreadState {
                             // If postprocessing, use states from first render
                             let states = pre_postprocess_data.states.unwrap_or(frame_result.states);
                             self.send_dmabuf_feedback(states);
+
+                            let shell = self.shell.read();
+                            shell.signal_fifos(&self.output);
                         }
 
                         if x.is_ok() {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -39,6 +39,7 @@ use smithay::{
         utils::{
             OutputPresentationFeedback, surface_presentation_feedback_flags_from_states,
             surface_primary_scanout_output, take_presentation_feedback_surface_tree,
+            with_surfaces_surface_tree,
         },
     },
     input::{
@@ -52,9 +53,11 @@ use smithay::{
         wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1,
         wayland_server::{Client, protocol::wl_surface::WlSurface},
     },
-    utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
+    utils::{IsAlive, Logical, Monotonic, Point, Rectangle, Serial, Size, Time},
     wayland::{
-        compositor::{SurfaceAttributes, get_parent, with_states},
+        commit_timing::CommitTimerBarrierStateUserData,
+        compositor::{SurfaceAttributes, SurfaceData, get_parent, with_states},
+        fifo::FifoBarrierCachedState,
         seat::WaylandFocus,
         session_lock::LockSurface,
         shell::{
@@ -2113,6 +2116,192 @@ impl Shell {
                         })
                 })
             })
+    }
+
+    pub fn signal_commit_timing(&self, output: &Output, until: Time<Monotonic>) {
+        let processor = |_surface: &WlSurface, states: &SurfaceData| {
+            if let Some(mut commit_timer_state) = states
+                .data_map
+                .get::<CommitTimerBarrierStateUserData>()
+                .map(|commit_timer| commit_timer.lock().unwrap())
+            {
+                commit_timer_state.signal_until(until);
+            }
+        };
+
+        if let Some(session_lock) = self.session_lock.as_ref() {
+            if let Some(lock_surface) = session_lock.surfaces.get(output) {
+                with_surfaces_surface_tree(lock_surface.wl_surface(), processor);
+            }
+        }
+
+        self.workspaces
+            .sets
+            .get(output)
+            .unwrap()
+            .sticky_layer
+            .mapped()
+            .for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+
+        for workspace in self.workspaces.spaces_for_output(output) {
+            for seat in self.seats.iter() {
+                if let Some(window) = workspace.get_fullscreen(seat) {
+                    window.surface.0.with_surfaces(processor);
+                }
+            }
+            workspace.mapped().for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+            workspace.minimized_windows.iter().for_each(|m| {
+                for window in m.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+        }
+
+        let map = smithay::desktop::layer_map_for_output(output);
+        for layer_surface in map.layers() {
+            layer_surface.with_surfaces(processor);
+        }
+
+        self.override_redirect_windows.iter().for_each(|or| {
+            // Find output the override redirect window overlaps the most with
+            let or_geo = or.geometry().as_global();
+            let max_intersect_output = self
+                .outputs()
+                .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
+                .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
+                .map(|(o, _)| o);
+            if max_intersect_output == Some(output) {
+                if let Some(wl_surface) = or.wl_surface() {
+                    with_surfaces_surface_tree(&wl_surface, processor);
+                }
+            }
+        });
+
+        for seat in self
+            .seats
+            .iter()
+            .filter(|seat| &seat.active_output() == output)
+        {
+            let cursor_status = seat.cursor_image_status();
+
+            if let CursorImageStatus::Surface(wl_surface) = cursor_status {
+                with_surfaces_surface_tree(&wl_surface, processor);
+            }
+
+            if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
+                if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
+                    for (window, _) in grab_state.element().windows() {
+                        window.0.with_surfaces(processor);
+                    }
+                }
+            }
+
+            if let Some(icon) = get_dnd_icon(seat) {
+                with_surfaces_surface_tree(&icon.surface, processor);
+            }
+        }
+    }
+
+    pub fn signal_fifos(&self, output: &Output) {
+        fn processor(_surface: &WlSurface, states: &SurfaceData) {
+            let fifo_barrier = states
+                .cached_state
+                .get::<FifoBarrierCachedState>()
+                .current()
+                .barrier
+                .take();
+            if let Some(fifo_barrier) = fifo_barrier {
+                fifo_barrier.signal();
+            }
+        }
+
+        if let Some(session_lock) = self.session_lock.as_ref() {
+            if let Some(lock_surface) = session_lock.surfaces.get(output) {
+                with_surfaces_surface_tree(lock_surface.wl_surface(), processor);
+            }
+        }
+
+        self.workspaces
+            .sets
+            .get(output)
+            .unwrap()
+            .sticky_layer
+            .mapped()
+            .for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+
+        for workspace in self.workspaces.spaces_for_output(output) {
+            for seat in self.seats.iter() {
+                if let Some(window) = workspace.get_fullscreen(seat) {
+                    window.surface.0.with_surfaces(processor);
+                }
+            }
+            workspace.mapped().for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+            workspace.minimized_windows.iter().for_each(|m| {
+                for window in m.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+        }
+
+        let map = smithay::desktop::layer_map_for_output(output);
+        for layer_surface in map.layers() {
+            layer_surface.with_surfaces(processor);
+        }
+
+        self.override_redirect_windows.iter().for_each(|or| {
+            // Find output the override redirect window overlaps the most with
+            let or_geo = or.geometry().as_global();
+            let max_intersect_output = self
+                .outputs()
+                .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
+                .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
+                .map(|(o, _)| o);
+            if max_intersect_output == Some(output) {
+                if let Some(wl_surface) = or.wl_surface() {
+                    with_surfaces_surface_tree(&wl_surface, processor);
+                }
+            }
+        });
+
+        for seat in self
+            .seats
+            .iter()
+            .filter(|seat| &seat.active_output() == output)
+        {
+            let cursor_status = seat.cursor_image_status();
+
+            if let CursorImageStatus::Surface(wl_surface) = cursor_status {
+                with_surfaces_surface_tree(&wl_surface, processor);
+            }
+
+            if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
+                if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
+                    for (window, _) in grab_state.element().windows() {
+                        window.0.with_surfaces(processor);
+                    }
+                }
+            }
+
+            if let Some(icon) = get_dnd_icon(seat) {
+                with_surfaces_surface_tree(&icon.surface, processor);
+            }
+        }
     }
 
     pub fn workspace_for_surface(&self, surface: &WlSurface) -> Option<(WorkspaceHandle, Output)> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -77,6 +77,7 @@ use smithay::{
         compositor::{CompositorClientState, CompositorState, SurfaceData},
         cursor_shape::CursorShapeManagerState,
         dmabuf::{DmabufFeedback, DmabufGlobal, DmabufState},
+        fifo::FifoManagerState,
         fixes::FixesState,
         fractional_scale::{FractionalScaleManagerState, with_fractional_scale},
         idle_inhibit::IdleInhibitManagerState,
@@ -285,6 +286,7 @@ pub struct Common {
     pub dbus_state: DBusState,
     pub keyboard_layout_state: KeyboardLayoutState,
     pub background_effect_state: BackgroundEffectState,
+    pub fifo_manager_state: FifoManagerState,
 
     // shell-related wayland state
     pub xdg_shell_state: XdgShellState,
@@ -741,6 +743,8 @@ impl State {
 
         let dbus_state = DBusState::init(&handle);
 
+        let fifo_manager_state = FifoManagerState::new::<State>(dh);
+
         State {
             common: Common {
                 config,
@@ -799,6 +803,7 @@ impl State {
                 workspace_state,
                 background_effect_state,
                 a11y_state,
+                fifo_manager_state,
                 xwayland_scale: None,
                 xwayland_state: None,
                 xwayland_shell_state,


### PR DESCRIPTION
This needs testing, and still need to signal the commit timing.

I'd like to de-duplicate the different places that iterate over all different types of surface (instead of adding more code for this for fifo and commit timing, along with the existing `send_frames`, `update_primary_output`, `send_dmabuf_feedback`, `visisible_output_for_surface`, as well as the similar but slightly different code already shared in `render_input_order()`). But these seem to all be slightly different, so I'm not sure how best to unify them...