### PR TITLE
fix: high CPU usage (200-600%) on EVDI/DisplayLink outputs

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -820,6 +820,7 @@ impl InnerDevice {
                     primary_node,
                     self.dev_node,
                     self.render_node,
+                    self.is_software,
                     evlh,
                     screen_filter,
                     shell,


### PR DESCRIPTION
## Problem

EVDI/DisplayLink outputs use llvmpipe (software OpenGL) for rendering, causing **200-600% CPU usage** with simple mouse movements on high-resolution displays (e.g. 3440×1440). This makes EVDI-connected monitors essentially unusable for desktop use.

The root cause is twofold:
1. The EVDI virtual GPU has no hardware renderer — smithay initializes it with llvmpipe, so all rendering is CPU-bound.
2. When cosmic-comp detects that the render node differs from the target node, it uses `MultiRenderer` (cross-device path), which copies pixels back via `glReadPixels` — another expensive CPU operation on top of software rendering.

## Solution

Replace the EVDI swapchain allocator with the primary (hardware) GPU's GBM device using `DrmCompositor::set_format()` with `Modifier::Linear`, then render using `single_renderer` on the primary GPU. This is similar to how [niri handles display-only devices](https://github.com/YaLTeR/niri/blob/main/src/backend/tty.rs).

After `initialize_output()`, for software targets:
1. `set_format()` swaps the swapchain allocator from EVDI's GBM (llvmpipe) to the primary GPU's GBM with Linear modifier
2. The surface thread uses `(primary_node, primary_node)` as `(render_node, effective_target)`, keeping everything in the `single_renderer` path
3. `GbmFramebufferExporter` detects the buffer as "foreign" and imports it via dmabuf into EVDI's GBM for DRM framebuffer creation — no CPU-side pixel copy

The render path change is guarded by a shared `AtomicBool` (`swapchain_on_primary`) that is only set to `true` when `set_format()` succeeds. If it fails, the surface thread falls back to the original render path.

### Important implementation note

The compositor is accessed directly through `drm.compositors().get(crtc)` instead of `DrmOutput::with_compositor()` because `LockedDrmOutputManager` already holds a write lock on the compositor `RwLock` — calling `with_compositor()` would deadlock trying to acquire a read lock on it.

## Test plan

- [x] Tested on a 3440×1440 EVDI/DisplayLink monitor connected via USB — CPU usage dropped from 200-600% to normal levels
- [x] Non-EVDI outputs (direct GPU) are unaffected (code path only activates when `is_software == true` AND `set_format()` succeeds)
- [ ] Fallback path when `set_format()` fails (not tested — would require a setup where the DRM test commit rejects Linear buffers from the primary GPU)

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.