### PR TITLE
chore: smithay update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4961,7 +4961,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=d743e1a#d743e1a317fa0f01d1c4cadd96d277a1ec7b59d9"
+source = "git+https://github.com/smithay/smithay.git?rev=15e3fcd#15e3fcde99deb1adfab4c63be0a06783b780e963"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,4 +145,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "d743e1a" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "15e3fcd" }


### PR DESCRIPTION
Updates smithay, notably including [this fix](https://github.com/Smithay/smithay/pull/1856).

Which might not fully fix the adaptive sync logic, but it should avoid bugs like:
- https://github.com/pop-os/cosmic-comp/issues/1657
- https://github.com/pop-os/cosmic-comp/issues/1372