### PR TITLE
screencopy: Without `draw_cursor`, omit dnd icon from toplevel capture

### DIFF
--- a/src/wayland/handlers/screencopy/render.rs
+++ b/src/wayland/handlers/screencopy/render.rs
@@ -602,17 +602,21 @@ pub fn render_window_to_buffer(
                 );
             }
 
-            if let Some(dnd_icon) = get_dnd_icon(&seat) {
-                elements.extend(
-                    cursor::draw_dnd_icon(
-                        renderer,
-                        &dnd_icon.surface,
-                        (location + dnd_icon.offset.to_f64()).to_i32_round(),
-                        1.0,
-                    )
-                    .into_iter()
-                    .map(WindowCaptureElement::from),
-                );
+            // TODO cosmic-workspaces wants to omit, but metadata cursor capture in portal should
+            // still include dnd surface in window capture buffer?
+            if draw_cursor {
+                if let Some(dnd_icon) = get_dnd_icon(&seat) {
+                    elements.extend(
+                        cursor::draw_dnd_icon(
+                            renderer,
+                            &dnd_icon.surface,
+                            (location + dnd_icon.offset.to_f64()).to_i32_round(),
+                            1.0,
+                        )
+                        .into_iter()
+                        .map(WindowCaptureElement::from),
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
It seems https://github.com/pop-os/cosmic-comp/pull/1638 caused an issue in cosmic-workspaces, where if there are multiple toplevels, when dragging a toplevel, the drag surface would appear in capture for other toplevels.

For now, omit drag surface in toplevel capture without `draw_cursor`. Though I guess ultimately we do want it for metadata cursor capture in the portal, but not in cosmic-workspaces? Maybe the protocol needs some additional option for this...