### PR TITLE
Allow to disable workspace switch animation in AppearanceConfig

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -54,6 +54,7 @@ pub struct AppearanceConfig {
     pub clip_floating_windows: bool,
     pub clip_tiled_windows: bool,
     pub shadow_tiled_windows: bool,
+    pub disable_workspace_switch_animation: bool,
 }
 
 impl Default for AppearanceConfig {
@@ -62,6 +63,7 @@ impl Default for AppearanceConfig {
             clip_floating_windows: true,
             clip_tiled_windows: true,
             shadow_tiled_windows: false,
+            disable_workspace_switch_animation: false,
         }
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -504,11 +504,13 @@ impl WorkspaceSet {
             return Err(InvalidWorkspaceIndex);
         }
 
-        // Animate if workspaces overview isn't open
+        // Animate if not disabled, and workspaces overview isn't open
         let layer_map = layer_map_for_output(&self.output);
-        let animate = !layer_map
+        let workspaces_overview_not_open = !layer_map
             .layers()
             .any(|l| l.namespace() == WORKSPACE_OVERVIEW_NAMESPACE);
+        let animate =
+            workspaces_overview_not_open && !self.appearance.disable_workspace_switch_animation;
 
         if self.active != idx {
             let old_active = self.active;


### PR DESCRIPTION
This PR introduces a new setting to disable the animation that happens when switching between workspaces. Putting it inside AppearanceConfig allowed minimal changes, but I'm not sure if it is a good place for it in general.  

I've been using this for a few days, but there's one issue with cosmic-workspace-applet (Numbered Workspaces), which happens in overview mode as well. The workspace number becomes highlighted only after some delay, you can see it in a video. It happens because the applet is not immediately notified, I think. I couldn't debug it, unfortunately, but I figured that adding 'state.common.refresh();' right after 'shell.move_window' fixes the issue.

Showcase: [https://github.com/user-attachments/assets/32cf4201-02d5-4426-8ec6-25d50a5af001](https://github.com/user-attachments/assets/32cf4201-02d5-4426-8ec6-25d50a5af001)
Happy to hear any feedback. Feel free to reject if you have a different implementation in mind. 