### PR TITLE
Software rendering support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,7 +4915,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=20d2dac#20d2dacd71394b5f96f6ace0a70a6f20dc62c0c6"
+source = "git+https://github.com/smithay/smithay.git?rev=d3bdae4#d3bdae43afb37a52acbeeada574cc05b06b539ba"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,4 +147,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "20d2dac" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "d3bdae4" }

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -107,6 +107,7 @@ pub struct LockedDevice<'a> {
 pub struct InnerDevice {
     pub dev_node: DrmNode,
     pub render_node: DrmNode,
+    pub is_software: bool,
     pub egl: Option<EGLInternals>,
 
     pub outputs: HashMap<connector::Handle, Output>,
@@ -124,6 +125,7 @@ impl fmt::Debug for InnerDevice {
         f.debug_struct("Device")
             .field("dev_node", &self.dev_node)
             .field("render_node", &self.render_node)
+            .field("is_software", &self.is_software)
             .field("egl", &self.egl)
             .field("outputs", &self.outputs)
             .field("surfaces", &self.surfaces)
@@ -323,6 +325,7 @@ impl State {
             inner: InnerDevice {
                 dev_node: drm_node,
                 render_node,
+                is_software,
                 egl: None,
 
                 outputs: HashMap::new(),

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -249,7 +249,7 @@ impl State {
                 .ok()
                 .and_then(std::convert::identity)
                 .unwrap_or(drm_node);
-            let render_formats = egl.context.dmabuf_texture_formats().clone();
+            let render_formats = egl.context.dmabuf_render_formats().clone();
 
             (render_node, render_formats, egl.device.is_software())
         };

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -834,7 +834,7 @@ impl<'a> KmsGuard<'a> {
                             let driver = drm.device().get_driver().ok();
 
                             // QUIRK: Using an overlay plane on a nvidia card breaks the display controller (wtf...)
-                            if driver.is_some_and(|driver| {
+                            if driver.as_ref().is_some_and(|driver| {
                                 driver
                                     .name()
                                     .to_string_lossy()
@@ -842,6 +842,17 @@ impl<'a> KmsGuard<'a> {
                                     .contains("nvidia")
                             }) {
                                 planes.overlay = vec![];
+                            }
+                            // QUIRK: Cursor planes on evdi sometimes don't disappear correctly.
+                            // TODO: Debug and figure out, as they can be a nice improvement.
+                            if driver.as_ref().is_some_and(|driver| {
+                                driver
+                                    .name()
+                                    .to_string_lossy()
+                                    .to_lowercase()
+                                    .contains("evdi")
+                            }) {
+                                planes.cursor = vec![];
                             }
 
                             let mut renderer = self

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -437,16 +437,17 @@ impl KmsState {
         global: &DmabufGlobal,
         dmabuf: Dmabuf,
     ) -> Result<DrmNode> {
-        let (expected_node, other_nodes) =
-            self.drm_devices
-                .values_mut()
-                .partition::<Vec<_>, _>(|device| {
-                    device
-                        .socket
-                        .as_ref()
-                        .map(|s| &s.dmabuf_global == global)
-                        .unwrap_or(false)
-                });
+        let (expected_node, mut other_nodes) = self
+            .drm_devices
+            .values_mut()
+            .partition::<Vec<_>, _>(|device| {
+                device
+                    .socket
+                    .as_ref()
+                    .map(|s| &s.dmabuf_global == global)
+                    .unwrap_or(false)
+            });
+        other_nodes.retain(|device| device.socket.is_some());
 
         let mut last_err = anyhow::anyhow!("Dmabuf cannot be imported on any gpu");
         for device in expected_node.into_iter().chain(other_nodes.into_iter()) {

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -238,7 +238,11 @@ fn determine_primary_gpu(
     }
 
     // else just take the first
-    Ok(drm_devices.values().next().map(|dev| dev.inner.render_node))
+    Ok(drm_devices
+        .values()
+        .next()
+        .filter(|dev| !dev.inner.is_software)
+        .map(|dev| dev.inner.render_node))
 }
 
 /// Create `GlowRenderer` for `EGL_MESA_device_software` device, if present

--- a/src/backend/kms/render/gles.rs
+++ b/src/backend/kms/render/gles.rs
@@ -8,14 +8,14 @@ use smithay::backend::{
     },
     drm::{CreateDrmNodeError, DrmNode},
     renderer::{
-        gles::GlesError,
+        gles::{GlesError, GlesRenderer},
         glow::GlowRenderer,
         multigpu::{ApiDevice, Error as MultiError, GraphicsApi},
         RendererSuper,
     },
     SwapBuffersError,
 };
-use std::cell::Cell;
+use std::{borrow::Borrow, cell::Cell};
 use std::{
     collections::HashMap,
     fmt,
@@ -176,6 +176,9 @@ impl ApiDevice for GbmGlowDevice {
     }
     fn node(&self) -> &DrmNode {
         &self.node
+    }
+    fn can_do_cross_device_imports(&self) -> bool {
+        !Borrow::<GlesRenderer>::borrow(&self.renderer).is_software()
     }
 }
 

--- a/src/backend/kms/render/pixman.rs
+++ b/src/backend/kms/render/pixman.rs
@@ -152,4 +152,8 @@ impl ApiDevice for GbmPixmanDevice {
     fn node(&self) -> &DrmNode {
         &self.node
     }
+
+    fn can_do_cross_device_imports(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/144

Turns out the stupidest solution is the fastest...

The biggest changes are in smithay to fix llvmpipe (https://github.com/Smithay/smithay/pull/1811), but a few additional commits here clean up support for display link and other software devices. In general we don't want to expose hardware acceleration related features:
- Never consider a software based gpu a primary node (we have fallbacks for when no primary node is set)
- Don't advertise dmabuf-support for software gpus
- Don't advertise their outputs for leasing
- Don't test dmabuf imports on them
- Work around cursor bugs on evdi specifcially

I have another commit that uses what mutter describes as "zero-copy" (https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/810) or how anvil supports display link, but...
- Some render gpus don't support that anyway (e.g. nvidia can't render into a linear buffer), so we need the fallback path.
- Some gpu-less display drivers also don't support it.
- It isn't truly zero-copy, as of course the driver will still read from the dmabuf, which causes it to be migrated into memory, which ruins performance on all of my test machines. So I am getting similar latency and better performance across the board by just letting our existing multi-gpu infrastructure download and copy the new contents with damage.
- On Meteor/Arrow Lake we get interesting artifacts with this approach, just like when using screencopy.

I also spent a lot of time trying to get the PixmanRenderer and a second backend working instead of relying on llvmpipe. Except for the annoyance of implementing our shaders in software, it turns out that large effort did not only lead no or only marginal benefits, but instead didn't work at all on evdi.

The driver doesn't allow us to map dmabufs created from it's GbmBuffers or DumbBuffers, which we need to render with both the `PixmanRenderer` and more annoyingly `DrmCompositor`. Looking at the source code of the module, mapping the DumbBuffer directly with the corresponding ioctls would probably work, but that would need more architectural changes in smithay, at which point I just gave up.

So in the end we just use llvmpipe and mostly treat the drm device like any other.