### PR TITLE
Don't crash if `GreeterAccessibilityState::config()` fails

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::state::State;
 use crate::wayland::protocols::a11y::A11yHandler;
-use crate::{config::ScreenFilter, state::State};
 use anyhow::{anyhow, Context, Result};
 use cosmic_comp_config::NumlockState;
 use cosmic_config::CosmicConfigEntry;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -73,14 +73,19 @@ pub fn init_backend_auto(
             .seats
             .add_seat(initial_seat.clone());
 
-        let helper = greeter::GreeterAccessibilityState::config()?;
-        let greeter_state = match greeter::GreeterAccessibilityState::get_entry(&helper) {
-            Ok(s) => s,
-            Err((errs, s)) => {
-                for err in errs {
-                    tracing::error!("Error loading greeter state: {err:?}");
+        let greeter_state = match greeter::GreeterAccessibilityState::config() {
+            Ok(helper) => match greeter::GreeterAccessibilityState::get_entry(&helper) {
+                Ok(s) => s,
+                Err((errs, s)) => {
+                    for err in errs {
+                        tracing::error!("Error loading greeter state: {err:?}");
+                    }
+                    s
                 }
-                s
+            },
+            Err(_) => {
+                tracing::info!("`cosmic-greeter` state not found.");
+                greeter::GreeterAccessibilityState::default()
             }
         };
 

--- a/src/backend/render/element.rs
+++ b/src/backend/render/element.rs
@@ -244,7 +244,7 @@ where
         }
     }
 
-    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
         match self {
             CosmicElement::Workspace(elem) => elem.underlying_storage(renderer),
             CosmicElement::Cursor(elem) => elem.underlying_storage(renderer),

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -1322,7 +1322,7 @@ where
         }
     }
 
-    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage<'_>> {
         match self {
             CosmicMappedRenderElement::Stack(elem) => elem.underlying_storage(renderer),
             CosmicMappedRenderElement::Window(elem) => elem.underlying_storage(renderer),

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1969,7 +1969,7 @@ where
     fn underlying_storage(
         &self,
         renderer: &mut R,
-    ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
+    ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
         match self {
             WorkspaceRenderElement::OverrideRedirect(elem) => elem.underlying_storage(renderer),
             WorkspaceRenderElement::Fullscreen(elem) => elem.underlying_storage(renderer),

--- a/src/state.rs
+++ b/src/state.rs
@@ -356,7 +356,7 @@ impl BackendData {
     pub fn offscreen_renderer<N: Into<KmsNodes>, F: FnOnce(&mut KmsState) -> Option<N>>(
         &mut self,
         kms_node_cb: F,
-    ) -> Result<RendererRef, GlMultiError> {
+    ) -> Result<RendererRef<'_>, GlMultiError> {
         match self {
             BackendData::Kms(kms) => {
                 if let Some(nodes) = kms_node_cb(kms) {


### PR DESCRIPTION
`cosmic-comp` should run without needing the greeter to be running (or installed).