### PR TITLE
Improvements around disabled outputs

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -68,7 +68,7 @@ pub struct KmsState {
     pub software_renderer: Option<GlowRenderer>,
     pub api: GpuManager<GbmGlowBackend<DrmDeviceFd>>,
 
-    session: LibSeatSession,
+    pub session: LibSeatSession,
     libinput: Libinput,
 
     pub syncobj_state: Option<DrmSyncobjState>,

--- a/src/dbus/logind.rs
+++ b/src/dbus/logind.rs
@@ -1,9 +1,10 @@
 use std::os::fd::OwnedFd;
 
+use anyhow::{Context, Result};
 use logind_zbus::manager::{InhibitType::HandleLidSwitch, ManagerProxyBlocking};
 use zbus::blocking::Connection;
 
-pub fn inhibit_lid() -> anyhow::Result<OwnedFd> {
+pub fn inhibit_lid() -> Result<OwnedFd> {
     let conn = Connection::system()?;
     let proxy = ManagerProxyBlocking::new(&conn)?;
     let fd = proxy.inhibit(
@@ -14,4 +15,10 @@ pub fn inhibit_lid() -> anyhow::Result<OwnedFd> {
     )?;
 
     Ok(fd.into())
+}
+
+pub fn lid_closed() -> Result<bool> {
+    let conn = Connection::system()?;
+    let proxy = ManagerProxyBlocking::new(&conn)?;
+    proxy.lid_closed().context("Failed to talk to logind")
 }

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -29,6 +29,8 @@ pub fn init(evlh: &LoopHandle<'static, State>) -> Result<Vec<RegistrationToken>>
                                 tracing::error!(?err, "Failed to update drm device {}.", node);
                             }
                         }
+                        state.refresh_output_config();
+
                         ()
                     }
                     calloop::channel::Event::Closed => (),


### PR DESCRIPTION
This should improve our handling of disabled outputs and fix https://github.com/pop-os/cosmic-comp/issues/1562 in the process.

- 6cfbb7a - Previously we always re-enumerated disabled connectors on `device_changed`, which added them back to the `OutputConfigurationState`, even if they remained disabled and wrote the config to disk.
- c9c3503 - Previously we reloaded outputs for every single event. This was especially problematic after standby, when call `device_changed` for every single device. Potentially calling read_outputs before we have evaluated a device, which lost an output, causing modesetting errors on `apply_config_for_outputs` in the kms-backend.
- eec7279 - Resets configs that disable every output
- 5fcde81 - Previously our inhibitor/lid-state could break, if we missed a lid-switch event while exiting standby. Make sure we always re-enable the output before removing the lock and evaluate the current lid-state on re-lock.