### PR TITLE
fix: handle destroyed image capture sources gracefully

### DIFF
--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -21,8 +21,9 @@ use smithay::{
         dmabuf::get_dmabuf,
         image_capture_source::ImageCaptureSource,
         image_copy_capture::{
-            BufferConstraints, CursorSession, CursorSessionRef, DmabufConstraints, Frame, FrameRef,
-            ImageCopyCaptureHandler, ImageCopyCaptureState, Session, SessionRef,
+            BufferConstraints, CaptureFailureReason, CursorSession, CursorSessionRef,
+            DmabufConstraints, Frame, FrameRef, ImageCopyCaptureHandler, ImageCopyCaptureState,
+            Session, SessionRef,
         },
         seat::WaylandFocus,
     },
@@ -138,7 +139,7 @@ impl ImageCopyCaptureHandler for State {
                 });
                 toplevel.add_session(session);
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => return,
         }
     }
 
@@ -258,7 +259,7 @@ impl ImageCopyCaptureHandler for State {
 
                 toplevel.add_cursor_session(session);
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => return,
         }
     }
 
@@ -284,7 +285,10 @@ impl ImageCopyCaptureHandler for State {
             ImageCaptureSourceKind::Toplevel(toplevel) => {
                 render_window_to_buffer(self, session, frame, &toplevel)
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => {
+                frame.fail(CaptureFailureReason::Unknown);
+                return;
+            }
         }
     }
 
@@ -330,7 +334,7 @@ impl ImageCopyCaptureHandler for State {
                 }
             }
             ImageCaptureSourceKind::Toplevel(mut toplevel) => toplevel.remove_session(&session),
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => return,
         }
     }
 
@@ -361,7 +365,7 @@ impl ImageCopyCaptureHandler for State {
             ImageCaptureSourceKind::Toplevel(mut toplevel) => {
                 toplevel.remove_cursor_session(&session)
             }
-            ImageCaptureSourceKind::Destroyed => unreachable!(),
+            ImageCaptureSourceKind::Destroyed => return,
         }
     }
 }


### PR DESCRIPTION
## Summary

When a capture source (output, workspace, or toplevel) is destroyed before a session interacts with it, the `Destroyed` variant is reached in `ImageCopyCaptureHandler` methods. Previously this triggered `unreachable!()`, crashing the compositor.

This patch handles the `Destroyed` case gracefully:
- `new_session` / `new_cursor_session`: return without setup
- `session_destroyed` / `cursor_session_destroyed`: return without cleanup  
- `frame`: explicitly fail the frame with `CaptureFailureReason::Unknown` to notify the client rather than silently dropping

## Architectural note

The `Output` variant already handles lifecycle races cleanly via `WeakOutput` — when the output is gone, `weak.upgrade()` returns `None` and the handler returns gracefully. The `Workspace` and `Toplevel` variants use strong references, which is why the `Destroyed` fallback variant exists.

A deeper fix would be to use weak references for `Workspace` and `Toplevel` as well, making the `Destroyed` variant unnecessary. This has broader implications across the codebase, so it is left as a recommendation for maintainers to evaluate.

## Test plan

- [ ] Reproduce by destroying a capture source while a session is active
- [ ] Verify compositor no longer crashes on `unreachable!()`
- [ ] Verify client receives frame failure notification