### PR TITLE
kms/surface: Don't send screencopy`success()` until sync point is reached

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4792,7 +4792,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=ae1faae#ae1faaeb71e2664f4ddb3db7423a5ec746a6a51d"
+source = "git+https://github.com/smithay/smithay.git?rev=20d2dac#20d2dacd71394b5f96f6ace0a70a6f20dc62c0c6"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,4 +146,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "ae1faae" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "20d2dac" }

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -8,7 +8,7 @@ use crate::{
     config::{AdaptiveSync, EdidProduct, OutputConfig, OutputState, ScreenFilter},
     shell::Shell,
     utils::{env::dev_list_var, prelude::*},
-    wayland::protocols::screencopy::Frame,
+    wayland::handlers::screencopy::PendingImageCopyData,
 };
 
 use anyhow::{Context, Result};
@@ -39,9 +39,7 @@ use smithay::{
         rustix::fs::OFlags,
         wayland_server::{protocol::wl_buffer::WlBuffer, DisplayHandle, Weak},
     },
-    utils::{
-        Buffer as BufferCoords, Clock, DevPath, DeviceFd, Monotonic, Point, Rectangle, Transform,
-    },
+    utils::{Clock, DevPath, DeviceFd, Monotonic, Point, Transform},
     wayland::drm_lease::{DrmLease, DrmLeaseState},
 };
 use tracing::{error, info, warn};
@@ -71,7 +69,7 @@ pub type LockedGbmDrmOutputManager<'a> = LockedDrmOutputManager<
     GbmFramebufferExporter<DrmDeviceFd>,
     Option<(
         OutputPresentationFeedback,
-        Receiver<(Frame, Vec<Rectangle<i32, BufferCoords>>)>,
+        Receiver<PendingImageCopyData>,
         Duration,
     )>,
     DrmDeviceFd,
@@ -82,7 +80,7 @@ pub type GbmDrmOutputManager = DrmOutputManager<
     GbmFramebufferExporter<DrmDeviceFd>,
     Option<(
         OutputPresentationFeedback,
-        Receiver<(Frame, Vec<Rectangle<i32, BufferCoords>>)>,
+        Receiver<PendingImageCopyData>,
         Duration,
     )>,
     DrmDeviceFd,

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -819,8 +819,12 @@ impl SurfaceThreadState {
 
                 self.timings.presented(clock);
 
-                while let Ok(PendingImageCopyData { frame, damage, .. }) = frames.recv() {
-                    frame.success(self.output.current_transform(), damage, clock);
+                while let Ok(pending_image_copy_data) = frames.recv() {
+                    pending_image_copy_data.send_success_when_ready(
+                        self.output.current_transform(),
+                        &self.loop_handle,
+                        clock,
+                    );
                 }
             }
         }

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1729,7 +1729,8 @@ fn send_screencopy_result<'a>(
 
             if let Some(fb) = fb.as_mut() {
                 for rect in adjusted.iter().copied() {
-                    renderer
+                    // TODO: On Vulkan, may need to combine sync points instead of just using latest?
+                    sync = renderer
                         .blit(&mut tex_fb, fb, rect, rect, TextureFilter::Linear)
                         .map_err(
                             RenderError::<<GlMultiRenderer as RendererSuper>::Error>::Rendering,

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -28,7 +28,7 @@ use crate::{
         handlers::{
             compositor::FRAME_TIME_FILTER,
             data_device::get_dnd_icon,
-            screencopy::{render_session, FrameHolder, SessionData},
+            screencopy::{render_session, FrameHolder, PendingImageCopyData, SessionData},
         },
         protocols::workspace::WorkspaceHandle,
     },
@@ -1332,7 +1332,11 @@ where
     match result {
         Ok((res, mut elements)) => {
             for (session, frame) in output.take_pending_frames() {
-                if let Some((frame, damage)) = render_session::<_, _, GlesTexture>(
+                if let Some(PendingImageCopyData { frame, damage, .. }) = render_session::<
+                    _,
+                    _,
+                    GlesTexture,
+                >(
                     renderer,
                     &session.user_data().get::<SessionData>().unwrap(),
                     frame,

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -1379,14 +1379,17 @@ where
                             elements.truncate(old_len);
                         }
 
+                        let mut sync = SyncPoint::default();
+
                         if let (Some(damage), _) = &res {
+                            // TODO: On Vulkan, may need to combine sync points instead of just using latest?
                             let blit_to_buffer =
                                 |renderer: &mut R, blit_from: &mut R::Framebuffer<'_>| {
                                     if let Ok(dmabuf) = get_dmabuf(buffer) {
                                         let mut dmabuf_clone = dmabuf.clone();
                                         let mut fb = renderer.bind(&mut dmabuf_clone)?;
                                         for rect in damage.iter() {
-                                            renderer.blit(
+                                            sync = renderer.blit(
                                                 blit_from,
                                                 &mut fb,
                                                 *rect,
@@ -1398,7 +1401,7 @@ where
                                         let fb = offscreen
                                             .expect("shm buffers should have offscreen target");
                                         for rect in damage.iter() {
-                                            renderer.blit(
+                                            sync = renderer.blit(
                                                 blit_from,
                                                 fb,
                                                 *rect,
@@ -1425,7 +1428,7 @@ where
 
                         Ok(RenderOutputResult {
                             damage: res.0,
-                            sync: SyncPoint::default(),
+                            sync,
                             states: res.1,
                         })
                     },

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -63,6 +63,7 @@ impl WinitState {
             &self.output,
             CursorMode::NotDefault,
             &mut self.screen_filter_state,
+            &state.event_loop_handle,
         ) {
             Ok(RenderOutputResult { damage, states, .. }) => {
                 std::mem::drop(fb);

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -230,6 +230,7 @@ impl Surface {
             &self.output,
             render::CursorMode::NotDefault,
             &mut self.screen_filter_state,
+            &state.event_loop_handle,
         ) {
             Ok(RenderOutputResult { damage, states, .. }) => {
                 self.surface

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -100,7 +100,7 @@ pub fn submit_buffer<R>(
     offscreen: Option<&mut R::Framebuffer<'_>>,
     transform: Transform,
     damage: Option<&[Rectangle<i32, Physical>]>,
-    sync: SyncPoint,
+    mut sync: SyncPoint,
 ) -> Result<Option<PendingImageCopyData>, R::Error>
 where
     R: ExportMem,
@@ -154,6 +154,11 @@ where
                     );
                 }
             }
+
+            // We've already waited on the sync point and copied from the texture
+            // TODO: Don't block in this function, and defer copy until ready?
+            sync = SyncPoint::signaled();
+
             Ok(())
         })
         .map_err(|err| R::Error::from_gles_error(GlesError::BufferAccessError(err)))

--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -471,8 +471,12 @@ pub fn render_workspace_to_buffer(
         }
     };
 
-    if let Some(PendingImageCopyData { frame, damage, .. }) = result {
-        frame.success(transform, damage, common.clock.now())
+    if let Some(pending_image_copy_data) = result {
+        pending_image_copy_data.send_success_when_ready(
+            transform,
+            &common.event_loop_handle,
+            common.clock.now(),
+        );
     }
 }
 
@@ -702,8 +706,12 @@ pub fn render_window_to_buffer(
         },
     };
 
-    if let Some(PendingImageCopyData { frame, damage, .. }) = result {
-        frame.success(Transform::Normal, damage, common.clock.now())
+    if let Some(pending_image_copy_data) = result {
+        pending_image_copy_data.send_success_when_ready(
+            Transform::Normal,
+            &common.event_loop_handle,
+            common.clock.now(),
+        );
     }
 }
 
@@ -858,7 +866,11 @@ pub fn render_cursor_to_buffer(
         }
     };
 
-    if let Some(PendingImageCopyData { frame, damage, .. }) = result {
-        frame.success(Transform::Normal, damage, common.clock.now())
+    if let Some(pending_image_copy_data) = result {
+        pending_image_copy_data.send_success_when_ready(
+            Transform::Normal,
+            &common.event_loop_handle,
+            common.clock.now(),
+        );
     }
 }


### PR DESCRIPTION
Uses https://github.com/Smithay/smithay/pull/1805 to get a sync point from the blit, and then waits on it in a calloop source without blocking the thread.

Like https://github.com/pop-os/cosmic-comp/pull/1580, this should fix some screen capture synchronization issues, but without the overhead of a `glFinish`.