### PR TITLE
Rename bare-session files not to overwrite cosmic-session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,14 +53,14 @@ install:
 	install -Dm0644 "data/tiling-exceptions.ron" "$(TILING_EXCEPTIONS_CONF)"
 
 install-bare-session: install
-	install -Dm0644 "data/cosmic.desktop" "$(DESTDIR)$(sharedir)/wayland-sessions/cosmic.desktop"
-	install -Dm0644 "data/cosmic-session.target" "$(DESTDIR)$(libdir)/systemd/user/cosmic-session.target"
-	install -Dm0644 "data/cosmic-session-pre.target" "$(DESTDIR)$(libdir)/systemd/user/cosmic-session-pre.target"
+	install -Dm0644 "data/cosmic-comp.desktop" "$(DESTDIR)$(sharedir)/wayland-sessions/cosmic-comp.desktop"
+	install -Dm0644 "data/cosmic-comp-session.target" "$(DESTDIR)$(libdir)/systemd/user/cosmic-comp-session.target"
+	install -Dm0644 "data/cosmic-comp-session-pre.target" "$(DESTDIR)$(libdir)/systemd/user/cosmic-comp-session-pre.target"
 	install -Dm0644 "data/cosmic-comp.service" "$(DESTDIR)$(libdir)/systemd/user/cosmic-comp.service"
-	install -Dm0755 "data/cosmic-service" "$(DESTDIR)/$(bindir)/cosmic-service"
+	install -Dm0755 "data/cosmic-comp-service" "$(DESTDIR)/$(bindir)/cosmic-comp-service"
 
 uninstall:
 	rm "$(TARGET_BIN)" "$(KEYBINDINGS_CONF)"
 
 uninstall-bare-session:
-	rm "$(DESTDIR)$(sharedir)/wayland-sessions/cosmic.desktop"
+	rm "$(DESTDIR)$(sharedir)/wayland-sessions/cosmic-comp.desktop"

--- a/data/cosmic-comp-service
+++ b/data/cosmic-comp-service
@@ -6,7 +6,7 @@
 # reset them so that they don't break this startup
 for unit in $(systemctl --user --no-legend --state=failed --plain list-units | cut -f1 -d' '); do
 	partof="$(systemctl --user show -p PartOf --value "$unit")"
-	for target in cosmic-session.target graphical-session.target; do
+	for target in cosmic-comp-session.target graphical-session.target; do
 		if [ "$partof" = "$target" ]; then
 			systemctl --user reset-failed "$unit"
 			break

--- a/data/cosmic-comp-session-pre.target
+++ b/data/cosmic-comp-session-pre.target
@@ -1,8 +1,8 @@
 [Unit]
-Description=Cosmic session early services
+Description=Cosmic compositor-only session early services
 Documentation=man:systemd.special(7)
 RefuseManualStart=yes
 StopWhenUnneeded=yes
 BindsTo=graphical-session-pre.target
 Before=graphical-session-pre.target
-Before=cosmic-session.target
+Before=cosmic-comp-session.target

--- a/data/cosmic-comp-session.target
+++ b/data/cosmic-comp-session.target
@@ -1,5 +1,5 @@
 [Unit]
-Description=Cosmic session
+Description=Cosmic compositor-only session
 Documentation=man:systemd.special(7)
 RefuseManualStart=yes
 StopWhenUnneeded=yes

--- a/data/cosmic-comp.desktop
+++ b/data/cosmic-comp.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Cosmic (Compositor Only)
+Comment=This session logs you into a bare cosmic-comp session
+Exec=/usr/bin/cosmic-comp-service
+Type=Application
+DesktopNames=pop:COSMIC
+X-GDM-SessionRegisters=false

--- a/data/cosmic-comp.service
+++ b/data/cosmic-comp.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Cosmic wayland compositor
-BindsTo=cosmic-session.target
-Wants=cosmic-session-pre.target
-After=cosmic-session-pre.target
-Before=cosmic-session.target
+BindsTo=cosmic-comp-session.target
+Wants=cosmic-comp-session-pre.target
+After=cosmic-comp-session-pre.target
+Before=cosmic-comp-session.target
 
 [Service]
 Type=notify

--- a/data/cosmic.desktop
+++ b/data/cosmic.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=Cosmic
-Commment=This session logs you into Cosmic
-Commment[sv]=Denna session loggar in dig till Cosmic
-Exec=/usr/bin/cosmic-service
-Type=Application
-DesktopNames=pop:COSMIC
-X-GDM-SessionRegisters=false


### PR DESCRIPTION
Running `make install-bare-session` breaks your system (login loop and other issues) because it overwrites `cosmic-session`'s files with outdated files. ~~Instead of keeping these files updated and in sync with cosmic-session, we should probably just remove them.~~ Renaming them.