### PR TITLE
fix(popup): avoid panic when None

### DIFF
--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -186,8 +186,7 @@ pub fn get_popup_toplevel(popup: &PopupSurface) -> Option<WlSurface> {
                 .parent
                 .as_ref()
                 .cloned()
-                .unwrap()
-        });
+        })?;
     }
     Some(parent)
 }


### PR DESCRIPTION
cosmic-comp panics here after launching an app from the app tray overflow popup. While it may indicate a panel issue that I also need to look into, it seems to work fine if we don't unwrap on this option.