### PR TITLE
config: Make read_outputs failable

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -494,8 +494,9 @@ impl State {
             if let Some(mut leasing_global) = device.inner.leasing_global.take() {
                 leasing_global.disable_global::<State>();
             }
-            for surface in device.inner.surfaces.values_mut() {
+            for (_, surface) in device.inner.surfaces.drain() {
                 outputs_removed.push(surface.output.clone());
+                surface.drop_and_join();
             }
             if let Some(token) = device.event_token.take() {
                 self.common.event_loop_handle.remove(token);

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -705,11 +705,9 @@ impl<'a> KmsGuard<'a> {
                 .crtcs()
                 .iter()
                 .filter(|crtc| {
-                    !device
-                        .inner
-                        .surfaces
-                        .get(crtc)
-                        .is_some_and(|surface| surface.output.is_enabled())
+                    !device.inner.surfaces.get(crtc).is_some()
+                    // TODO: We can't do this. See https://github.com/Smithay/smithay/pull/1820
+                    //.is_some_and(|surface| surface.output.is_enabled())
                 })
                 .copied()
                 .collect::<HashSet<crtc::Handle>>();

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -468,6 +468,16 @@ impl Surface {
             }
         }
     }
+
+    pub fn drop_and_join(mut self) {
+        let thread = self.thread.take();
+        let _ = self;
+        if let Some(thread) = thread {
+            let name = thread.thread().name().unwrap().to_string();
+            let _ = thread.join();
+            info!("Thread {} terminated.", name)
+        }
+    }
 }
 
 impl Drop for Surface {
@@ -475,9 +485,13 @@ impl Drop for Surface {
         let _ = self.thread_command.send(ThreadCommand::End);
         self.loop_handle.remove(self.thread_token);
         if let Some(thread) = self.thread.take() {
-            let name = thread.thread().name().unwrap().to_string();
-            let _ = thread.join();
-            info!("Thread {} terminated.", name)
+            let _ = thread;
+            // We want to do this, but this currently deadlocks on `apply_config_for_outputs`.
+            /*
+                let name = thread.thread().name().unwrap().to_string();
+                let _ = thread.join();
+                info!("Thread {} terminated.", name)
+            */
         }
     }
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -227,7 +227,7 @@ pub fn init_backend(
         .add_heads(std::iter::once(&output));
     {
         state.common.add_output(&output);
-        state.common.config.read_outputs(
+        if let Err(err) = state.common.config.read_outputs(
             &mut state.common.output_configuration_state,
             &mut state.backend,
             &state.common.shell,
@@ -236,7 +236,9 @@ pub fn init_backend(
             &state.common.xdg_activation_state,
             state.common.startup_done.clone(),
             &state.common.clock,
-        );
+        ) {
+            error!("Unrecoverable output config error: {}", err);
+        }
         state.common.refresh();
     }
     state.launch_xwayland(None);

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -370,7 +370,7 @@ pub fn init_backend(
         .add_heads(std::iter::once(&output));
     {
         state.common.add_output(&output);
-        state.common.config.read_outputs(
+        if let Err(err) = state.common.config.read_outputs(
             &mut state.common.output_configuration_state,
             &mut state.backend,
             &state.common.shell,
@@ -379,7 +379,9 @@ pub fn init_backend(
             &state.common.xdg_activation_state,
             state.common.startup_done.clone(),
             &state.common.clock,
-        );
+        ) {
+            error!("Unrecoverable output configuration error: {}", err);
+        }
         state.common.refresh();
     }
     state.launch_xwayland(None);

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -1,7 +1,12 @@
-use crate::state::{BackendData, Common, State};
+use crate::{
+    state::{BackendData, Common, State},
+    utils::prelude::OutputExt,
+};
 use anyhow::{Context, Result};
 use calloop::{InsertError, LoopHandle, RegistrationToken};
+use cosmic_comp_config::output::comp::OutputState;
 use std::collections::HashMap;
+use tracing::{error, warn};
 use zbus::blocking::{fdo::DBusProxy, Connection};
 
 #[cfg(feature = "systemd")]
@@ -24,12 +29,26 @@ pub fn init(evlh: &LoopHandle<'static, State>) -> Result<Vec<RegistrationToken>>
                             }
                             _ => Vec::new(),
                         };
+                        let mut added = Vec::new();
                         for node in nodes {
-                            if let Err(err) = state.device_changed(node.dev_id()) {
-                                tracing::error!(?err, "Failed to update drm device {}.", node);
+                            match state.device_changed(node.dev_id()) {
+                                Ok(outputs) => added.extend(outputs),
+                                Err(err) => {
+                                    tracing::error!(?err, "Failed to update drm device {}.", node)
+                                }
                             }
                         }
-                        state.refresh_output_config();
+                        if let Err(err) = state.refresh_output_config() {
+                            warn!("Unable to load output config: {}", err);
+                            if !added.is_empty() {
+                                for output in added {
+                                    output.config_mut().enabled = OutputState::Disabled;
+                                }
+                                if let Err(err) = state.refresh_output_config() {
+                                    error!("Unrecoverable config error: {}", err);
+                                }
+                            }
+                        }
 
                         ()
                     }


### PR DESCRIPTION
Based on https://github.com/pop-os/cosmic-comp/pull/1632 as some scenarios here aren't really testable with the deadlock.

Previously we ignored when we had no output configuration **and** failed to apply the automatically created config (which is just every output enabled with it's preferred mode).

This leads to two problems:
- If this happens on startup, we end up with no outputs being added to the shell and we quit.
- If this happens later, we might end up in an inconsistent state, where the shell thinks we have an output, when it didn't light up, for similar reasons.

Thus `read_outputs` is failable and handling that very much depends on the where is was called from, because `read_outputs` doesn't know what configuration was active before.

Thus make it failable and provide useful mitigations everywhere
possible:
- Try to enable just one output in case we fail on start-up.
- Don't enable any additional outputs, when we fail on hot-plug.
- Log the error like previously in any other case (and come up with more
  mitigations, once we understand these cases better).
  
This is another output-configuration change close to the beta release, which might sound scary, but this addresses three real issues with the serw14 and it's 300Hz mode, which is currently the preferred mode. The reason being that 300hz takes so much bandwidth, that no additional output can be enabled.

Scenarios previously broken and fixed now:
- If you have another output plugged in on startup in a configuration the system hasn't seen before, we end up looping in cosmic-session, due to cosmic-comp quitting as it isn't able to initialize all outputs at once. With this fix it falls back to enabling only the internal display.
- If you plug in the output later, while being on 300hz, it would still show up as enabled under cosmic-settings and the shell state. With this fix the additional monitor initializes as disabled and can be enabled once the mode has been lowered.
- Convoluted setup, but if you use an output on the HDMI port (which is connected to the nvidia GPU this doesn't influence bandwidth), close the lid, then attach a DisplayPort output and then re-open the lid, you get a black internal screen with cosmic-settings showing the internal one as enabled similarly to the previous scenario. With this fix it shows correctly as disabled. You can't enable it without disabling the DisplayPort output first, because cosmic-settings won't give you a refresh rate selection on a disabled output. But that is purely an UI issue, as it works correctly with cosmic-randr.