### PR TITLE
layout/floating: In `unmap`, don't alter size if no pending changes

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -173,6 +173,13 @@ impl CosmicSurface {
         }
     }
 
+    pub fn has_pending_changes(&self) -> bool {
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => toplevel.has_pending_changes(),
+            WindowSurface::X11(_surface) => false,
+        }
+    }
+
     pub fn global_geometry(&self) -> Option<Rectangle<i32, Global>> {
         *self
             .0

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -679,8 +679,10 @@ impl FloatingLayout {
                 mapped_geometry.size = last_size;
             }
         } else if !window.is_maximized(true) {
-            if let Some(pending_size) = window.pending_size() {
-                mapped_geometry.size = pending_size.as_local();
+            if window.active_window().has_pending_changes() {
+                if let Some(pending_size) = window.pending_size() {
+                    mapped_geometry.size = pending_size.as_local();
+                }
             }
             *window.last_geometry.lock().unwrap() = Some(mapped_geometry);
         }


### PR DESCRIPTION
If the intent here was that the `if let` would only handle the case where there are pending changes, then something like this should be right.

Seems to fix behavior in https://github.com/pop-os/cosmic-comp/issues/1819. https://github.com/pop-os/cosmic-comp/issues/1645 may be the same issue.