### PR TITLE
Use automatic shared library dependency on libdisplay-info

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,6 @@ Depends:
     ${shlibs:Depends},
     libegl1,
     libwayland-server0,
-    libdisplay-info1,
 Recommends:
     cosmic-session,
     libgl1-mesa-dri


### PR DESCRIPTION
Should fix installation on 26.04, which instead has `libdisplay-info2`. This is the control file that is generated, it still has `libdisplay-info1` in `Depends`:

```
Package: cosmic-comp
Version: 0.1
Architecture: amd64
Maintainer: Victoria Brekenfeld <victoria@system76.com>
Installed-Size: 25567
Depends: libc6 (>= 2.39), libdisplay-info1 (>= 0.1.1), libgbm1 (>= 21.3.0~rc1), libgcc-s1 (>= 4.2), libinput10 (>= 1.19.1), libpixman-1-0 (>= 0.30.0), libseat1 (>= 0.5.0), libudev1 (>= 183), libxkbcommon0 (>= 0.5.0), libegl1, libwayland-server0
Recommends: cosmic-session, libgl1-mesa-dri
Section: x11
Priority: optional
Homepage: https://github.com/pop-os/cosmic-comp
Description: Wayland compositor of pop-os cosmic shell
```