### PR TITLE
Fix focus stack crash

### DIFF
--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -29,7 +29,7 @@ use super::{SeatExt, grabs::SeatMoveGrabState, layout::floating::FloatingLayout}
 mod order;
 pub mod target;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FocusTarget {
     Window(CosmicMapped),
     Fullscreen(CosmicSurface),
@@ -56,6 +56,15 @@ impl indexmap::Equivalent<FocusTarget> for CosmicMapped {
 impl indexmap::Equivalent<FocusTarget> for CosmicSurface {
     fn equivalent(&self, key: &FocusTarget) -> bool {
         key == self
+    }
+}
+
+impl Hash for FocusTarget {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            FocusTarget::Window(window) => window.hash(state),
+            FocusTarget::Fullscreen(surface) => surface.hash(state),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes pop-os/cosmic-epoch#2548

# Issue
The focus stack was not properly being cleaned up after moving the element to another workspace.
This was not properly working for both tiling and floating layout. 

`shift_remove` does not remove  the occurrences within the focus_stack. This was caused because the elements were not properly hashed, which is required for `indexmap::Equivalent`. 

