### PR TITLE
focus: Restore focus to swap group

### DIFF
--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    shell::{CosmicSurface, MinimizedWindow, Shell, element::CosmicMapped},
+    shell::{CosmicSurface, MinimizedWindow, Shell, Trigger, element::CosmicMapped},
     state::Common,
     utils::prelude::*,
     wayland::handlers::{xdg_shell::PopupGrabData, xwayland_keyboard_grab::XWaylandGrabSeatData},
@@ -680,17 +680,23 @@ fn update_focus_target(
             .cloned()
             .map(KeyboardFocusTarget::from)
     } else {
-        shell
-            .active_space(output)
-            .unwrap()
+        let workspace = shell.active_space(output).unwrap();
+
+        if let Some(Trigger::KeyboardSwap(_, desc)) = shell.overview_mode().0.active_trigger() {
+            if workspace.handle == desc.handle && workspace.tiling_layer.has_node(&desc.node) {
+                if let Some(focus) = workspace.tiling_layer.node_desc_to_focus(desc) {
+                    return Some(focus);
+                }
+            }
+        }
+
+        workspace
             .focus_stack
             .get(seat)
             .last()
             .cloned()
             .map(Into::<KeyboardFocusTarget>::into)
             .or_else(|| {
-                let workspace = shell.active_space(output).unwrap();
-
                 workspace
                     .mapped()
                     .next()


### PR DESCRIPTION
Fixes the second issue reported in https://github.com/pop-os/cosmic-epoch/issues/1269.

The issue was triggered, because the switch back from the second workspace to the first, did not take the swap groups into consideration, allowing the code to falsely select a child of the group as it's focus. Swapping then attempted to swap between a group and a child of said group, which resulted in cosmic-comp "losing" a window.

This fix makes sure, that we always select any active swap group for focus when switching back to the originating workspace, thus fixing the issue.

(A nicer fix would be to have an easier way to determine, if a potential selection would part of the tree of a current swap group. But that would require some more refactoring for quite a niche issue, the focus of this PR is just to avoid the error state.)