### PR TITLE
kms: Import on device supporting format, if not advertised device

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -95,6 +95,7 @@ pub struct Device {
     pub drm: GbmDrmOutputManager,
 
     supports_atomic: bool,
+    pub texture_formats: FormatSet,
     event_token: Option<RegistrationToken>,
     pub socket: Option<Socket>,
 }
@@ -285,7 +286,7 @@ impl State {
             .with_context(|| format!("Failed to add drm device to event loop: {}", dev))?;
 
         let socket = match (!is_software)
-            .then(|| self.create_socket(dh, render_node, texture_formats))
+            .then(|| self.create_socket(dh, render_node, texture_formats.clone()))
             .transpose()
         {
             Ok(socket) => socket,
@@ -349,6 +350,7 @@ impl State {
             },
 
             supports_atomic,
+            texture_formats,
             event_token: Some(token),
             socket,
         };


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-epoch/issues/2978.

This reverses the part of https://github.com/pop-os/cosmic-comp/commit/ca00df0b37 that made it only try import on the advertised GPU. But this version avoids initializing an EGL context simply to re-check the supported texture formats.