### PR TITLE
fix: preserve fullscreen state when moving window between workspaces

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3130,7 +3130,7 @@ impl Shell {
         let is_minimized = window.is_minimized();
         let is_fullscreen = from_workspace.get_fullscreen().is_some_and(|f| f == window);
         let mut window_state = if is_fullscreen {
-            let (previous_state, previous_geometry) = from_workspace.take_fullscreen().unwrap();
+            let (_, previous_state, previous_geometry) = from_workspace.take_fullscreen().unwrap();
             WorkspaceRestoreData::Fullscreen(previous_state.zip(previous_geometry).map(
                 |(previous_state, previous_geometry)| FullscreenRestoreData {
                     previous_state,

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1241,6 +1241,7 @@ impl Workspace {
     pub fn take_fullscreen(
         &mut self,
     ) -> Option<(
+        CosmicSurface,
         Option<FullscreenRestoreState>,
         Option<Rectangle<i32, Local>>,
     )> {
@@ -1250,7 +1251,11 @@ impl Workspace {
             focus_stack.retain(|t| t != &surface.surface);
         }
 
-        Some((surface.previous_state, surface.previous_geometry))
+        Some((
+            surface.surface,
+            surface.previous_state,
+            surface.previous_geometry,
+        ))
     }
 
     #[must_use]


### PR DESCRIPTION
Following up #2099. 
Fixes the issue where moving a full-screen window (e.g., Chrome with a full-screen video) between workspaces causes the client to exit full-screen.                                                                 
                                                                                                                                                                                                                                    
Root cause: `move_window` calls `unmap_surface`, which internally calls `remove_fullscreen()`. This sends an intermediate configure with `set_fullscreen(false)` before `map_fullscreen()`, and then `map_fullscreen ()` re-applies it on the destination workspace.      
Chrome sees the intermediate "not a full-screen" `configure` and cancels video full-screen.                                                                                                                                             
                                                                                                                                                                                                                                    
**Fix explanation**:
  - Added `Workspace::take_fullscreen()` — a silent counterpart to `remove_fullscreen()` that extracts the fullscreen state without notifying the client (no set_fullscreen(false), no send_configure(), no exit animation).
  - In move_window, fullscreen windows are detected and handled via `take_fullscreen()` instead of `unmap_surface()`. The destination workspace's `map_fullscreen()` then sends a single configure with fullscreen state preserved.
  - `remove_fullscreen()` and `unmap_surface()` remain unchanged — all other code paths (close, minimize, unfullscreen, drag-move) still go through the original flow with proper client notification and exit animation.

What I tested:
  - Chrome with fullscreen video > Move to another workspace > Video stays full-screen
  - Firefox with fullscreen video > Move to another workspace > Video stays full-screen (regression test)
  - Fullscreen game (Death Stranding) and Steam in Big-Picture mode successfully moved through workspaces without losing full-screen state

What I didn't test:
 - Moving windows through workspaces attached to different displays (I don't have such hw setup), but it still should work, since `toplevel_leave_output` and `toplevel_enter_output` handle this case.

**UPD**
Added agreement section from PR template:
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
