### PR TITLE
fix: Add second touchpad hotkey config for Pangolin keyboards

### DIFF
--- a/data/keybindings.ron
+++ b/data/keybindings.ron
@@ -122,4 +122,5 @@
     (modifiers: [], key: "XF86AudioNext"): System(PlayNext),
     (modifiers: [], key: "XF86PowerOff"): System(PowerOff),
     (modifiers: [], key: "XF86TouchpadToggle"): System(TouchpadToggle),
+    (modifiers: [Super, Ctrl], key: "XF86TouchpadToggle"): System(TouchpadToggle),
 }


### PR DESCRIPTION
Fixes #1855.

Certain Pangolin models send Ctrl+Super+XF86TouchpadToggle instead of just XF86TouchpadToggle. I guess GNOME somehow didn't care about this?