### PR TITLE
WIP Don't add focus indicator to another floating window when a floating window is dragged

### DIFF
--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     shell::{
         layout::{floating::FloatingLayout, tiling::TilingLayout},
-        OverviewMode, ANIMATION_DURATION,
+        OverviewMode, SeatMoveGrabState, ANIMATION_DURATION,
     },
     state::State,
     utils::{prelude::*, tween::EaseRectangle},
@@ -1502,7 +1502,19 @@ impl Workspace {
             let layer_map = layer_map_for_output(&self.output);
             layer_map.non_exclusive_zone().as_local()
         };
-        let focused = self.focus_stack.get(last_active_seat).last().cloned();
+        let has_move_grab = last_active_seat
+            .user_data()
+            .get::<SeatMoveGrabState>()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .is_some();
+        let focused = self
+            .focus_stack
+            .get(last_active_seat)
+            .last()
+            .filter(|_| !has_move_grab)
+            .cloned();
 
         let mut fullscreen_elements = if let Some(fullscreen) = self.fullscreen.as_ref() {
             let bbox = fullscreen.surface.bbox();


### PR DESCRIPTION
This has been annoying me when using floating windows. Colored indicators appearing where they shouldn't (and don't with tiling drags) is a bit distracting.

This fix seems to work on a single output, but with multiple outputs messes up the focus indicators on the other output. Since the floating layout (but not the tiling layout) can show focus indicators on multiple outputs, and we only want to omit it on the output we drag a window from.

I thought modifying `refresh_focus_stack` not to remove a window from the stack if it in the `SeatMoveGrabState` might work, but it seems `append_focus_stack` is being called when the move grab starts? (In `set_focus`, called by `process_input_event`).