### PR TITLE
fix(input): Fix pointer sticking to screen edges during cursor movement

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -59,7 +59,7 @@ use smithay::{
     reexports::{
         input::Device as InputDevice, wayland_server::protocol::wl_shm::Format as ShmFormat,
     },
-    utils::{Point, Rectangle, SERIAL_COUNTER, Serial},
+    utils::{Coordinate, Point, Rectangle, SERIAL_COUNTER, Serial},
     wayland::{
         image_copy_capture::{BufferConstraints, CursorSessionRef},
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
@@ -350,21 +350,48 @@ impl State {
                     let original_position = position;
                     position += event.delta().as_global();
 
-                    let output = shell
-                        .outputs()
-                        .find(|output| output.geometry().to_f64().contains(position))
+                    let output_containing_position =
+                        State::output_containing_point(position, &shell);
+
+                    let output = output_containing_position
                         .cloned()
                         .unwrap_or(current_output.clone());
 
                     let output_geometry = output.geometry();
-                    position.x = position.x.clamp(
-                        output_geometry.loc.x as f64,
-                        (output_geometry.loc.x + output_geometry.size.w - 1) as f64,
-                    );
-                    position.y = position.y.clamp(
-                        output_geometry.loc.y as f64,
-                        (output_geometry.loc.y + output_geometry.size.h - 1) as f64,
-                    );
+
+                    {
+                        // Clamp the position to the output geometry
+                        let top_left: Point<f64, Global> =
+                            Point::new(output_geometry.loc.x as f64, output_geometry.loc.y as f64);
+                        let bottom_right: Point<f64, Global> = Point::new(
+                            top_left.x.saturating_add(output_geometry.size.w as f64) - 1.0,
+                            top_left.y.saturating_add(output_geometry.size.h as f64) - 1.0,
+                        );
+                        if output_containing_position.is_none() {
+                            position.x = position.x.clamp(top_left.x, bottom_right.x);
+                            position.y = position.y.clamp(top_left.y, bottom_right.y);
+                        } else {
+                            let old_position = position.clone();
+                            if position.x > bottom_right.x
+                                && State::output_containing_point(
+                                    Point::new(bottom_right.x + 1.0, old_position.y),
+                                    &shell,
+                                )
+                                .is_none()
+                            {
+                                position.x = bottom_right.x;
+                            }
+                            if position.y > bottom_right.y
+                                && State::output_containing_point(
+                                    Point::new(old_position.x, bottom_right.y + 1.0),
+                                    &shell,
+                                )
+                                .is_none()
+                            {
+                                position.y = bottom_right.y;
+                            }
+                        }
+                    }
 
                     let new_under = State::surface_under(position, &output, &shell)
                         .map(|(target, pos)| (target, pos.as_logical()));
@@ -2148,6 +2175,12 @@ impl State {
         )
         .ok()
         .flatten()
+    }
+
+    pub fn output_containing_point(point: Point<f64, Global>, shell: &Shell) -> Option<&Output> {
+        shell
+            .outputs()
+            .find(|output| output.geometry().to_f64().contains(point))
     }
 
     #[profiling::function]


### PR DESCRIPTION
This PR fixes the pointer behavior reported in the linked issue where the cursor becomes stuck on screen edges during normal movement when multiple displays are connected.

The problem can be observed when moving the mouse left ↔ right as well as up ↕ down. Under certain display arrangements, the pointer incorrectly clamps to output boundaries instead of transitioning smoothly, resulting in the cursor appearing to "stick" to the edges.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Fixes #2102