### PR TITLE
Support `_NET_ACTIVE_WINDOW` to allow X11 windows to set focus

### DIFF
--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -1110,6 +1110,18 @@ impl XwmHandler for State {
         }
     }
 
+    fn active_window_request(
+        &mut self,
+        _xwm: XwmId,
+        window: X11Surface,
+        _timestamp: u32,
+        _currently_active_window: Option<X11Surface>,
+    ) {
+        if let Some(surface) = window.wl_surface() {
+            self.activate_surface(&surface, None);
+        }
+    }
+
     fn send_selection(
         &mut self,
         _xwm: XwmId,


### PR DESCRIPTION
Requires https://github.com/Smithay/smithay/pull/1863. This is based on https://github.com/pop-os/cosmic-comp/pull/1797 to compile with an updated Smithay.

This draft version duplicates logic from `XdgActivationHandler`. Though we probably don't want to set `WState::Urgent` like that (and should instead use the `UrgencyHint` from `WM_HINTS`).

We may want to restrict when a client can set this, but it's not clear exactly how. Comparing other implementations may help.

This seems for fix https://github.com/pop-os/cosmic-applets/issues/550, testing with the Slack app indicator. https://github.com/pop-os/cosmic-notifications/issues/35, with notifications, may the same problem.