### PR TITLE
Handle `xdg-system-bell-v1`, marking workspace as "urgent"

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -108,6 +108,7 @@ use smithay::{
         virtual_keyboard::VirtualKeyboardManagerState,
         xdg_activation::XdgActivationState,
         xdg_foreign::XdgForeignState,
+        xdg_system_bell::XdgSystemBellState,
         xwayland_keyboard_grab::XWaylandKeyboardGrabState,
         xwayland_shell::XWaylandShellState,
     },
@@ -703,6 +704,8 @@ impl State {
         let a11y_state = A11yState::new::<State, _>(dh, client_not_sandboxed);
 
         let a11y_keyboard_monitor_state = A11yKeyboardMonitorState::new(&async_executor);
+
+        XdgSystemBellState::new::<State>(dh);
 
         State {
             common: Common {

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -46,5 +46,6 @@ pub mod workspace;
 pub mod xdg_activation;
 pub mod xdg_foreign;
 pub mod xdg_shell;
+pub mod xdg_system_bell;
 pub mod xwayland_keyboard_grab;
 pub mod xwayland_shell;

--- a/src/wayland/handlers/xdg_system_bell.rs
+++ b/src/wayland/handlers/xdg_system_bell.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::{state::State, wayland::protocols::workspace::State as WState};
+use smithay::{
+    delegate_xdg_system_bell, reexports::wayland_server::protocol::wl_surface::WlSurface,
+    wayland::xdg_system_bell::XdgSystemBellHandler,
+};
+
+impl XdgSystemBellHandler for State {
+    fn ring(&mut self, surface: Option<WlSurface>) {
+        let shell = self.common.shell.read();
+
+        if let Some(surface) = surface {
+            if let Some((workspace, _output)) = shell.workspace_for_surface(&surface) {
+                let mut workspace_guard = self.common.workspace_state.update();
+                workspace_guard.add_workspace_state(&workspace, WState::Urgent);
+            }
+        }
+    }
+}
+
+delegate_xdg_system_bell!(State);


### PR DESCRIPTION
This can be tested with terminals like `foot`, though not with the version packaged by 24.04, using commands like `tput bel`. Or `sleep 2 && tput bel` then switching to a different workspace.

It seems reasonable that a "bell" will cause a window to be urgent to get the user's attention. If we want a more complete concept of urgency, we should probably have it as as part of the toplevels state, not just the workspace state, and can highlight urgent windows with window borders, and in `cosmic-workspaces`.