### PR TITLE
fix: preserve wl_output across connector disconnect/reconnect

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -764,7 +764,8 @@ impl KmsGuard<'_> {
                         .outputs
                         .iter()
                         .find_map(|(conn, o)| (output == o).then_some(*conn))
-                });
+                })
+                .filter(|conn| !device.inner.suspended_connectors.contains(conn));
 
             for conn in open_conns {
                 let conn_info = device


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

- When HDMI monitors power-cycle (or cable is unplugged/replugged), the kernel HPD de-assert produces the same udev event as a cable unplug. Previously cosmic-comp destroyed the Output (wl_output global, workspace state, client bindings) on disconnect and rebuilt everything on reconnect, causing browsers' D-Bus sessions to get stuck in Auth state with unrecoverable rendering failures.
- Track disconnected connectors as "suspended" instead of removing their Output. The Surface (render thread, DRM resources) is still destroyed since the hardware is gone, but the wl_output global, workspace assignments, and client bindings all survive.
- On reconnect, `connector_added()` finds the existing Output (via `outputs.get(&conn).cloned()` at device.rs:547) and creates a fresh Surface for it.

## What changes

| Component | Before | After |
|-----------|--------|-------|
| wl_output global | Destroyed + recreated | **Persists** |
| Client surface bindings | Severed | **Intact** |
| Workspace assignments | Lost + migrated | **Preserved** |
| Layer surfaces (panels) | Closed + respawned | **Preserved** |
| Window positions | Rearranged | **Preserved** |
| Surface (render thread) | Destroyed + recreated | Destroyed + recreated (unchanged) |

## Implementation

A `suspended_connectors: HashSet<connector::Handle>` field is added to `InnerDevice`. When a connector disappears:
- Surface is destroyed (DRM resources are invalid) — unchanged
- Output is **kept alive** and connector is marked suspended — **new**

When the connector reappears, it's reported as "added", `connector_added()` reuses the existing Output, a new Surface is created, and the suspended flag is cleared.

Suspend-without-timeout was chosen over a debounce approach (wait N seconds, then destroy). A timeout adds complexity and race conditions for minimal benefit — permanently-removed connectors are cleaned up when `device_removed()` handles full GPU removal, which is the only case where the hardware is truly gone rather than power-cycled.

Two files changed, ~28 lines added (~18 net). Edge cases handled:
- Repeated udev events while disconnected (skipped)
- Full GPU device removal (`device_removed()` cleans up suspended outputs)
- `enumerate_surfaces()` skips suspended connectors (avoids `bail!("Missing crtc")`)

## Test plan

- [x] `cargo build --release` — clean, zero warnings
- [x] Power-cycle HDMI monitor via external power button — Firefox/Librewolf tabs continue rendering
- [x] Unplug/replug HDMI cable — Firefox/Librewolf tabs continue rendering
- [ ] VT switch while monitor is disconnected
- [ ] Different monitor plugged into same connector

Supersedes #2115, which was filed as an issue with the patch linked externally because GitHub forking was restricted at the time. This PR contains the same fix submitted as a proper PR. Related: #1463, #906 — previous fixes made the destroy/recreate path crash-free; this PR avoids the destroy path entirely for transient disconnects.