### PR TITLE
input: Don't follow focus for resize borders

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -289,7 +289,7 @@ fn format_pointer_focus(focus: Option<PointerFocusTarget>) -> String {
             }
             _ => format!("X11Surface {}", surface.window_id()),
         },
-        Some(StackUI(stack)) => format!(
+        Some(StackUI { stack, .. }) => format!(
             "Stack SSD {} ({})",
             match stack.active().0.underlying_surface() {
                 WindowSurface::Wayland(t) => t.wl_surface().id().protocol_id(),
@@ -297,7 +297,7 @@ fn format_pointer_focus(focus: Option<PointerFocusTarget>) -> String {
             },
             stack.active().title()
         ),
-        Some(WindowUI(window)) => format!(
+        Some(WindowUI { window, .. }) => format!(
             "Window SSD {} ({})",
             match window.surface().0.underlying_surface() {
                 WindowSurface::Wayland(t) => t.wl_surface().id().protocol_id(),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     input::gestures::{GestureState, SwipeAction},
     shell::{
-        SeatExt, Trigger,
+        LastAcknowlegedElement, SeatExt, Trigger,
         focus::{
             Stage, render_input_order,
             target::{KeyboardFocusTarget, PointerFocusTarget},
@@ -437,14 +437,33 @@ impl State {
                         //If the pointer isn't grabbed, we should check if the focused element should be updated
                     } else if self.common.config.cosmic_conf.focus_follows_cursor {
                         let shell = self.common.shell.read();
-                        let old_keyboard_target =
-                            State::element_under(original_position, &current_output, &shell, &seat);
+                        let old_keyboard_target = seat
+                            .user_data()
+                            .get::<LastAcknowlegedElement>()
+                            .unwrap()
+                            .0
+                            .lock()
+                            .unwrap()
+                            .clone();
                         let new_keyboard_target =
                             State::element_under(position, &output, &shell, &seat);
 
                         if old_keyboard_target != new_keyboard_target
                             && new_keyboard_target.is_some()
+                            && under.as_ref().is_some_and(|(target, relative_offset)| {
+                                target.should_follow_focus(
+                                    position.as_logical() - relative_offset.clone(),
+                                )
+                            })
                         {
+                            *seat
+                                .user_data()
+                                .get::<LastAcknowlegedElement>()
+                                .unwrap()
+                                .0
+                                .lock()
+                                .unwrap() = new_keyboard_target.clone();
+
                             let create_source = if self.common.pointer_focus_state.is_none() {
                                 true
                             } else {

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -539,14 +539,20 @@ impl CosmicStack {
                         && point_i32.y - geo.loc.y < geo.size.h + TAB_HEIGHT + RESIZE_BORDER)
                 {
                     stack_ui = Some((
-                        PointerFocusTarget::StackUI(self.clone()),
+                        PointerFocusTarget::StackUI {
+                            stack: self.clone(),
+                            is_border: true,
+                        },
                         Point::from((0., 0.)),
                     ));
                 }
 
                 if point_i32.y - geo.loc.y < TAB_HEIGHT {
                     stack_ui = Some((
-                        PointerFocusTarget::StackUI(self.clone()),
+                        PointerFocusTarget::StackUI {
+                            stack: self.clone(),
+                            is_border: false,
+                        },
                         Point::from((0., 0.)),
                     ));
                 }

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -303,14 +303,20 @@ impl CosmicWindow {
                         && point_i32.y - geo.loc.y < geo.size.h + ssd_height + RESIZE_BORDER)
                 {
                     window_ui = Some((
-                        PointerFocusTarget::WindowUI(self.clone()),
+                        PointerFocusTarget::WindowUI {
+                            window: self.clone(),
+                            is_border: true,
+                        },
                         Point::from((0., 0.)),
                     ));
                 }
 
                 if has_ssd && (point_i32.y - geo.loc.y < SSD_HEIGHT) {
                     window_ui = Some((
-                        PointerFocusTarget::WindowUI(self.clone()),
+                        PointerFocusTarget::WindowUI {
+                            window: self.clone(),
+                            is_border: false,
+                        },
                         Point::from((0., 0.)),
                     ));
                 }

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -57,8 +57,14 @@ pub enum PointerFocusTarget {
         surface: X11Surface,
         toplevel: Option<CosmicSurface>,
     },
-    StackUI(CosmicStack),
-    WindowUI(CosmicWindow),
+    StackUI {
+        stack: CosmicStack,
+        is_border: bool,
+    },
+    WindowUI {
+        window: CosmicWindow,
+        is_border: bool,
+    },
     ResizeFork(ResizeForkTarget),
     ZoomUI(ZoomFocusTarget),
 }
@@ -146,8 +152,8 @@ impl PointerFocusTarget {
         match self {
             PointerFocusTarget::WlSurface { surface, .. } => surface,
             PointerFocusTarget::X11Surface { surface, .. } => surface,
-            PointerFocusTarget::StackUI(u) => u,
-            PointerFocusTarget::WindowUI(u) => u,
+            PointerFocusTarget::StackUI { stack, .. } => stack,
+            PointerFocusTarget::WindowUI { window, .. } => window,
             PointerFocusTarget::ResizeFork(f) => f,
             PointerFocusTarget::ZoomUI(e) => e,
         }
@@ -157,8 +163,8 @@ impl PointerFocusTarget {
         match self {
             PointerFocusTarget::WlSurface { surface, .. } => surface,
             PointerFocusTarget::X11Surface { surface, .. } => surface,
-            PointerFocusTarget::StackUI(u) => u,
-            PointerFocusTarget::WindowUI(u) => u,
+            PointerFocusTarget::StackUI { stack, .. } => stack,
+            PointerFocusTarget::WindowUI { window, .. } => window,
             PointerFocusTarget::ResizeFork(f) => f,
             PointerFocusTarget::ZoomUI(e) => e,
         }
@@ -211,8 +217,8 @@ impl PointerFocusTarget {
                 toplevel: Some(surface),
                 ..
             } => Some(surface.clone()),
-            PointerFocusTarget::StackUI(stack) => Some(stack.active()),
-            PointerFocusTarget::WindowUI(window) => Some(window.surface()),
+            PointerFocusTarget::StackUI { stack, .. } => Some(stack.active()),
+            PointerFocusTarget::WindowUI { window, .. } => Some(window.surface()),
             _ => None,
         }
     }
@@ -283,6 +289,27 @@ impl PointerFocusTarget {
         for session in cursor_sessions {
             session.set_cursor_pos(cursor_pos);
             session.set_cursor_hotspot(cursor_hotspot);
+        }
+    }
+
+    pub fn should_follow_focus(&self, relative_pos: Point<f64, Logical>) -> bool {
+        match self {
+            PointerFocusTarget::WlSurface { toplevel, .. } => {
+                toplevel.as_ref().is_none_or(|toplevel| match toplevel {
+                    PointerFocusToplevel::Popup(popup) => {
+                        popup.geometry().contains(relative_pos.to_i32_round())
+                    }
+                    PointerFocusToplevel::Surface(surface) => {
+                        surface.0.geometry().contains(relative_pos.to_i32_round())
+                    }
+                })
+            }
+            PointerFocusTarget::X11Surface { surface, .. } => {
+                surface.geometry().contains(relative_pos.to_i32_round())
+            }
+            PointerFocusTarget::StackUI { is_border, .. }
+            | PointerFocusTarget::WindowUI { is_border, .. } => !*is_border,
+            PointerFocusTarget::ResizeFork(_) | PointerFocusTarget::ZoomUI(_) => false,
         }
     }
 }
@@ -374,8 +401,8 @@ impl IsAlive for PointerFocusTarget {
             // XXX? does this change anything
             PointerFocusTarget::WlSurface { surface, .. } => surface.alive(),
             PointerFocusTarget::X11Surface { surface, .. } => surface.alive(),
-            PointerFocusTarget::StackUI(e) => e.alive(),
-            PointerFocusTarget::WindowUI(e) => e.alive(),
+            PointerFocusTarget::StackUI { stack, .. } => stack.alive(),
+            PointerFocusTarget::WindowUI { window, .. } => window.alive(),
             PointerFocusTarget::ResizeFork(f) => f.alive(),
             PointerFocusTarget::ZoomUI(_) => true,
         }
@@ -764,8 +791,8 @@ impl WaylandFocus for PointerFocusTarget {
             PointerFocusTarget::WlSurface { surface, .. } => Cow::Borrowed(surface),
             PointerFocusTarget::X11Surface { surface, .. } => Cow::Owned(surface.wl_surface()?),
             PointerFocusTarget::ResizeFork(_)
-            | PointerFocusTarget::StackUI(_)
-            | PointerFocusTarget::WindowUI(_)
+            | PointerFocusTarget::StackUI { .. }
+            | PointerFocusTarget::WindowUI { .. }
             | PointerFocusTarget::ZoomUI(_) => {
                 return None;
             }
@@ -777,11 +804,12 @@ impl WaylandFocus for PointerFocusTarget {
             PointerFocusTarget::X11Surface { surface, .. } => surface
                 .wl_surface()
                 .is_some_and(|s| s.id().same_client_as(object_id)),
-            PointerFocusTarget::StackUI(stack) => stack
+            PointerFocusTarget::StackUI { stack, .. } => stack
                 .active()
                 .wl_surface()
-                .is_some_and(|s| s.id().same_client_as(object_id)),
-            PointerFocusTarget::WindowUI(window) => window
+                .map(|s| s.id().same_client_as(object_id))
+                .unwrap_or(false),
+            PointerFocusTarget::WindowUI { window, .. } => window
                 .wl_surface()
                 .is_some_and(|s| s.id().same_client_as(object_id)),
             PointerFocusTarget::ResizeFork(_) | PointerFocusTarget::ZoomUI(_) => false,

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -6,6 +6,7 @@ use crate::{
     backend::render::cursor::CursorState,
     config::{Config, xkb_config_to_wl},
     input::{InputBackendId, ModifiersShortcutQueue, SupressedButtons, SupressedKeys},
+    shell::focus::target::KeyboardFocusTarget,
     state::State,
 };
 use smithay::{
@@ -209,6 +210,9 @@ pub struct PointerConstraintHint(pub Mutex<Option<(WlSurface, Point<f64, Logical
 #[derive(Default)]
 pub struct LastModifierChange(pub Mutex<(HashMap<InputBackendId, Serial>, Option<Serial>)>);
 
+#[derive(Default)]
+pub struct LastAcknowlegedElement(pub Mutex<Option<KeyboardFocusTarget>>);
+
 pub fn create_seat(
     dh: &DisplayHandle,
     seat_state: &mut SeatState<State>,
@@ -224,6 +228,7 @@ pub fn create_seat(
     userdata.insert_if_missing(SupressedButtons::default);
     userdata.insert_if_missing(ModifiersShortcutQueue::default);
     userdata.insert_if_missing(LastModifierChange::default);
+    userdata.insert_if_missing(LastAcknowlegedElement::default);
     userdata.insert_if_missing_threadsafe(SeatMoveGrabState::default);
     userdata.insert_if_missing_threadsafe(SeatMenuGrabState::default);
     userdata.insert_if_missing_threadsafe(CursorState::default);


### PR DESCRIPTION
This partially addresses the broken behaviour seen in https://github.com/pop-os/cosmic-comp/issues/1467, by making sure we don't switch focus for the invisible resize borders around windows (~~at least for server-side decorated windows and stacks, we might want to similarly make sure we are inside the window geometry before following for client-side decorated windows~~ done).

The underlying problem with the panel appears to be however, that cosmic-panel simply isn't forwarding any popup-grabs and thus won't be fixed in cosmic-comp, but cosmic-panel.