### PR TITLE
Use `wayland_server::DisplayHandle::set_default_max_buffer_size`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "tracy-client",
  "wayland-backend",
  "wayland-scanner",
+ "wayland-server",
  "xcursor",
  "xdg",
  "xdg-user",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ tracing-subscriber = { version = "0.3.22", features = [
 tracy-client = { version = "0.18.4", default-features = false }
 wayland-backend = "0.3.12"
 wayland-scanner = "0.31.8"
+wayland-server = { version = "0.31.12", features = ["libwayland_1_23"] }
 xcursor = "0.3.10"
 xdg = "^3.0"
 xdg-user = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,8 @@ fn init_wayland_display(
     let display = Display::new().unwrap();
     let handle = display.handle();
 
+    handle.set_default_max_buffer_size(1024 * 1024);
+
     let source = ListeningSocketSource::new_auto().unwrap();
     let socket_name = source.socket_name().to_os_string();
     info!("Listening on {:?}", socket_name);


### PR DESCRIPTION
This matches what `sway` and `mutter` use. See https://github.com/niri-wm/niri/pull/1699, https://github.com/niri-wm/niri/issues/1989.

I still need to reproduce the crashes this should address.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

