### PR TITLE
Move initization of pointer state to Common state

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -37,7 +37,6 @@ use smithay::{
     wayland::{
         dmabuf::DmabufGlobal,
         drm_syncobj::{DrmSyncobjState, supports_syncobj_eventfd},
-        relative_pointer::RelativePointerManagerState,
     },
 };
 use surface::GbmDrmOutput;
@@ -91,7 +90,7 @@ pub fn init_backend(
     let (session, notifier) = LibSeatSession::new().context("Failed to acquire session")?;
 
     // setup input
-    let libinput_context = init_libinput(dh, &session, &event_loop.handle())
+    let libinput_context = init_libinput(&session, &event_loop.handle())
         .context("Failed to initialize libinput backend")?;
 
     // watch for gpu events
@@ -179,11 +178,7 @@ pub fn init_backend(
     Ok(())
 }
 
-fn init_libinput(
-    dh: &DisplayHandle,
-    session: &LibSeatSession,
-    evlh: &LoopHandle<'static, State>,
-) -> Result<Libinput> {
+fn init_libinput(session: &LibSeatSession, evlh: &LoopHandle<'static, State>) -> Result<Libinput> {
     let mut libinput_context =
         Libinput::new_with_udev::<LibinputSessionInterface<LibSeatSession>>(session.clone().into());
     libinput_context
@@ -211,9 +206,6 @@ fn init_libinput(
     })
     .map_err(|err| err.error)
     .context("Failed to initialize libinput event source")?;
-
-    // Create relative pointer global
-    RelativePointerManagerState::new::<State>(dh);
 
     Ok(libinput_context)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -88,6 +88,7 @@ use smithay::{
         pointer_constraints::PointerConstraintsState,
         pointer_gestures::PointerGesturesState,
         presentation::PresentationState,
+        relative_pointer::RelativePointerManagerState,
         seat::WaylandFocus,
         security_context::{SecurityContext, SecurityContextState},
         selection::{
@@ -674,6 +675,7 @@ impl State {
         let xwayland_shell_state = XWaylandShellState::new::<Self>(dh);
         PointerConstraintsState::new::<Self>(dh);
         PointerGesturesState::new::<Self>(dh);
+        RelativePointerManagerState::new::<Self>(dh);
         TabletManagerState::new::<Self>(dh);
         SecurityContextState::new::<Self, _>(dh, client_has_no_security_context);
         InputMethodManagerState::new::<Self, _>(dh, client_not_sandboxed);


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This branch seems to fix https://github.com/pop-os/cosmic-epoch/issues/2021 from my personal testing.

I purposefully have not ticked the "I understand all the changes in this branch fully" since I'm not 100% certain of the side effects this patch can have (I do not know why the initialization was done how it was done before). I noticed this particular state wrapper was handled differently from the others.

What I think was causing the linked issue is the libinput context initialization being triggered once again when entering 3d state, which reset the state for relative pointer management tracking, resulting in it thinking the cursor was not captured.

Instead, this patch makes the state for relative cursor part of the overall state, ensuring it is not reset (?). This follows the same pattern as other State wrappers. This seems to solve my particular issue: relative movement being broken in Helldivers2 in 3d mode (2d mode - hence, not "relative movement" related, worked fine).

I would like this branch to undergo more manual testing for other games before being merged. While I can see it fixed my own problem (I have been running my branch successfully for a while), I am unsure of the implications on the rest of the compositor - it's my first time looking at the code base and I would be lying if I said I understand how it all works at this point (it's... complex).

