### PR TITLE
Call `dbus::ready` even when systemd is enabled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,6 @@ impl State {
             if let state::BackendData::Kms(_) = &self.backend {
                 #[cfg(feature = "systemd")]
                 systemd::ready(&self.common);
-                #[cfg(not(feature = "systemd"))]
                 if let Err(err) = dbus::ready(&self.common) {
                     error!(?err, "Failed to update the D-Bus activation environment");
                 }


### PR DESCRIPTION
The Gentoo overlap packaged needed this to get socket activation working properly (https://github.com/fsvm88/cosmic-overlay/pull/88).

For some reason I didn't seem to need this testing socket activation on Pop!_OS? Unless someone knows exactly why or has a better idea, for now apply this change along with the socket activation change in https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/176.