### PR TITLE
fix(actions): switch-display focus when switching screens for MoveToOutput shortcuts

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -626,6 +626,11 @@ impl State {
 
                     if let Ok(Some((target, new_pos))) = res {
                         std::mem::drop(shell);
+
+                        if is_move_action {
+                            seat.set_active_output(&next_output);
+                        }
+
                         Shell::set_focus(self, Some(&target), seat, None, is_move_action);
                         if let Some(ptr) = seat.get_pointer() {
                             ptr.motion(


### PR DESCRIPTION
Previously it wouldn't switch the focused display (verifiable by keeping settings open, and trying MoveToOutput shortcuts). 

This PR aims to fix that. (sorry for the long branch name, had meant to have it for the commit)

Also #394 can be closed ig, it seems to work as intended now

Wasn't able to test multi-monitor, but from the previous results and guessing from code, it should likely be the fix (though do need someone to verify it once)

Edit: super + shift + alt + hjkl shortcuts work as intended, but super + alt + > (move to output) doesn't seem to work for switching windows continously (works only once). Is this shortcut marked as deprecated (might've missed) or is being removed in the future?