### PR TITLE
Fix toplevel disappearing after window gets unmapped and mapped 

### DIFF
--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -335,9 +335,16 @@ where
         let toplevel_handle = self
             .foreign_toplevel_list
             .new_toplevel::<D>(toplevel.title(), toplevel.app_id());
-        toplevel
-            .user_data()
-            .insert_if_missing(move || ToplevelStateInner::from_foreign(toplevel_handle));
+
+        if let Some(toplevel_state) = toplevel.user_data().get::<ToplevelState>() {
+            let mut toplevel_state = toplevel_state.lock().unwrap();
+            toplevel_state.foreign_handle = Some(toplevel_handle);
+        } else {
+            toplevel
+                .user_data()
+                .insert_if_missing(move || ToplevelStateInner::from_foreign(toplevel_handle));
+        }
+
         for instance in &self.instances {
             send_toplevel_to_client::<D, W>(&self.dh, workspace_state, instance, toplevel);
         }


### PR DESCRIPTION
Currently, when a window  is unmapped and at some point mapped again, it doesn't reappear as a toplevel.
This happens, because `new_toplevel` only inserts a toplevel state in the userdata of the window if it doesn't already exist, which is just the first time the window is mapped.
So when it gets unmapped, and [its foreign handle gets removed](https://github.com/pop-os/cosmic-comp/blob/8fc7f0809f32664864582ed39e40169cf6cfe8a0/src/wayland/protocols/toplevel_info.rs#L362)
it doesn't get it's foreign_handle reassigned.

Also, I am not entirely sure about this, but shouldn't the `state_inner.instances` get drained in remove_toplevel while sending out the closed events? If they aren't and for some reason the `ZcosmicToplevelHandleV1` objects there aren't destroyed by the time the surface is mapped again, aren't events are going to be sent for a presumably closed handle?
