### PR TITLE
Set "suspended" when a surface is minimized

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -104,6 +104,9 @@ struct Minimized(AtomicBool);
 struct Sticky(AtomicBool);
 
 #[derive(Default)]
+struct Suspended(AtomicBool);
+
+#[derive(Default)]
 struct GlobalGeometry(Mutex<Option<Rectangle<i32, Global>>>);
 
 impl CosmicSurface {
@@ -448,6 +451,7 @@ impl CosmicSurface {
                 let _ = surface.set_mapped(true);
             }
         }
+        self.update_suspended();
     }
 
     pub fn is_sticky(&self) -> bool {
@@ -466,7 +470,16 @@ impl CosmicSurface {
             .store(sticky, Ordering::SeqCst);
     }
 
-    pub fn set_suspended(&self, suspended: bool) {
+    fn update_suspended(&self) {
+        let minimized = self.is_minimized();
+        let suspended = self
+            .0
+            .user_data()
+            .get_or_insert_threadsafe(Minimized::default)
+            .0
+            .load(Ordering::SeqCst);
+
+        let suspended = minimized || suspended;
         match self.0.underlying_surface() {
             WindowSurface::Wayland(window) => window.with_pending_state(|state| {
                 if suspended {
@@ -479,6 +492,15 @@ impl CosmicSurface {
                 let _ = surface.set_suspended(suspended);
             }
         }
+    }
+
+    pub fn set_suspended(&self, suspended: bool) {
+        self.0
+            .user_data()
+            .get_or_insert_threadsafe(Suspended::default)
+            .0
+            .store(suspended, Ordering::SeqCst);
+        self.update_suspended();
     }
 
     pub fn min_size_without_ssd(&self) -> Option<Size<i32, Logical>> {


### PR DESCRIPTION
This seems for an SDL XWayland client to restore fullscreen after unminimize, it needs to see the `_NET_WM_STATE_FOCUSED` state get set and unset.

This is a somewhat awkward way to do this. I'm not sure if the Wayland `suspended` flag should be treated as equivalent to `_NET_WM_STATE_FOCUSED`? If it's meant to be, the way it's defined in the protocol doesn't quite seem right.

https://github.com/pop-os/cosmic-comp/issues/1510