### PR TITLE
focus: Check if X11 surface matches in `KeyboardFocus::replace()`

### DIFF
--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -494,7 +494,7 @@ impl KeyboardTarget<State> for KeyboardFocusTarget {
     }
     fn replace(
         &self,
-        replaced: <State as smithay::input::SeatHandler>::KeyboardFocus,
+        replaced: Self,
         seat: &Seat<State>,
         data: &mut State,
         keys: Vec<KeysymHandle<'_>>,
@@ -504,6 +504,9 @@ impl KeyboardTarget<State> for KeyboardFocusTarget {
         if !replaced
             .wl_surface()
             .is_some_and(|s| Some(s) == self.wl_surface())
+            && !replaced
+                .x11_surface()
+                .is_some_and(|s| Some(s) == self.x11_surface())
         {
             KeyboardTarget::leave(&replaced, seat, data, serial);
             KeyboardTarget::enter(self, seat, data, keys, serial);


### PR DESCRIPTION
Tested on `SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=1 supertux2`, using XWayland. If the game starts with fullscreen configured, it minimizes immediately on start. But after this change, this no longer happens.

This hopefully will improve behaviors with various X11/wine fullscreen clients. It may fix https://github.com/pop-os/cosmic-comp/issues/1510, though looking at the video the behavior there may be a bit different.