### PR TITLE
image-copy: Do not panic on `ImageCaptureSourceKind::Destroyed`

### DIFF
--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -21,8 +21,9 @@ use smithay::{
         dmabuf::get_dmabuf,
         image_capture_source::ImageCaptureSource,
         image_copy_capture::{
-            BufferConstraints, CursorSession, CursorSessionRef, DmabufConstraints, Frame, FrameRef,
-            ImageCopyCaptureHandler, ImageCopyCaptureState, Session, SessionRef,
+            BufferConstraints, CaptureFailureReason, CursorSession, CursorSessionRef,
+            DmabufConstraints, Frame, FrameRef, ImageCopyCaptureHandler, ImageCopyCaptureState,
+            Session, SessionRef,
         },
         seat::WaylandFocus,
     },
@@ -138,7 +139,9 @@ impl ImageCopyCaptureHandler for State {
                 });
                 toplevel.add_session(session);
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => {
+                session.stop();
+            }
         }
     }
 
@@ -258,7 +261,9 @@ impl ImageCopyCaptureHandler for State {
 
                 toplevel.add_cursor_session(session);
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => {
+                session.stop();
+            }
         }
     }
 
@@ -284,7 +289,9 @@ impl ImageCopyCaptureHandler for State {
             ImageCaptureSourceKind::Toplevel(toplevel) => {
                 render_window_to_buffer(self, session, frame, &toplevel)
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => {
+                frame.fail(CaptureFailureReason::Stopped);
+            }
         }
     }
 
@@ -330,7 +337,7 @@ impl ImageCopyCaptureHandler for State {
                 }
             }
             ImageCaptureSourceKind::Toplevel(mut toplevel) => toplevel.remove_session(&session),
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => {}
         }
     }
 
@@ -361,7 +368,7 @@ impl ImageCopyCaptureHandler for State {
             ImageCaptureSourceKind::Toplevel(mut toplevel) => {
                 toplevel.remove_cursor_session(&session)
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => {}
         }
     }
 }


### PR DESCRIPTION
The way this was handled previously is incorrect. We should still handle creation of a capture session, just send `stopped` when it is created.

This can be tested by creating a capture source and session for a workspace that has been removed. Toplevel and output sources have a different issue in `smithay`: https://github.com/Smithay/smithay/pull/1961

Should fix https://github.com/pop-os/cosmic-epoch/issues/3319.

https://gist.github.com/ids1024/808358ed4671af7a8b31edc97a45cccc has a minimal test client using `cosmic-client-toolkit` to reproduce the issue; by trying to create a capture session for a workspace as soon as it is removed. Prior to this PR, that crashed the compositor when a workspace is removed. After it, the compositor runs fine, and that shows the capture session is `stopped`.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

