### PR TITLE
Add Center zone for keyboard window snapping

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -906,6 +906,7 @@ impl State {
                     TilingZone::BottomLeft => TiledCorners::BottomLeft,
                     TilingZone::Left => TiledCorners::Left,
                     TilingZone::TopLeft => TiledCorners::TopLeft,
+                    TilingZone::Center => TiledCorners::Center,
                 };
 
                 let mut shell = self.common.shell.write();

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -893,6 +893,25 @@ impl State {
                 }
             }
 
+            Action::TileWindow(zone) => {
+                use cosmic_settings_config::shortcuts::action::TilingZone;
+                use crate::shell::layout::floating::TiledCorners;
+
+                let corner = match zone {
+                    TilingZone::Top => TiledCorners::Top,
+                    TilingZone::TopRight => TiledCorners::TopRight,
+                    TilingZone::Right => TiledCorners::Right,
+                    TilingZone::BottomRight => TiledCorners::BottomRight,
+                    TilingZone::Bottom => TiledCorners::Bottom,
+                    TilingZone::BottomLeft => TiledCorners::BottomLeft,
+                    TilingZone::Left => TiledCorners::Left,
+                    TilingZone::TopLeft => TiledCorners::TopLeft,
+                };
+
+                let mut shell = self.common.shell.write();
+                shell.tile_window(corner, seat);
+            }
+
             Action::Fullscreen => {
                 let Some(focused_output) = seat.focused_output() else {
                     return;

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -177,6 +177,7 @@ pub enum TiledCorners {
     BottomLeft,
     Left,
     TopLeft,
+    Center,
 }
 
 impl TiledCorners {
@@ -255,6 +256,16 @@ impl TiledCorners {
                 )),
                 Size::from((
                     output_geometry.size.w / 2 - inner * 3 / 2,
+                    output_geometry.size.h - inner * 2,
+                )),
+            ),
+            TiledCorners::Center => (
+                Point::from((
+                    output_geometry.loc.x + output_geometry.size.w / 4 + inner,
+                    output_geometry.loc.y + inner,
+                )),
+                Size::from((
+                    output_geometry.size.w / 2 - inner * 2,
                     output_geometry.size.h - inner * 2,
                 )),
             ),
@@ -1243,7 +1254,8 @@ impl FloatingLayout {
                     (Direction::Up, Some(TiledCorners::Bottom))
                     | (Direction::Down, Some(TiledCorners::Top))
                     | (Direction::Left, Some(TiledCorners::Right))
-                    | (Direction::Right, Some(TiledCorners::Left)) => {
+                    | (Direction::Right, Some(TiledCorners::Left))
+                    | (Direction::Up, Some(TiledCorners::Center)) => {
                         std::mem::drop(tiled_state);
 
                         let mut maximized_state = element.maximized_state.lock().unwrap();
@@ -1256,6 +1268,11 @@ impl FloatingLayout {
                         self.map_maximized(element.clone(), start_rectangle, true);
                         return MoveResult::Done;
                     }
+
+                    // center transitions
+                    (Direction::Left, Some(TiledCorners::Center)) => TiledCorners::Left,
+                    (Direction::Right, Some(TiledCorners::Center)) => TiledCorners::Right,
+                    (Direction::Down, Some(TiledCorners::Center)) => TiledCorners::Bottom,
 
                     // figure out if we need to quater tile
                     (Direction::Up, Some(TiledCorners::Left))

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4124,6 +4124,26 @@ impl Shell {
         }
     }
 
+    pub fn tile_window(&mut self, corner: layout::floating::TiledCorners, seat: &Seat<State>) {
+        let output = seat.active_output();
+        let Some(workspace) = self.workspaces.active_mut(&output) else {
+            return;
+        };
+
+        let Some(KeyboardFocusTarget::Element(window)) =
+            seat.get_keyboard().and_then(|k| k.current_focus())
+        else {
+            return;
+        };
+
+        // Only works on floating windows
+        if workspace.floating_layer.mapped().any(|w| w == &window) {
+            workspace
+                .floating_layer
+                .tile_window(&window, corner, &self.theme);
+        }
+    }
+
     pub fn minimize_request<S>(&mut self, surface: &S)
     where
         CosmicSurface: PartialEq<S>,


### PR DESCRIPTION
## Summary

- Adds `TiledCorners::Center` — a horizontally centered, full-height column (50% width)
- Geometry: positioned at 25% from left edge, full height minus gaps
- Direction transitions from Center: Left → Left, Right → Right, Up → Maximize, Down → Bottom
- Maps `TilingZone::Center` from cosmic-settings-config to the new variant

Primarily useful on ultrawide monitors where the existing left/right halves are too wide for focused single-window work (terminals, editors, reading).

## Dependencies

- Builds on #2009 (`TileWindow` handler)
- Companion PR: pop-os/cosmic-settings-daemon#130 (Center variant in TilingZone enum)

## Example keybinding

```ron
(modifiers: [Super, Ctrl], key: "c"): TileWindow(Center),
```

## Test plan

- [ ] Build succeeds
- [ ] Center zone positions window at horizontal center with 50% width, full height
- [ ] Direction keys from Center transition correctly (Left/Right to halves, Up to maximize, Down to bottom)
- [ ] Existing 8-zone behavior unchanged