### PR TITLE
cosmic-comp-config: Fix building without `output` feature

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use crate::input::TouchpadOverride;
 
 pub mod input;
-#[cfg(feature = "output")]
 pub mod output;
 pub mod workspace;
 

--- a/cosmic-comp-config/src/output/comp.rs
+++ b/cosmic-comp-config/src/output/comp.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs::OpenOptions, path::Path};
+use std::collections::HashMap;
+#[cfg(feature = "output")]
+use std::{fs::OpenOptions, path::Path};
+#[cfg(feature = "output")]
 use tracing::{error, warn};
 
 #[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -99,6 +102,7 @@ pub struct OutputInfo {
     pub model: String,
 }
 
+#[cfg(feature = "output")]
 pub fn load_outputs(path: Option<impl AsRef<Path>>) -> OutputsConfig {
     if let Some(path) = path.as_ref() {
         let path: &Path = path.as_ref();


### PR DESCRIPTION
`EdidProduct` is needed in `workspace`.

Only `load_outputs` really needs to be gated by the `output` feature. Just the type definitions don't require any extra dependencies.