### PR TITLE
x11: stop remapping minimized windows on restore

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -429,10 +429,6 @@ impl CosmicSurface {
             .store(minimized, Ordering::SeqCst);
         if let WindowSurface::X11(surface) = self.0.underlying_surface() {
             let _ = surface.set_hidden(minimized);
-            if !minimized {
-                let _ = surface.set_mapped(false);
-                let _ = surface.set_mapped(true);
-            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-epoch/issues/2879

This removes the X11 remap cycle from `CosmicSurface::set_minimized()` when restoring a minimized surface.

The remap-on-restore path was introduced in [`3b9d0ce` (HACK: Remap minimized X11 windows on restore) ](https://github.com/pop-os/cosmic-comp/commit/3b9d0ce) as a workaround for older X11/XWayland restore issues. However, forcing
```
surface.set_mapped(false)
surface.set_mapped(true)
```
on unminimize now appears to cause a regression with Steam: when restoring a non-fullscreen Steam window, the main surface can remain black even though tooltips still render and input continues to work.

This change keeps the existing `surface.set_hidden(minimized)` behavior intact and only removes the forced remap cycle. That means we still preserve the newer `_NET_WM_STATE_HIDDEN` handling for X11 clients, while avoiding an extra unmap/map transition during restore.

I'm not sure why the original hack was introduced, so I did some best guesses, and tested this specifically against the regressions that likely motivated previous X11/XWayland minimize/restore fixes:

- Steam (original reproducer; non-fullscreen minimize/restore black screen)
- OpenTTD (native SDL over XWayland)
- Sheepy: A Short Adventure (Wine/Proton over XWayland)
- SuperTux2 using SDL_VIDEODRIVER=x11 SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=1 supertux2 -f as a regression check for the XWayland fullscreen focus-loss/minimize path covered by #1691

All of the above behaved correctly after removing the remap cycle.
It would be helpful to know what exactly was the trigger behind the original hack and test whether it's relevant at this point.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x]  I understand these changes in full and will be able to respond to review comments.
- [x]  My change is accurately described in the commit message.
- [x]  My contribution is tested and working as described.
- [x]  I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions