### PR TITLE
Handle TileWindow action for keyboard window snapping

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -893,6 +893,25 @@ impl State {
                 }
             }
 
+            Action::TileWindow(zone) => {
+                use cosmic_settings_config::shortcuts::action::TilingZone;
+                use crate::shell::layout::floating::TiledCorners;
+
+                let corner = match zone {
+                    TilingZone::Top => TiledCorners::Top,
+                    TilingZone::TopRight => TiledCorners::TopRight,
+                    TilingZone::Right => TiledCorners::Right,
+                    TilingZone::BottomRight => TiledCorners::BottomRight,
+                    TilingZone::Bottom => TiledCorners::Bottom,
+                    TilingZone::BottomLeft => TiledCorners::BottomLeft,
+                    TilingZone::Left => TiledCorners::Left,
+                    TilingZone::TopLeft => TiledCorners::TopLeft,
+                };
+
+                let mut shell = self.common.shell.write();
+                shell.tile_window(corner, seat);
+            }
+
             Action::Fullscreen => {
                 let Some(focused_output) = seat.focused_output() else {
                     return;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4124,6 +4124,26 @@ impl Shell {
         }
     }
 
+    pub fn tile_window(&mut self, corner: layout::floating::TiledCorners, seat: &Seat<State>) {
+        let output = seat.active_output();
+        let Some(workspace) = self.workspaces.active_mut(&output) else {
+            return;
+        };
+
+        let Some(KeyboardFocusTarget::Element(window)) =
+            seat.get_keyboard().and_then(|k| k.current_focus())
+        else {
+            return;
+        };
+
+        // Only works on floating windows
+        if workspace.floating_layer.mapped().any(|w| w == &window) {
+            workspace
+                .floating_layer
+                .tile_window(&window, corner, &self.theme);
+        }
+    }
+
     pub fn minimize_request<S>(&mut self, surface: &S)
     where
         CosmicSurface: PartialEq<S>,


### PR DESCRIPTION
## Summary
- Add handler for `TileWindow(TilingZone)` action that snaps floating windows to screen edges and corners
- Maps `TilingZone` from cosmic-settings-config to existing `TiledCorners` enum
- Adds `Shell::tile_window()` and `FloatingLayout::tile_window()` methods
- Reuses existing animation system for smooth 200ms ease-in-out transitions

## Dependencies
- Requires pop-os/cosmic-settings-daemon#124 to be merged first

## Test plan
- [x] Build succeeds
- [x] Tested all 8 zones with custom keybindings:
  - Halves: Top, Bottom, Left, Right
  - Corners: TopLeft, TopRight, BottomLeft, BottomRight
- [x] Animation plays correctly
- [x] Works only on floating windows (as expected)

## Example keybindings
```ron
{
    (modifiers: [Super, Ctrl], key: "Left"): TileWindow(Left),
    (modifiers: [Super, Ctrl], key: "Right"): TileWindow(Right),
    (modifiers: [Super, Ctrl], key: "Up"): TileWindow(Top),
    (modifiers: [Super, Ctrl], key: "Down"): TileWindow(Bottom),
    (modifiers: [Ctrl, Shift], key: "Left"): TileWindow(TopLeft),
    (modifiers: [Ctrl, Shift], key: "Right"): TileWindow(TopRight),
    (modifiers: [Ctrl, Super, Alt], key: "Left"): TileWindow(BottomLeft),
    (modifiers: [Ctrl, Super, Alt], key: "Right"): TileWindow(BottomRight),
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)
[Kooha-2026-01-20-15-32-59.webm](https://github.com/user-attachments/assets/674fbe17-86d9-4b00-8221-80e23378073d)

