### PR TITLE
Float cosmic-store dialogs, needed for gstreamer codec install

### DIFF
--- a/data/tiling-exceptions.ron
+++ b/data/tiling-exceptions.ron
@@ -21,6 +21,7 @@
 	(appid: "Com.github.amezin.ddterm", titles: [".*"]),
 	(appid: "Com.github.donadigo.eddy", titles: [".*"]),
 	(appid: "com.system76.CosmicFilesDialog", titles: [".*"]),
+	(appid: "com.system76.CosmicStoreDialog", titles: [".*"]),
 	(appid: "Enpass", titles: ["Enpass Assistant"]),
 	(appid: "Gjs", titles: ["Settings"]),
 	(appid: "Gnome-initial-setup", titles: [".*"]),


### PR DESCRIPTION
Will be used by https://github.com/pop-os/cosmic-store/pull/229