### PR TITLE
x11: fix fractional scaling

### DIFF
--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -692,7 +692,7 @@ impl Common {
                             ),
                             (
                                 "Gdk/WindowScalingFactor".into(),
-                                (new_scale.round() as i32).into(),
+                                (new_scale.floor() as i32).into(),
                             ),
                             (
                                 "Gtk/CursorThemeSize".into(),


### PR DESCRIPTION
Fractional scaling was broken when the fractional part was .75 as the round rounded up the WindowScalingFactor to the upper bound and applied extra scaling in addition to the one in UnscaledDPI (1.75 * 2 for 175% scaling instead of 1.75 * 1).

Noticed this running discord app at 175% scaling. Tested it now works as you'd expect with the scaling being gradual instead of going to what looked like 300% at 175%.

Forgot to mention this is for fractional scaling so "Optimize for gaming and full-screen apps" X11 compatibility mode in Cosmic settings.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

