### PR TITLE
feat: add --no-xwayland argument for running without Xwayland

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -168,9 +168,13 @@ pub fn init_backend(
         }
     }
 
-    // start x11
-    let primary = *state.backend.kms().primary_node.read().unwrap();
-    state.launch_xwayland(primary);
+    if state.common.with_xwayland {
+        // start x11
+        let primary = *state.backend.kms().primary_node.read().unwrap();
+        state.launch_xwayland(primary);
+    } else {
+        state.notify_ready();
+    }
 
     Ok(())
 }

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -241,7 +241,12 @@ pub fn init_backend(
         }
         state.common.refresh();
     }
-    state.launch_xwayland(None);
+
+    if state.common.with_xwayland {
+        state.launch_xwayland(None);
+    } else {
+        state.notify_ready();
+    }
 
     Ok(())
 }

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -384,7 +384,12 @@ pub fn init_backend(
         }
         state.common.refresh();
     }
-    state.launch_xwayland(None);
+
+    if state.common.with_xwayland {
+        state.launch_xwayland(None);
+    } else {
+        state.notify_ready();
+    }
 
     event_loop
         .handle()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,12 +109,17 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
     let mut cursor = raw_args.cursor();
     let git_hash = option_env!("GIT_HASH").unwrap_or("unknown");
 
+    let mut with_xwayland = true;
     // Parse the arguments
     while let Some(arg) = raw_args.next_os(&mut cursor) {
         match arg.to_str() {
             Some("--help") | Some("-h") => {
                 print_help(env!("CARGO_PKG_VERSION"), git_hash);
                 return Ok(());
+            }
+            Some("--no-xwayland") => {
+                tracing::info!("Running without Xwayland");
+                with_xwayland = false;
             }
             Some("--version") | Some("-V") => {
                 println!(
@@ -152,6 +157,7 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
         socket,
         event_loop.handle(),
         event_loop.get_signal(),
+        with_xwayland,
     );
     // init backend
     backend::init_backend_auto(&display, &mut event_loop, &mut state)?;
@@ -239,8 +245,9 @@ Designed for the COSMIC™ desktop environment, cosmic-comp is a Wayland Composi
 Project home page: https://github.com/pop-os/cosmic-comp
 
 Options:
-  -h, --help     Show this message
-  -v, --version  Show the version of cosmic-comp"#
+  -h, --help          Show this message
+  --no-xwayland       Run without Xwayland
+  -v, --version       Show the version of cosmic-comp"#
     );
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -296,6 +296,8 @@ pub struct Common {
 
     #[cfg(feature = "systemd")]
     pub inhibit_lid_fd: Option<OwnedFd>,
+
+    pub with_xwayland: bool,
 }
 
 #[derive(Debug)]
@@ -626,6 +628,7 @@ impl State {
         socket: OsString,
         handle: LoopHandle<'static, State>,
         signal: LoopSignal,
+        with_xwayland: bool,
     ) -> State {
         let requested_languages = DesktopLanguageRequester::requested_languages();
         i18n_embed::select(&*LANG_LOADER, &Localizations, &requested_languages)
@@ -801,6 +804,8 @@ impl State {
 
                 #[cfg(feature = "systemd")]
                 inhibit_lid_fd: None,
+
+                with_xwayland,
             },
             backend: BackendData::Unset,
             ready: Once::new(),


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Tested with an unmodified `/usr/bin/start-cosmic`, and with --no-xwayland appended like so:

```bash
# Run cosmic-session
if [[ -z "${DBUS_SESSION_BUS_ADDRESS}" ]]; then
    exec /usr/bin/dbus-run-session -- /usr/bin/cosmic-session cosmic-comp --no-xwayland
else
    exec /usr/bin/cosmic-session cosmic-comp --no-xwayland
fi
```

When `--no-xwayland` is appended, Xwayland is not started:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/812e9ae0-0124-4a42-8a29-bf1efbe983ef" />

When `--no-xwayland` is not appended, Xwayland is started:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/677b6eb6-affb-446f-b2e8-01034affc015" />
