### PR TITLE
layout/tiling: Always send output_enter after swap

### DIFF
--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -1075,9 +1075,7 @@ impl TilingLayout {
                 .into();
                 mapped.set_tiled(true);
                 mapped.refresh();
-                if this.output != other_output {
-                    mapped.output_enter(&other_output, mapped.bbox());
-                }
+                mapped.output_enter(&other_output, mapped.bbox());
 
                 *mapped.tiling_node_id.lock().unwrap() = Some(other_desc.node.clone());
                 other_tree
@@ -1162,9 +1160,7 @@ impl TilingLayout {
                 .into();
                 mapped.set_tiled(true);
                 mapped.refresh();
-                if this.output != other_output {
-                    mapped.output_enter(&this.output, mapped.bbox());
-                }
+                mapped.output_enter(&this.output, mapped.bbox());
 
                 *mapped.tiling_node_id.lock().unwrap() = Some(this_desc.node.clone());
                 this_tree


### PR DESCRIPTION
Fixes a bug I found while testing https://github.com/pop-os/cosmic-comp/pull/1878.

Swapping a window, that would have server-side-decorations from inside a stack to the outside would leave the newly created window without a drawn window decoration until something refreshes it.