### PR TITLE
toolchain: update to 1.90

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.90"
 components = [ "rust-src" ]


### PR DESCRIPTION
### Rationale 
Using a consistent Rust toolchain across all components simplifies development and increases reproducibility.

Since cosmic-applets, cosmic-notifications and cosmic-settings-daemon are in 1.90, we should probably follow that as well for the rest of the components.