### PR TITLE
feat(input): bind XF86LaunchA to workspace overview

### DIFF
--- a/data/keybindings.ron
+++ b/data/keybindings.ron
@@ -124,4 +124,5 @@
     (modifiers: [], key: "XF86PowerOff"): System(PowerOff),
     (modifiers: [], key: "XF86TouchpadToggle"): System(TouchpadToggle),
     (modifiers: [Super, Ctrl], key: "XF86TouchpadToggle"): System(TouchpadToggle),
+    (modifiers: [], key: "XF86LaunchA"): System(WorkspaceOverview),
 }


### PR DESCRIPTION
This allows to toggle the Workspace Overview with the Mission Control button present on Apple / macOS keyboards.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

