### PR TITLE
fix: Remove redundant configure in popup reposition_request

### DIFF
--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -164,12 +164,6 @@ impl XdgShellHandler for State {
 
         self.common.shell.read().unconstrain_popup(&surface);
         surface.send_repositioned(token);
-        if let Err(err) = surface.send_configure() {
-            warn!(
-                ?err,
-                "Client bug: Unable to re-configure repositioned popup.",
-            );
-        }
     }
 
     fn move_request(&mut self, surface: ToplevelSurface, seat: WlSeat, serial: Serial) {


### PR DESCRIPTION
Fixes: https://github.com/pop-os/cosmic-comp/issues/1971, https://github.com/pop-os/cosmic-epoch/issues/3151

`send_repositioned()` already sends a configure event internally via `send_configure_internal()`. The extra `send_configure()` call right after either sends a duplicate configure (for reactive popups) or fails with a misleading "Client bug: Unable to re-configure repositioned popup" warning (for non-reactive popups).