### PR TITLE
kms: Don't join on `DrmSurface` drop

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -494,8 +494,9 @@ impl State {
             if let Some(mut leasing_global) = device.inner.leasing_global.take() {
                 leasing_global.disable_global::<State>();
             }
-            for surface in device.inner.surfaces.values_mut() {
+            for (_, surface) in device.inner.surfaces.drain() {
                 outputs_removed.push(surface.output.clone());
+                surface.drop_and_join();
             }
             if let Some(token) = device.event_token.take() {
                 self.common.event_loop_handle.remove(token);

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -705,11 +705,9 @@ impl<'a> KmsGuard<'a> {
                 .crtcs()
                 .iter()
                 .filter(|crtc| {
-                    !device
-                        .inner
-                        .surfaces
-                        .get(crtc)
-                        .is_some_and(|surface| surface.output.is_enabled())
+                    !device.inner.surfaces.get(crtc).is_some()
+                    // TODO: We can't do this. See https://github.com/Smithay/smithay/pull/1820
+                    //.is_some_and(|surface| surface.output.is_enabled())
                 })
                 .copied()
                 .collect::<HashSet<crtc::Handle>>();

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -468,6 +468,16 @@ impl Surface {
             }
         }
     }
+
+    pub fn drop_and_join(mut self) {
+        let thread = self.thread.take();
+        let _ = self;
+        if let Some(thread) = thread {
+            let name = thread.thread().name().unwrap().to_string();
+            let _ = thread.join();
+            info!("Thread {} terminated.", name)
+        }
+    }
 }
 
 impl Drop for Surface {
@@ -475,9 +485,13 @@ impl Drop for Surface {
         let _ = self.thread_command.send(ThreadCommand::End);
         self.loop_handle.remove(self.thread_token);
         if let Some(thread) = self.thread.take() {
-            let name = thread.thread().name().unwrap().to_string();
-            let _ = thread.join();
-            info!("Thread {} terminated.", name)
+            let _ = thread;
+            // We want to do this, but this currently deadlocks on `apply_config_for_outputs`.
+            /*
+                let name = thread.thread().name().unwrap().to_string();
+                let _ = thread.join();
+                info!("Thread {} terminated.", name)
+            */
         }
     }
 }


### PR DESCRIPTION
This partially reverts https://github.com/pop-os/cosmic-comp/pull/1624/commits/91af833e286ea645e95cb2f7865fe94ab9c5d5c8 to not join threads on `apply_config_for_output` disabled and thus dropped surfaces.

This is hopefully a temporary fix until a better solution is found upstream (e.g. https://github.com/Smithay/smithay/pull/1820), since this prevents us from immediately re-using any freed crtcs.

Fixes https://github.com/pop-os/cosmic-comp/issues/1631
Closes https://github.com/pop-os/cosmic-epoch/issues/2133