### PR TITLE
Fix keybinding case for Period and Comma to match internal naming

### DIFF
--- a/data/keybindings.ron
+++ b/data/keybindings.ron
@@ -92,8 +92,8 @@
 
     (modifiers: [Super], key: "equal"): ZoomIn,
     (modifiers: [Super], key: "minus"): ZoomOut,
-    (modifiers: [Super], key: "Period"): ZoomIn,
-    (modifiers: [Super], key: "Comma"): ZoomOut,
+    (modifiers: [Super], key: "period"): ZoomIn,
+    (modifiers: [Super], key: "comma"): ZoomOut,
 
     (modifiers: [Super], key: "b"): System(WebBrowser),
     (modifiers: [Super], key: "f"): System(HomeFolder),


### PR DESCRIPTION
Fix keybinding case for Period and Comma
Changed "Period" → "period" and "Comma" → "comma" in keybindings.ron to match internal naming and **remove case-insensitive match warnings at runtime**.

This is because key names in keybinding configuration files (such as RON, JSON, YAML, etc.) typically use lowercase for standard character keys. In the file, other key names like "space", "minus", "equal", "slash", and "tab" are also lowercase, which suggests consistency is intended.