### PR TITLE
fix: defer seat creation until output is detected

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -387,6 +387,18 @@ impl State {
             .add_heads(wl_outputs.iter());
 
         self.backend.kms().refresh_used_devices()?;
+
+        if !self
+            .common
+            .startup_done
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            if let Some(output) = wl_outputs.iter().next().cloned() {
+                if let Err(err) = self.finish_startup(output) {
+                    tracing::error!("Failed to finish startup: {err:?}");
+                }
+            }
+        }
         Ok(wl_outputs)
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,9 +3,6 @@
 use crate::state::State;
 use crate::wayland::protocols::a11y::A11yHandler;
 use anyhow::{Context, Result, anyhow};
-use cosmic_comp_config::NumlockState;
-use cosmic_config::CosmicConfigEntry;
-use cosmic_settings_daemon_config::greeter;
 use smithay::reexports::{calloop::EventLoop, wayland_server::DisplayHandle};
 use tracing::{info, warn};
 
@@ -46,118 +43,12 @@ pub fn init_backend_auto(
     };
 
     if res.is_ok() {
-        let output = state
-            .common
-            .shell
-            .read()
-            .outputs()
-            .next()
-            .with_context(|| "Backend initialized without output")
-            .cloned()?;
-        let initial_seat = crate::shell::create_seat(
-            dh,
-            &mut state.common.seat_state,
-            &output,
-            &state.common.config,
-            "seat-0".into(),
-        );
-
-        let keyboard = initial_seat
-            .get_keyboard()
-            .ok_or_else(|| anyhow!("`shell::create_seat` did not setup keyboard"))?;
-
-        state
-            .common
-            .shell
-            .write()
-            .seats
-            .add_seat(initial_seat.clone());
-
-        let greeter_state = match greeter::GreeterAccessibilityState::config() {
-            Ok(helper) => match greeter::GreeterAccessibilityState::get_entry(&helper) {
-                Ok(s) => s,
-                Err((errs, s)) => {
-                    for err in errs {
-                        tracing::error!("Error loading greeter state: {err:?}");
-                    }
-                    s
-                }
-            },
-            Err(_) => {
-                tracing::info!("`cosmic-greeter` state not found.");
-                greeter::GreeterAccessibilityState::default()
+        if let Some(output) = state.common.shell.read().outputs().next().cloned() {
+            if let Err(err) = state.finish_startup(output) {
+                tracing::error!("Failed to finish startup: {err:?}");
             }
-        };
-
-        if let Some(magnifier) = greeter_state.magnifier {
-            let mut zoom = state.common.config.cosmic_conf.accessibility_zoom;
-
-            zoom.start_on_login = magnifier;
-            if let Err(err) = state
-                .common
-                .config
-                .cosmic_conf
-                .set_accessibility_zoom(&state.common.config.cosmic_helper, zoom)
-            {
-                tracing::error!("Failed to set screen filter: {err:?}");
-            }
-        }
-
-        if let Some(inverted) = greeter_state.invert_colors {
-            if inverted != state.a11y_state().screen_inverted() {
-                state.request_screen_invert(inverted);
-            }
-        }
-
-        if state
-            .common
-            .config
-            .cosmic_conf
-            .accessibility_zoom
-            .start_on_login
-        {
-            state.common.shell.write().trigger_zoom(
-                &initial_seat,
-                None,
-                1.0 + (state.common.config.cosmic_conf.accessibility_zoom.increment as f64 / 100.),
-                &state.common.config.cosmic_conf.accessibility_zoom,
-                true,
-                &state.common.event_loop_handle,
-            );
-        }
-
-        let desired_numlock = state
-            .common
-            .config
-            .cosmic_conf
-            .keyboard_config
-            .numlock_state;
-        // Restore numlock state based on config.
-        let toggle_numlock = match desired_numlock {
-            NumlockState::BootOff => keyboard.modifier_state().num_lock,
-            NumlockState::BootOn => !keyboard.modifier_state().num_lock,
-            NumlockState::LastBoot => {
-                keyboard.modifier_state().num_lock
-                    != state.common.config.dynamic_conf.numlock().last_state
-            }
-        };
-
-        // If we're enabling numlock...
-        if toggle_numlock {
-            /// Linux scancode for numlock key.
-            const NUMLOCK_SCANCODE: u32 = 69;
-            crate::config::change_modifier_state(&keyboard, NUMLOCK_SCANCODE, state);
-        }
-        {
-            {
-                state
-                    .common
-                    .startup_done
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
-                for output in state.common.shell.read().outputs() {
-                    state.backend.schedule_render(output);
-                }
-            }
+        } else {
+            tracing::warn!("Backend initialized without output, deferring startup");
         }
     }
     res


### PR DESCRIPTION
Fixes #1644. This change allows the backend to initialize even if no outputs are immediately present, by deferring Seat creation and other output-dependent logic until an output is hotplugged or detected.