### PR TITLE
Fix reuse of wl_surface by distinguishing between Unmap and Destroy

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2832,7 +2832,8 @@ impl Shell {
         surface: &S,
         seat: &Seat<State>,
         toplevel_info: &mut ToplevelInfoState<State, CosmicSurface>,
-    ) where
+    ) -> Option<PendingWindow>
+    where
         CosmicSurface: PartialEq<S>,
     {
         for set in self.workspaces.sets.values_mut() {
@@ -2890,15 +2891,16 @@ impl Shell {
 
             if let Some(surface) = surface {
                 toplevel_info.remove_toplevel(&surface);
-                self.pending_windows.push(PendingWindow {
+                return Some(PendingWindow {
                     surface,
                     seat: seat.clone(),
                     fullscreen: None,
                     maximized: false,
                 });
-                return;
             }
         }
+
+        None
     }
 
     pub fn move_current(

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -321,7 +321,7 @@ impl XdgShellHandler for State {
             let output = shell
                 .visible_output_for_surface(surface.wl_surface())
                 .cloned();
-            shell.unmap_surface(
+            let _ = shell.unmap_surface(
                 surface.wl_surface(),
                 &seat,
                 &mut self.common.toplevel_info_state,

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -873,7 +873,11 @@ impl XwmHandler for State {
             shell.override_redirect_windows.retain(|or| or != &window);
         } else {
             let seat = shell.seats.last_active().clone();
-            shell.unmap_surface(&window, &seat, &mut self.common.toplevel_info_state);
+            if let Some(pending) =
+                shell.unmap_surface(&window, &seat, &mut self.common.toplevel_info_state)
+            {
+                shell.pending_windows.push(pending);
+            }
         }
 
         let outputs = if let Some(wl_surface) = window.wl_surface() {


### PR DESCRIPTION
Fixes #1816
and pop-os/cosmic-epoch#2513 (at least for Telegram, can't say for others)

Clients like Telegram (Qt) reuse `wl_surface` objects. They destroy an `xdg_toplevel`, keep the surface, and later create a new toplevel on it.
Currently, `unmap_surface` unconditionally pushes the unmapped window into `pending_windows`. This leads to invalid state transitions during surface reuse:

1. Client destroys the `xdg_toplevel`.
2. `unmap_surface` saves the "dead" window to `pending_windows`.
3. Client performs a cleanup commit (e.g., attaching a null buffer) on the `wl_surface`.
4. Because the surface is in `pending_windows`, the compositor reacts to this commit by sending a configure event.
5. **Crucially:** This marks the surface as `configured = true` in the underlying state.
6. Client creates a _new_ `xdg_toplevel` role on the same surface.
7. The compositor checks `configured`. Since it is true, it skips sending the **initial configure** event.
8. The client waits forever for the initial configure, and the window never maps.

The Fix:
I have refactored `unmap_surface` to remove the side effect of automatically pushing to `pending_windows`.

- `unmap_surface` now returns `Option<PendingWindow>`.
- X11 (Unmap): The caller explicitly saves the returned window to `pending_windows` (preserving existing behavior for minimization/restore).
- Wayland (Destroy): The caller ignores the returned value, dropping the `PendingWindow` struct immediately.

This ensures that when a Wayland role is destroyed, it is fully removed from internal tracking, allowing the next role on that surface to start with a clean state.