### PR TITLE
Add EIS input receiver for RemoteDesktop portal support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "profiling",
  "rand 0.9.2",
  "regex",
+ "reis",
  "ron",
  "rust-embed",
  "rustix 1.1.2",
@@ -1268,7 +1269,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1578,7 +1579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2875,7 +2876,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d463f34ca3c400fde3a054da0e0b8c6ffa21e4590922f3e18281bb5eeef4cbdc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3499,7 +3500,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4541,6 +4542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reis"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00939c5c526a1b4054ef8d9d96b3f92227f08ca355965e986741b556eda6d289"
+dependencies = [
+ "futures",
+ "rustix 0.38.44",
+ "tokio",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,7 +4697,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5141,6 +5153,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
 
 [[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "softbuffer"
 version = "0.4.1"
 source = "git+https://github.com/pop-os/softbuffer?tag=cosmic-4.0#a3f77e251e7422803f693df6e3fc313c010c4dcb"
@@ -5332,7 +5354,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5501,6 +5523,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "windows-sys 0.61.2",
 ]
 
@@ -6353,7 +6376,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ xdg-user = "0.2.1"
 xkbcommon = "0.9"
 zbus = "5.12.0"
 profiling = { version = "1.0" }
-rustix = { version = "1.1.2", features = ["process"] }
+rustix = { version = "1.1.2", features = ["process", "event"] }
 rand = "0.9.2"
 # CLI arguments
 clap_lex = "0.7"
@@ -89,6 +89,7 @@ logind-zbus = { version = "5.3.2", optional = true }
 futures-executor = { version = "0.3.31", features = ["thread-pool"] }
 futures-util = "0.3.31"
 cgmath = "0.18.0"
+reis = { version = "0.5", features = ["tokio"] }
 
 [dependencies.id_tree]
 branch = "feature/copy_clone"

--- a/src/dbus/eis.rs
+++ b/src/dbus/eis.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! D-Bus interface for accepting EIS socket connections from the RemoteDesktop
+//! portal. The portal creates a UNIX socket pair and sends the server-side fd
+//! to the compositor via this interface.
+
+use calloop::channel;
+use futures_executor::ThreadPool;
+use std::os::unix::net::UnixStream;
+use tracing::{error, info, warn};
+use zbus::message::Header;
+
+/// Channel sender for delivering EIS sockets to the compositor's calloop.
+#[derive(Clone)]
+pub struct EisSocketSender {
+    tx: channel::Sender<UnixStream>,
+}
+
+impl EisSocketSender {
+    pub fn new(tx: channel::Sender<UnixStream>) -> Self {
+        Self { tx }
+    }
+}
+
+/// Allowed D-Bus well-known names that may call `AcceptEisSocket`.
+const ALLOWED_CALLERS: &[&str] = &["org.freedesktop.impl.portal.desktop.cosmic"];
+
+/// D-Bus interface for the compositor to accept EIS socket fds.
+pub struct CosmicCompEis {
+    sender: EisSocketSender,
+}
+
+impl CosmicCompEis {
+    pub fn new(sender: EisSocketSender) -> Self {
+        Self { sender }
+    }
+}
+
+#[zbus::interface(name = "com.system76.CosmicComp.RemoteDesktop")]
+impl CosmicCompEis {
+    /// Accept an EIS socket fd from the RemoteDesktop portal.
+    /// The portal sends the server-side of a UNIX socket pair; the compositor
+    /// will run an EIS receiver on it to accept emulated input events.
+    ///
+    /// Only callers that own an allowed D-Bus well-known name (currently the
+    /// COSMIC portal) may invoke this method.
+    async fn accept_eis_socket(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+        fd: zbus::zvariant::OwnedFd,
+    ) -> zbus::fdo::Result<()> {
+        // Verify caller identity: resolve sender's unique name to well-known names
+        let sender = header
+            .sender()
+            .ok_or_else(|| zbus::fdo::Error::AccessDenied("no sender in D-Bus message".into()))?;
+
+        let dbus_proxy = zbus::fdo::DBusProxy::new(connection)
+            .await
+            .map_err(|e| zbus::fdo::Error::Failed(format!("D-Bus proxy error: {e}")))?;
+
+        // Check if the sender owns any of the allowed well-known names
+        let mut authorized = false;
+        for allowed in ALLOWED_CALLERS {
+            let bus_name: zbus::names::BusName<'_> = (*allowed)
+                .try_into()
+                .map_err(|e| zbus::fdo::Error::Failed(format!("invalid bus name: {e}")))?;
+            if let Ok(owner) = dbus_proxy.get_name_owner(bus_name).await
+                && owner.as_str() == sender.as_str()
+            {
+                authorized = true;
+                break;
+            }
+        }
+
+        if !authorized {
+            warn!(
+                sender = sender.as_str(),
+                "Rejected AcceptEisSocket call from unauthorized D-Bus sender"
+            );
+            return Err(zbus::fdo::Error::AccessDenied(
+                "caller is not an authorized portal process".into(),
+            ));
+        }
+
+        // Verify the fd is a UNIX stream socket (not a file, pipe, etc.)
+        let raw_fd = std::os::fd::OwnedFd::from(fd);
+        {
+            use std::os::fd::AsRawFd;
+            let mut sock_type: libc::c_int = 0;
+            let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+            let ret = unsafe {
+                libc::getsockopt(
+                    raw_fd.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_TYPE,
+                    std::ptr::addr_of_mut!(sock_type).cast(),
+                    std::ptr::addr_of_mut!(len),
+                )
+            };
+            if ret != 0 || sock_type != libc::SOCK_STREAM {
+                warn!(
+                    sender = sender.as_str(),
+                    "Rejected AcceptEisSocket: fd is not a SOCK_STREAM socket"
+                );
+                return Err(zbus::fdo::Error::InvalidArgs(
+                    "fd must be a SOCK_STREAM Unix socket".into(),
+                ));
+            }
+        }
+
+        let stream = UnixStream::from(raw_fd);
+        info!(sender = sender.as_str(), "Accepted EIS socket via D-Bus");
+        self.sender
+            .tx
+            .send(stream)
+            .map_err(|_| zbus::fdo::Error::Failed("Compositor EIS channel closed".to_string()))
+    }
+}
+
+/// Initialize the EIS D-Bus interface and register it on the session bus.
+///
+/// Sets up a calloop channel to deliver EIS socket connections to the
+/// compositor's event loop, and spawns async D-Bus registration via the
+/// executor.
+pub fn init(
+    evlh: &calloop::LoopHandle<'static, crate::state::State>,
+    executor: &ThreadPool,
+) -> anyhow::Result<()> {
+    let (socket_tx, socket_rx) = channel::channel::<UnixStream>();
+
+    // Register the socket receiver with calloop - when the portal sends
+    // an EIS fd, this will deliver it to the compositor
+    evlh.insert_source(socket_rx, |event, _, state| {
+        if let channel::Event::Msg(stream) = event {
+            // Initialize EIS state if needed, then add connection
+            if state.common.eis_state.is_none() {
+                match crate::input::eis::EisState::new(&state.common.event_loop_handle) {
+                    Ok(eis_state) => {
+                        state.common.eis_state = Some(eis_state);
+                    }
+                    Err(err) => {
+                        error!("Failed to initialize EIS state: {}", err);
+                        return;
+                    }
+                }
+            }
+            if let Some(eis_state) = &state.common.eis_state {
+                eis_state.add_connection(stream);
+            }
+        }
+    })
+    .map_err(|e| anyhow::anyhow!("Failed to insert EIS socket channel: {}", e.error))?;
+
+    // Spawn async D-Bus registration via the executor (same pattern as a11y)
+    let sender = EisSocketSender::new(socket_tx);
+    executor.spawn_ok(async move {
+        match register_dbus(sender).await {
+            Ok(()) => info!("EIS D-Bus interface registered"),
+            Err(err) => error!("Failed to register EIS D-Bus interface: {}", err),
+        }
+    });
+
+    Ok(())
+}
+
+async fn register_dbus(sender: EisSocketSender) -> anyhow::Result<()> {
+    let connection = zbus::Connection::session().await?;
+    let eis_interface = CosmicCompEis::new(sender);
+
+    connection
+        .object_server()
+        .at("/com/system76/CosmicComp", eis_interface)
+        .await?;
+
+    connection
+        .request_name("com.system76.CosmicComp.RemoteDesktop")
+        .await?;
+
+    // Keep the connection alive
+    std::future::pending::<()>().await;
+    Ok(())
+}

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -12,6 +12,7 @@ use tracing::{error, warn};
 use zbus::blocking::{Connection, fdo::DBusProxy};
 
 pub mod a11y_keyboard_monitor;
+pub mod eis;
 #[cfg(feature = "systemd")]
 pub mod logind;
 mod name_owners;
@@ -22,6 +23,11 @@ pub fn init(
     executor: &ThreadPool,
 ) -> Result<Vec<RegistrationToken>> {
     let mut tokens = Vec::new();
+
+    // Register EIS D-Bus interface for RemoteDesktop portal input injection
+    if let Err(err) = eis::init(evlh, executor) {
+        tracing::info!(?err, "Failed to initialize EIS D-Bus interface");
+    }
 
     match block_on(power::init()) {
         Ok(power_daemon) => {

--- a/src/input/eis.rs
+++ b/src/input/eis.rs
@@ -1,0 +1,655 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! EIS (Emulated Input Server) receiver for remote desktop input injection.
+//!
+//! Accepts input events from EIS clients (e.g., xdg-desktop-portal-cosmic
+//! RemoteDesktop sessions) and injects them into the compositor's input stack
+//! using the same Smithay APIs as the virtual keyboard handler.
+
+use calloop::channel;
+use reis::{
+    PendingRequestResult, eis,
+    event::DeviceCapability,
+    handshake::{self, EisHandshaker},
+    request::{EisRequest, EisRequestConverter},
+};
+use smithay::{
+    backend::input::{KeyState, TouchSlot},
+    input::{
+        keyboard::{FilterResult, Keycode},
+        touch::{DownEvent, MotionEvent as TouchMotionEvent, UpEvent},
+    },
+    utils::SERIAL_COUNTER,
+};
+use std::os::unix::net::UnixStream;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tracing::{debug, error, info, warn};
+
+use crate::state::State;
+use crate::utils::prelude::{OutputExt, PointGlobalExt};
+
+/// Events sent from the EIS processing thread to the compositor's calloop.
+#[derive(Debug)]
+pub enum EisInputEvent {
+    /// Keyboard key press/release (evdev keycode)
+    KeyboardKey { keycode: u32, pressed: bool },
+    /// Relative pointer motion
+    PointerMotion { dx: f64, dy: f64 },
+    /// Absolute pointer motion (for absolute positioning devices)
+    PointerMotionAbsolute { x: f64, y: f64 },
+    /// Mouse button press/release (linux button code, e.g., BTN_LEFT=0x110)
+    Button { button: u32, pressed: bool },
+    /// Scroll delta (smooth scrolling)
+    Scroll { dx: f64, dy: f64 },
+    /// Touch down (finger placed on surface)
+    TouchDown { touch_id: u32, x: f64, y: f64 },
+    /// Touch motion (finger moved on surface)
+    TouchMotion { touch_id: u32, x: f64, y: f64 },
+    /// Touch up (finger lifted from surface)
+    TouchUp { touch_id: u32 },
+    /// Touch cancel (touch sequence cancelled)
+    TouchCancel { touch_id: u32 },
+    /// Client disconnected
+    Disconnected,
+}
+
+/// Maximum number of concurrent EIS connections allowed.
+const MAX_EIS_CONNECTIONS: usize = 8;
+
+/// Poll timeout for EIS socket operations (30 seconds).
+const POLL_TIMEOUT: rustix::event::Timespec = rustix::event::Timespec {
+    tv_sec: 30,
+    tv_nsec: 0,
+};
+
+/// Manages EIS connections and routes input events to the compositor.
+#[derive(Debug)]
+pub struct EisState {
+    /// Channel sender to inject events into calloop
+    pub(crate) tx: channel::Sender<EisInputEvent>,
+    /// Number of active EIS connections (shared with background threads)
+    active_connections: Arc<AtomicUsize>,
+}
+
+impl EisState {
+    /// Create a new EIS state and register the event channel with calloop.
+    ///
+    /// Returns the `EisState` which can accept new socket connections.
+    pub fn new(evlh: &calloop::LoopHandle<'static, State>) -> anyhow::Result<Self> {
+        let (tx, rx) = channel::channel::<EisInputEvent>();
+
+        evlh.insert_source(rx, |event, _, state| {
+            if let channel::Event::Msg(eis_event) = event {
+                process_eis_event(state, eis_event);
+            }
+        })
+        .map_err(|e| anyhow::anyhow!("Failed to insert EIS channel source: {}", e.error))?;
+
+        info!("EIS input receiver initialized");
+        Ok(Self {
+            tx,
+            active_connections: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    /// Accept a new EIS client connection from a UNIX socket fd.
+    ///
+    /// Spawns a background thread that reads EIS protocol events from the
+    /// socket and forwards them as `EisInputEvent` through the calloop channel.
+    /// Rejects the connection if the maximum number of concurrent connections
+    /// has been reached.
+    pub fn add_connection(&self, socket: UnixStream) {
+        // Atomically check-and-increment to avoid TOCTOU race.
+        loop {
+            let current = self.active_connections.load(Ordering::Acquire);
+            if current >= MAX_EIS_CONNECTIONS {
+                warn!(
+                    current,
+                    max = MAX_EIS_CONNECTIONS,
+                    "Rejecting EIS connection: limit reached"
+                );
+                return;
+            }
+            if self
+                .active_connections
+                .compare_exchange(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                break;
+            }
+        }
+        let tx = self.tx.clone();
+        let counter = Arc::clone(&self.active_connections);
+        let active = self.active_connections.load(Ordering::Acquire);
+        info!(active, "Accepting new EIS client connection");
+
+        let thread_name = format!("eis-client-{active}");
+        std::thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || {
+                let result = run_eis_server(socket, tx);
+                let remaining = counter.fetch_sub(1, Ordering::AcqRel) - 1;
+                match result {
+                    Ok(()) => info!(active = remaining, "EIS connection closed"),
+                    Err(err) => error!(active = remaining, "EIS server error: {}", err),
+                }
+            })
+            .expect("failed to spawn EIS thread");
+    }
+}
+
+/// Perform the EIS server-side handshake (blocking, with timeout).
+fn eis_handshake(context: &eis::Context) -> Result<handshake::EisHandshakeResp, reis::Error> {
+    let mut handshaker = EisHandshaker::new(context, 0);
+    // Flush the initial handshake version message
+    context.flush().map_err(|e| reis::Error::Io(e.into()))?;
+
+    loop {
+        // Block until data is available (with timeout)
+        let n = rustix::event::poll(
+            &mut [rustix::event::PollFd::new(
+                context,
+                rustix::event::PollFlags::IN,
+            )],
+            Some(&POLL_TIMEOUT),
+        )
+        .map_err(|e| reis::Error::Io(e.into()))?;
+
+        if n == 0 {
+            return Err(reis::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "EIS handshake timed out",
+            )));
+        }
+
+        context.read().map_err(reis::Error::Io)?;
+
+        while let Some(result) = context.pending_request() {
+            let request = match result {
+                PendingRequestResult::Request(r) => r,
+                PendingRequestResult::ParseError(e) => return Err(reis::Error::Parse(e)),
+                PendingRequestResult::InvalidObject(id) => {
+                    return Err(handshake::HandshakeError::InvalidObject(id).into());
+                }
+            };
+
+            if let Some(resp) = handshaker
+                .handle_request(request)
+                .map_err(reis::Error::Handshake)?
+            {
+                return Ok(resp);
+            }
+        }
+    }
+}
+
+/// Run the EIS server protocol on a socket, forwarding events to the compositor.
+fn run_eis_server(socket: UnixStream, tx: channel::Sender<EisInputEvent>) -> anyhow::Result<()> {
+    /// Send an event to the compositor channel, returning from the enclosing
+    /// function if the channel is closed.
+    macro_rules! send_or_return {
+        ($tx:expr, $event:expr) => {
+            if $tx.send($event).is_err() {
+                debug!("Compositor channel closed");
+                return Ok(());
+            }
+        };
+    }
+    let context = eis::Context::new(socket)
+        .map_err(|e| anyhow::anyhow!("failed to create EIS context from socket: {e}"))?;
+
+    // Perform server-side handshake
+    let handshake_resp = eis_handshake(&context)?;
+    // Truncate client name to prevent log flooding from malicious clients.
+    let client_name: String = handshake_resp
+        .name
+        .as_deref()
+        .unwrap_or("<unknown>")
+        .chars()
+        .take(128)
+        .collect();
+    debug!(
+        client = %client_name,
+        context_type = ?handshake_resp.context_type,
+        "EIS handshake complete"
+    );
+
+    // Create the request converter which manages seats, devices, and events
+    let mut converter = EisRequestConverter::new(&context, handshake_resp, 0);
+
+    // Add a seat with keyboard + pointer capabilities.
+    // The seat is stored in the converter's connection state; _seat keeps it alive.
+    let _seat = converter.handle().add_seat(
+        Some("seat0"),
+        &[
+            DeviceCapability::Keyboard,
+            DeviceCapability::Pointer,
+            DeviceCapability::PointerAbsolute,
+            DeviceCapability::Button,
+            DeviceCapability::Scroll,
+            DeviceCapability::Touch,
+        ],
+    );
+    converter.handle().flush()?;
+
+    // Main event loop
+    loop {
+        // Block until data is available (with timeout)
+        let n = rustix::event::poll(
+            &mut [rustix::event::PollFd::new(
+                &context,
+                rustix::event::PollFlags::IN,
+            )],
+            Some(&POLL_TIMEOUT),
+        )
+        .map_err(std::io::Error::from)?;
+
+        if n == 0 {
+            // Timeout with no data - check if channel is still open
+            if tx.send(EisInputEvent::Disconnected).is_err() {
+                debug!("Compositor channel closed during poll timeout");
+                return Ok(());
+            }
+            // Channel alive but client idle - send disconnect and exit
+            info!("EIS client idle timeout, disconnecting");
+            return Ok(());
+        }
+
+        let bytes_read = context.read()?;
+        if bytes_read == 0 {
+            info!("EIS connection closed (EOF)");
+            let _ = tx.send(EisInputEvent::Disconnected);
+            break;
+        }
+
+        // Process raw protocol requests through the converter
+        while let Some(result) = context.pending_request() {
+            let raw_request = match result {
+                PendingRequestResult::Request(r) => r,
+                PendingRequestResult::ParseError(e) => {
+                    warn!("EIS parse error: {}", e);
+                    continue;
+                }
+                PendingRequestResult::InvalidObject(id) => {
+                    debug!("EIS invalid object: {}", id);
+                    continue;
+                }
+            };
+
+            if let Err(err) = converter.handle_request(raw_request) {
+                warn!("EIS request handling error: {}", err);
+                continue;
+            }
+        }
+
+        // Drain high-level events from the converter
+        while let Some(eis_request) = converter.next_request() {
+            match eis_request {
+                EisRequest::KeyboardKey(key_evt) => {
+                    let pressed = key_evt.state == eis::keyboard::KeyState::Press;
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::KeyboardKey {
+                            keycode: key_evt.key,
+                            pressed,
+                        }
+                    );
+                }
+                EisRequest::PointerMotion(motion) => {
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::PointerMotion {
+                            dx: f64::from(motion.dx),
+                            dy: f64::from(motion.dy),
+                        }
+                    );
+                }
+                EisRequest::PointerMotionAbsolute(motion) => {
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::PointerMotionAbsolute {
+                            x: f64::from(motion.dx_absolute),
+                            y: f64::from(motion.dy_absolute),
+                        }
+                    );
+                }
+                EisRequest::Button(btn) => {
+                    let pressed = btn.state == eis::button::ButtonState::Press;
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::Button {
+                            button: btn.button,
+                            pressed,
+                        }
+                    );
+                }
+                EisRequest::ScrollDelta(scroll) => {
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::Scroll {
+                            dx: f64::from(scroll.dx),
+                            dy: f64::from(scroll.dy),
+                        }
+                    );
+                }
+                EisRequest::Disconnect => {
+                    info!("EIS client disconnected");
+                    let _ = tx.send(EisInputEvent::Disconnected);
+                    return Ok(());
+                }
+                EisRequest::Bind(bind) => {
+                    // Client bound to seat capabilities - add device and resume
+                    let capabilities = capabilities_from_mask(bind.capabilities);
+                    debug!("EIS client bound with capabilities: {:?}", capabilities);
+                    let device = bind.seat.add_device(
+                        Some("remote-input"),
+                        eis::device::DeviceType::Virtual,
+                        &capabilities,
+                        |_| {},
+                    );
+                    device.resumed();
+                    if let Err(e) = converter.handle().flush() {
+                        warn!("Failed to flush EIS device announcement: {e}");
+                    }
+                }
+                EisRequest::DeviceStartEmulating(_) | EisRequest::DeviceStopEmulating(_) => {
+                    // Acknowledged implicitly
+                }
+                EisRequest::TouchDown(touch) => {
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::TouchDown {
+                            touch_id: touch.touch_id,
+                            x: f64::from(touch.x),
+                            y: f64::from(touch.y),
+                        }
+                    );
+                }
+                EisRequest::TouchMotion(touch) => {
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::TouchMotion {
+                            touch_id: touch.touch_id,
+                            x: f64::from(touch.x),
+                            y: f64::from(touch.y),
+                        }
+                    );
+                }
+                EisRequest::TouchUp(touch) => {
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::TouchUp {
+                            touch_id: touch.touch_id,
+                        }
+                    );
+                }
+                EisRequest::TouchCancel(touch) => {
+                    send_or_return!(
+                        tx,
+                        EisInputEvent::TouchCancel {
+                            touch_id: touch.touch_id,
+                        }
+                    );
+                }
+                EisRequest::Frame(_) => {
+                    // Frame boundaries - we process events individually
+                }
+                _ => {
+                    debug!("Unhandled EIS request: {:?}", eis_request);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Convert a capability bitmask to a list of DeviceCapability values.
+fn capabilities_from_mask(mask: u64) -> Vec<DeviceCapability> {
+    let mut caps = Vec::new();
+    for cap in [
+        DeviceCapability::Pointer,
+        DeviceCapability::PointerAbsolute,
+        DeviceCapability::Keyboard,
+        DeviceCapability::Touch,
+        DeviceCapability::Scroll,
+        DeviceCapability::Button,
+    ] {
+        if mask & (2 << cap as u64) != 0 {
+            caps.push(cap);
+        }
+    }
+    caps
+}
+
+/// Resolve the surface under a given position, acquiring and releasing the
+/// shell read lock. Used by touch events that need both the seat and the
+/// surface target but must release the lock before calling into Smithay
+/// (which needs `&mut State`).
+#[allow(clippy::type_complexity)]
+fn resolve_touch_target(
+    state: &State,
+    x: f64,
+    y: f64,
+) -> (
+    smithay::input::Seat<State>,
+    Option<(
+        <State as smithay::input::SeatHandler>::PointerFocus,
+        smithay::utils::Point<f64, smithay::utils::Logical>,
+    )>,
+) {
+    let shell = state.common.shell.read();
+    let seat = shell.seats.last_active().clone();
+    let position = (x, y).into();
+    let under = shell
+        .outputs()
+        .find(|output| output.geometry().to_f64().contains(position))
+        .and_then(|output| {
+            State::surface_under(position, output, &shell)
+                .map(|(target, pos)| (target, pos.as_logical()))
+        });
+    (seat, under)
+}
+
+/// Returns `true` if the value is finite (not NaN or infinity).
+fn is_finite_f64(v: f64) -> bool {
+    v.is_finite()
+}
+
+/// Maximum valid evdev keycode (KEY_MAX from linux/input-event-codes.h).
+const MAX_EVDEV_KEYCODE: u32 = 0x2FF;
+
+/// Maximum touch slot ID (generous upper bound; real devices rarely exceed 20).
+const MAX_TOUCH_ID: u32 = 256;
+
+/// Process a single EIS input event by injecting it into the compositor's
+/// Smithay input stack.
+fn process_eis_event(state: &mut State, event: EisInputEvent) {
+    let time = state.common.clock.now().as_millis();
+
+    match event {
+        EisInputEvent::KeyboardKey { keycode, pressed } => {
+            if keycode > MAX_EVDEV_KEYCODE {
+                warn!(keycode, "Rejecting keyboard event: keycode out of range");
+                return;
+            }
+            let seat = state.common.shell.read().seats.last_active().clone();
+            if let Some(keyboard) = seat.get_keyboard() {
+                let serial = SERIAL_COUNTER.next_serial();
+                let key_state = if pressed {
+                    KeyState::Pressed
+                } else {
+                    KeyState::Released
+                };
+                keyboard.input(
+                    state,
+                    Keycode::new(keycode),
+                    key_state,
+                    serial,
+                    time,
+                    |_, _, _| FilterResult::Forward::<bool>,
+                );
+            }
+        }
+        EisInputEvent::PointerMotion { dx, dy } => {
+            if !is_finite_f64(dx) || !is_finite_f64(dy) {
+                warn!("Rejecting pointer motion: non-finite delta");
+                return;
+            }
+            let seat = state.common.shell.read().seats.last_active().clone();
+            if let Some(pointer) = seat.get_pointer() {
+                let current = pointer.current_location();
+                let new_location = (current.x + dx, current.y + dy).into();
+                let serial = SERIAL_COUNTER.next_serial();
+                pointer.motion(
+                    state,
+                    None,
+                    &smithay::input::pointer::MotionEvent {
+                        location: new_location,
+                        serial,
+                        time,
+                    },
+                );
+                pointer.frame(state);
+            }
+        }
+        EisInputEvent::PointerMotionAbsolute { x, y } => {
+            if !is_finite_f64(x) || !is_finite_f64(y) {
+                warn!("Rejecting absolute pointer motion: non-finite coordinates");
+                return;
+            }
+            let seat = state.common.shell.read().seats.last_active().clone();
+            if let Some(pointer) = seat.get_pointer() {
+                let serial = SERIAL_COUNTER.next_serial();
+                pointer.motion(
+                    state,
+                    None,
+                    &smithay::input::pointer::MotionEvent {
+                        location: (x, y).into(),
+                        serial,
+                        time,
+                    },
+                );
+                pointer.frame(state);
+            }
+        }
+        EisInputEvent::Button { button, pressed } => {
+            if button > MAX_EVDEV_KEYCODE {
+                warn!(button, "Rejecting button event: code out of range");
+                return;
+            }
+            let seat = state.common.shell.read().seats.last_active().clone();
+            if let Some(pointer) = seat.get_pointer() {
+                let serial = SERIAL_COUNTER.next_serial();
+                let state_val = if pressed {
+                    smithay::backend::input::ButtonState::Pressed
+                } else {
+                    smithay::backend::input::ButtonState::Released
+                };
+                pointer.button(
+                    state,
+                    &smithay::input::pointer::ButtonEvent {
+                        button,
+                        state: state_val,
+                        serial,
+                        time,
+                    },
+                );
+                pointer.frame(state);
+            }
+        }
+        EisInputEvent::Scroll { dx, dy } => {
+            if !is_finite_f64(dx) || !is_finite_f64(dy) {
+                warn!("Rejecting scroll event: non-finite delta");
+                return;
+            }
+            let seat = state.common.shell.read().seats.last_active().clone();
+            if let Some(pointer) = seat.get_pointer() {
+                use smithay::backend::input::Axis;
+                let mut frame = smithay::input::pointer::AxisFrame::new(time);
+                if dy.abs() > 0.0 {
+                    frame = frame.value(Axis::Vertical, dy);
+                }
+                if dx.abs() > 0.0 {
+                    frame = frame.value(Axis::Horizontal, dx);
+                }
+                pointer.axis(state, frame);
+                pointer.frame(state);
+            }
+        }
+        EisInputEvent::TouchDown { touch_id, x, y } => {
+            if touch_id > MAX_TOUCH_ID {
+                warn!(touch_id, "Rejecting touch down: ID out of range");
+                return;
+            }
+            if !is_finite_f64(x) || !is_finite_f64(y) {
+                warn!("Rejecting touch down: non-finite coordinates");
+                return;
+            }
+            let (seat, under) = resolve_touch_target(state, x, y);
+            if let Some(touch) = seat.get_touch() {
+                let serial = SERIAL_COUNTER.next_serial();
+                touch.down(
+                    state,
+                    under,
+                    &DownEvent {
+                        slot: TouchSlot::from(Some(touch_id)),
+                        location: (x, y).into(),
+                        serial,
+                        time,
+                    },
+                );
+                touch.frame(state);
+            }
+        }
+        EisInputEvent::TouchMotion { touch_id, x, y } => {
+            if touch_id > MAX_TOUCH_ID {
+                warn!(touch_id, "Rejecting touch motion: ID out of range");
+                return;
+            }
+            if !is_finite_f64(x) || !is_finite_f64(y) {
+                warn!("Rejecting touch motion: non-finite coordinates");
+                return;
+            }
+            let (seat, under) = resolve_touch_target(state, x, y);
+            if let Some(touch) = seat.get_touch() {
+                touch.motion(
+                    state,
+                    under,
+                    &TouchMotionEvent {
+                        slot: TouchSlot::from(Some(touch_id)),
+                        location: (x, y).into(),
+                        time,
+                    },
+                );
+                touch.frame(state);
+            }
+        }
+        EisInputEvent::TouchUp { touch_id } => {
+            let seat = state.common.shell.read().seats.last_active().clone();
+            if let Some(touch) = seat.get_touch() {
+                let serial = SERIAL_COUNTER.next_serial();
+                touch.up(
+                    state,
+                    &UpEvent {
+                        slot: TouchSlot::from(Some(touch_id)),
+                        time,
+                        serial,
+                    },
+                );
+                touch.frame(state);
+            }
+        }
+        EisInputEvent::TouchCancel { touch_id: _ } => {
+            let seat = state.common.shell.read().seats.last_active().clone();
+            if let Some(touch) = seat.get_touch() {
+                touch.cancel(state);
+                touch.frame(state);
+            }
+        }
+        EisInputEvent::Disconnected => {
+            info!("EIS client disconnected, cleaning up");
+        }
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -81,6 +81,7 @@ use std::{
 };
 
 pub mod actions;
+pub mod eis;
 pub mod gestures;
 
 /// Used for debouncing focus updates due to pointer motion, if after the focus change is

--- a/src/state.rs
+++ b/src/state.rs
@@ -294,6 +294,9 @@ pub struct Common {
     pub xwayland_shell_state: XWaylandShellState,
     pub pointer_focus_state: Option<PointerFocusState>,
 
+    // EIS input injection (remote desktop)
+    pub eis_state: Option<crate::input::eis::EisState>,
+
     #[cfg(feature = "systemd")]
     pub inhibit_lid_fd: Option<OwnedFd>,
 }
@@ -798,6 +801,8 @@ impl State {
                 xwayland_state: None,
                 xwayland_shell_state,
                 pointer_focus_state: None,
+
+                eis_state: None,
 
                 #[cfg(feature = "systemd")]
                 inhibit_lid_fd: None,


### PR DESCRIPTION
## Summary

- Adds compositor-side EIS (Emulated Input Server) support via a D-Bus interface (`com.system76.CosmicComp.RemoteDesktop`) that accepts EIS socket fds from `xdg-desktop-portal-cosmic`
- Implements a full EIS protocol server using the `reis` crate, supporting keyboard, pointer (relative + absolute), button, scroll, and touch input injection into Smithay's input stack
- Includes D-Bus caller authentication, connection limits, poll timeouts, and input validation

## Context

This provides the compositor half of the [RemoteDesktop portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.RemoteDesktop.html) flow, as discussed in #584. The portal creates a socket pair, sends one end to the compositor via D-Bus, and gives the other end to the RDP/VNC client via the portal API.

I'm aware of the existing `upstream/reis` branch (from May 2024) which takes a Smithay-native approach via `smithay::backend::libei::EiInput`. That approach depends on Smithay changes (`ids1024/smithay` `reis` branch) that haven't been merged upstream yet. This implementation works with the current production Smithay and can serve as a bridge until native Smithay EIS support lands.

### Architecture

```
RDP/VNC client
    ↓ (portal API)
xdg-desktop-portal-cosmic
    ↓ (D-Bus: AcceptEisSocket fd)
cosmic-comp  ← this PR
    ├── src/dbus/eis.rs     (D-Bus interface, auth, socket validation)
    └── src/input/eis.rs    (EIS protocol server, event injection)
    ↓ (Smithay input APIs)
Wayland clients
```

### Files changed

| File | Change |
|------|--------|
| `src/dbus/eis.rs` (new) | D-Bus interface with caller auth and socket validation |
| `src/input/eis.rs` (new) | EIS protocol server with full input support |
| `src/dbus/mod.rs` | Register EIS module and init |
| `src/input/mod.rs` | Register EIS module |
| `src/state.rs` | Add `eis_state` field to `Common` |
| `Cargo.toml` | Add `reis` dep, `rustix` event feature |

## Test plan

- [ ] Verify `cargo check` passes with default features
- [ ] Verify `cargo check --no-default-features` passes
- [ ] Verify `cargo fmt --all -- --check` passes
- [ ] Integration test: portal sends EIS socket fd via D-Bus, compositor accepts and processes input events
- [ ] Verify unauthorized D-Bus callers are rejected

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)