### PR TITLE
feat: add nearest-neighbor filtering option for accessibility zoom

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -181,6 +181,10 @@ fn default_repeat_delay() -> u32 {
     600
 }
 
+fn default_smooth_images() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ZoomConfig {
     pub start_on_login: bool,
@@ -188,6 +192,10 @@ pub struct ZoomConfig {
     pub increment: u32,
     pub view_moves: ZoomMovement,
     pub enable_mouse_zoom_shortcuts: bool,
+    /// Use bilinear filtering when zoomed (smooth but blurry).
+    /// When false, use nearest-neighbor filtering (crisp pixels).
+    #[serde(default = "default_smooth_images")]
+    pub smooth_images: bool,
 }
 
 impl Default for ZoomConfig {
@@ -198,6 +206,7 @@ impl Default for ZoomConfig {
             increment: 50,
             view_moves: ZoomMovement::Continuously,
             enable_mouse_zoom_shortcuts: true,
+            smooth_images: true,
         }
     }
 }

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -572,6 +572,14 @@ impl KmsState {
             .copied()
     }
 
+    pub fn reset_buffer_ages(&self) {
+        for device in self.drm_devices.values() {
+            for surface in device.inner.surfaces.values() {
+                surface.reset_buffer_ages();
+            }
+        }
+    }
+
     pub fn update_screen_filter(&mut self, screen_filter: &ScreenFilter) -> Result<()> {
         for device in self.drm_devices.values_mut() {
             for surface in device.inner.surfaces.values_mut() {

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -219,6 +219,7 @@ pub enum ThreadCommand {
     AdaptiveSyncAvailable(SyncSender<Result<VrrSupport>>),
     UseAdaptiveSync(AdaptiveSync),
     AllowFrameFlags(bool, FrameFlags),
+    ResetBufferAges,
     End,
     DpmsOff,
 }
@@ -402,6 +403,10 @@ impl Surface {
         let _ = self
             .thread_command
             .send(ThreadCommand::UpdateScreenFilter(config));
+    }
+
+    pub fn reset_buffer_ages(&self) {
+        let _ = self.thread_command.send(ThreadCommand::ResetBufferAges);
     }
 
     pub fn adaptive_sync_support(&self) -> Result<VrrSupport> {
@@ -612,6 +617,12 @@ fn surface_thread(
             }
             Event::Msg(ThreadCommand::UseAdaptiveSync(vrr)) => {
                 state.vrr_mode = vrr;
+            }
+            Event::Msg(ThreadCommand::ResetBufferAges) => {
+                if let Some(compositor) = state.compositor.as_mut() {
+                    compositor.with_compositor(|c| c.reset_buffer_ages());
+                }
+                state.queue_redraw(false);
             }
             Event::Msg(ThreadCommand::DpmsOff) => {
                 if let Some(compositor) = state.compositor.as_mut() {
@@ -1083,6 +1094,19 @@ impl SurfaceThreadState {
             .then(|| take_screencopy_frames(&self.output, &elements, &mut has_cursor_mode_none))
             .unwrap_or_default();
 
+        // Use nearest-neighbor filtering when zoomed with smooth_images disabled.
+        // Both filters needed: on HiDPI displays, surface buffers may be higher
+        // resolution than the zoomed viewport, making this a downscale operation.
+        let use_nearest_zoom = self
+            .shell
+            .read()
+            .zoom_state()
+            .is_some_and(|z| !z.smooth_images);
+        if use_nearest_zoom {
+            let _ = renderer.upscale_filter(TextureFilter::Nearest);
+            let _ = renderer.downscale_filter(TextureFilter::Nearest);
+        }
+
         // actual rendering
         let source_output = self
             .mirroring
@@ -1294,6 +1318,12 @@ impl SurfaceThreadState {
                     .difference(remove_frame_flags),
             )
         };
+
+        if use_nearest_zoom {
+            let _ = renderer.upscale_filter(TextureFilter::Linear);
+            let _ = renderer.downscale_filter(TextureFilter::Linear);
+        }
+
         self.timings.draw_done(&self.clock);
 
         match res {

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -1535,6 +1535,14 @@ where
         damage_tracker.damage_output(age, &additional_damage_elements)?;
     }
 
+    // Both filters needed: on HiDPI displays, surface buffers may be higher
+    // resolution than the zoomed viewport, making this a downscale operation.
+    let use_nearest = zoom_level.is_some_and(|z| !z.smooth_images);
+    if use_nearest {
+        let _ = renderer.upscale_filter(TextureFilter::Nearest);
+        let _ = renderer.downscale_filter(TextureFilter::Nearest);
+    }
+
     let res = damage_tracker.render_output(
         renderer,
         target,
@@ -1542,6 +1550,11 @@ where
         &elements,
         CLEAR_COLOR, // TODO use a theme neutral color
     );
+
+    if use_nearest {
+        let _ = renderer.upscale_filter(TextureFilter::Linear);
+        let _ = renderer.downscale_filter(TextureFilter::Linear);
+    }
 
     res.map(|res| (res, elements))
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -126,6 +126,10 @@ impl WinitState {
         }
     }
 
+    pub fn reset_buffer_ages(&mut self) {
+        self.damage_tracker = OutputDamageTracker::from_output(&self.output);
+    }
+
     pub fn update_screen_filter(&mut self, screen_filter: &ScreenFilter) -> Result<()> {
         self.screen_filter_state.filter = screen_filter.clone();
         Ok(())

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -191,6 +191,12 @@ impl X11State {
         }
     }
 
+    pub fn reset_buffer_ages(&mut self) {
+        for surface in &mut self.surfaces {
+            surface.damage_tracker = OutputDamageTracker::from_output(&surface.output);
+        }
+    }
+
     pub fn update_screen_filter(&mut self, screen_filter: &ScreenFilter) -> Result<()> {
         for surface in &mut self.surfaces {
             surface.screen_filter_state.filter = screen_filter.clone();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -938,8 +938,18 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
             "accessibility_zoom" => {
                 let new = get_config::<ZoomConfig>(&config, "accessibility_zoom");
                 if new != state.common.config.cosmic_conf.accessibility_zoom {
+                    let smooth_changed = new.smooth_images
+                        != state.common.config.cosmic_conf.accessibility_zoom.smooth_images;
                     state.common.config.cosmic_conf.accessibility_zoom = new;
                     state.common.update_config();
+                    if smooth_changed {
+                        // Texture filter changes are invisible to the damage tracker,
+                        // so force full re-render by resetting buffer ages.
+                        state.backend.reset_buffer_ages();
+                    }
+                    for output in state.common.shell.read().outputs() {
+                        state.backend.schedule_render(output);
+                    }
                 }
             }
             "appearance_settings" => {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1467,6 +1467,7 @@ impl Common {
             zoom_state.increment = self.config.cosmic_conf.accessibility_zoom.increment;
             zoom_state.movement = self.config.cosmic_conf.accessibility_zoom.view_moves;
             zoom_state.show_overlay = self.config.cosmic_conf.accessibility_zoom.show_overlay;
+            zoom_state.smooth_images = self.config.cosmic_conf.accessibility_zoom.smooth_images;
 
             for output in shell_ref.workspaces.sets.keys() {
                 let output_state = output.user_data().get::<Mutex<OutputZoomState>>().unwrap();
@@ -2372,6 +2373,7 @@ impl Shell {
             show_overlay: zoom_config.show_overlay,
             increment: zoom_config.increment,
             movement: zoom_config.view_moves,
+            smooth_images: zoom_config.smooth_images,
         });
     }
 

--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -52,6 +52,7 @@ pub struct ZoomState {
     pub(super) show_overlay: bool,
     pub(super) increment: u32,
     pub(super) movement: ZoomMovement,
+    pub smooth_images: bool,
 }
 
 #[derive(Debug)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -355,6 +355,15 @@ impl BackendData {
         }
     }
 
+    pub fn reset_buffer_ages(&mut self) {
+        match self {
+            BackendData::Winit(state) => state.reset_buffer_ages(),
+            BackendData::X11(state) => state.reset_buffer_ages(),
+            BackendData::Kms(state) => state.reset_buffer_ages(),
+            _ => unreachable!("No backend was initialized"),
+        }
+    }
+
     pub fn schedule_render(&mut self, output: &Output) {
         match self {
             BackendData::Winit(_) => {} // We cannot do this on the winit backend.


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
## Summary

Adds a `smooth_images` option to `ZoomConfig` (default: `true`) that controls texture filtering during zoom rendering.

- **`true` (default)**: bilinear filtering (current behavior, smooth but blurry)
- **`false`**: nearest-neighbor filtering (crisp pixel boundaries)

Both upscale and downscale filters are set, since on HiDPI displays surface buffers may be at higher resolution than the zoomed viewport at lower zoom levels.

Filter state is restored after rendering to avoid affecting other render contexts.

### Live toggle support

Changing `smooth_images` at runtime (via the companion settings toggle) takes effect immediately. This required two additional fixes:

- **Schedule render on config change**: the config watcher now triggers a redraw for all outputs when zoom settings change.
- **Force full re-render on filter change**: GL texture filter state is invisible to the damage tracker (no element geometry or content changes), so the damage tracker would skip rendering entirely. Fixed by resetting buffer ages when `smooth_images` changes, which forces the damage tracker to treat all buffers as having no history.

Companion PR for the settings UI toggle: pop-os/cosmic-settings#1892.

Closes #1671.

## Test plan

- [x] Tested on 3840x2160 display at 175% fractional scale
- [x] Verified crisp pixels visible when zoomed above native scale
- [x] Verified smooth (default) behavior unchanged
- [x] Verified config backward compatibility (existing configs without `smooth_images` deserialize correctly via serde default)
- [x] Verified non-zoomed rendering unaffected when crisp mode enabled (no pixelation on other windows/outputs)
- [x] Verified live toggle via settings UI switches between smooth and crisp immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)