### PR TITLE
Partially revert "x11: stop remapping minimized windows on restore"

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -429,6 +429,10 @@ impl CosmicSurface {
             .store(minimized, Ordering::SeqCst);
         if let WindowSurface::X11(surface) = self.0.underlying_surface() {
             let _ = surface.set_hidden(minimized);
+            if !minimized && surface.is_fullscreen() {
+                let _ = surface.set_mapped(false);
+                let _ = surface.set_mapped(true);
+            }
         }
     }
 


### PR DESCRIPTION
This re-introduces the xwayland remap on un-minimize hack, but limited to fullscreen applications.

Fixes https://github.com/pop-os/cosmic-epoch/issues/3330.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

