### PR TITLE
Use keyboard focus target rather than `focus_stack` in keybindings

### DIFF
--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -220,6 +220,14 @@ impl KeyboardFocusTarget {
         }
     }
 
+    pub fn active_window(&self) -> Option<CosmicSurface> {
+        match self {
+            KeyboardFocusTarget::Element(mapped) => Some(mapped.active_window()),
+            KeyboardFocusTarget::Fullscreen(surface) => Some(surface.clone()),
+            _ => None,
+        }
+    }
+
     pub fn is_xwm(&self, xwm: XwmId) -> bool {
         match self {
             KeyboardFocusTarget::Element(mapped) => {

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -262,8 +262,7 @@ impl SeatExt for Seat<State> {
     }
 
     /// Returns the output that contains the cursor associated with a seat. Note that the window which has keyboard focus
-    /// may be on a different output. Currently, to get the focused output, first get the keyboard focus target and pass
-    /// it to get_focused_output in the shell.
+    /// may be on a different output. Currently, to get the focused output, use [`Self::focused_output`].
     fn active_output(&self) -> Output {
         self.user_data()
             .get::<ActiveOutput>()


### PR DESCRIPTION
`Action::Close` already used the keyboard focus target, but some other bindings didn't. Presumably it's most intuitive if all "current window" key bindings affect the window with keyboard focus.

These used the focus stack on the `focused_output()` (the one with keyboard focus), so I guess the main impact is when the keyboard target is a window being dragged? Then the binding will operate on that window, or have no effect.

This seems related to some of the behaviors discussed in https://github.com/pop-os/cosmic-comp/issues/453.