### PR TITLE
Change Focus keyboard action to check borders closest to focus direction

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3762,6 +3762,9 @@ impl Shell {
                     .max_by_key(|(_, other_geo)| {
                         let other_y_h = other_geo.loc.y + other_geo.size.h;
                         let delta = geometry.loc.y - other_y_h;
+                        if delta == 0 {
+                            return i32::MAX;
+                        }
                         if delta.is_positive() {
                             i32::MAX - delta
                         } else {
@@ -3773,6 +3776,9 @@ impl Shell {
                     .min_by_key(|(_, other_geo)| {
                         let current_y_h = geometry.loc.y + geometry.size.h;
                         let delta = current_y_h - other_geo.loc.y;
+                        if delta == 0 {
+                            return i32::MIN;
+                        }
                         if delta.is_negative() {
                             i32::MIN - delta
                         } else {
@@ -3784,6 +3790,9 @@ impl Shell {
                     .max_by_key(|(_, other_geo)| {
                         let other_x_w = other_geo.loc.x + other_geo.size.w;
                         let delta = geometry.loc.x - other_x_w;
+                        if delta == 0 {
+                            return i32::MAX;
+                        }
                         if delta.is_positive() {
                             i32::MAX - delta
                         } else {
@@ -3795,6 +3804,9 @@ impl Shell {
                     .min_by_key(|(_, other_geo)| {
                         let current_x_w = geometry.loc.x + geometry.size.w;
                         let delta = current_x_w - other_geo.loc.x;
+                        if delta == 0 {
+                            return i32::MIN;
+                        }
                         if delta.is_negative() {
                             i32::MIN - delta
                         } else {


### PR DESCRIPTION
Hello! I just want to say I love what you are doing with this desktop environment.

I often use keyboard shortcuts to navigate around the system both in floating and tiling so I couldn't help but notice the  odd priorities when the compositor has to choose which window should be focused next.

Right now the compositor chooses the next window to focus based on which is the closest window along the relevant axis (X for right and left, Y for up and down)
But this is clunky, because that position is on the opposite end of the current window, so for example if we are trying to focus to the right window of the current one, we end up choosing the window that's closest to the left border of the current window instead of the window that's closest to the right border of the current window. This leads to behavior like two windows that are seemingly perfectly next to each other, you want to switch focus, and a small window from under pops up.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dfdfc768-83bd-49ea-95fe-957f946e2a0c" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0837729c-a77d-4ed8-a50b-30622a4330b2" />

I changed this to prioritize windows that are closer to the relevant border on the relevant axis.
So if we take the example with the right window again it goes something like this:
Prioritize the window whose X position is closest to the right border on the right side of the right border.
i.e: `min(other.X - (current.X + current.width) ) // where this is > 0`
If there is no window that matches that, looks for the window whose X position is closest to the right border on the left side of the right border.
i.e: `max(other.X - (current.X + current.width)) // where this is < 0`


 