### PR TITLE
gestures: Cycle through workspaces

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1056,10 +1056,12 @@ impl State {
                         }
 
                         match gesture_state.action {
-                            Some(SwipeAction::NextWorkspace) | Some(SwipeAction::PrevWorkspace) => {
+                            Some(x @ SwipeAction::NextWorkspace)
+                            | Some(x @ SwipeAction::PrevWorkspace) => {
                                 self.common.shell.write().update_workspace_delta(
                                     &seat.active_output(),
                                     gesture_state.delta,
+                                    matches!(x, SwipeAction::NextWorkspace),
                                 )
                             }
                             _ => {}


### PR DESCRIPTION
Fix for https://github.com/pop-os/cosmic-comp/issues/725 / workspaces not cycling through when using the swipe touchpad gesture.

This required a few more small changes through out the code base to additionally track the direction of the swipe, since it cannot be inferred any more from the indicies of the workspaces alone.