### PR TITLE
shell/stack: Don't reset `previous_keyboard` on noop `set_active` call

### DIFF
--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -465,7 +465,9 @@ impl CosmicStack {
         self.0.with_program(|p| {
             if let Some(val) = p.windows.lock().unwrap().iter().position(|w| w == window) {
                 let old = p.active.swap(val, Ordering::SeqCst);
-                p.previous_keyboard.store(old, Ordering::SeqCst);
+                if old != val {
+                    p.previous_keyboard.store(old, Ordering::SeqCst);
+                }
             }
         });
         self.0


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/1674, or at least what has been reported by OP specifically with firefox (didn't work with chrome).

Key to this bug is, that the two windows need to be from the same client, which then gets confused due to a missing enter event as to which window should receive the key-events sent by us.