### PR TITLE
fix: break from loop instead of unwrapping

### DIFF
--- a/src/dbus/name_owners.rs
+++ b/src/dbus/name_owners.rs
@@ -3,6 +3,7 @@
 //! Compare to Mutter's `MetaDbusAccessChecker`
 
 use futures_executor::ThreadPool;
+use futures_util::stream::FusedStream;
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use std::{
     collections::{HashMap, HashSet},
@@ -38,9 +39,15 @@ impl Inner {
     /// Process all events so far on `stream`, and update `name_owners`.
     fn update_if_needed(&mut self) {
         let mut context = Context::from_waker(&self.waker);
-        while let Poll::Ready(val) = self.stream.poll_next_unpin(&mut context) {
-            let val = val.unwrap();
-            let args = val.args().unwrap();
+        while !self.stream.is_terminated()
+            && let Poll::Ready(val) = self.stream.poll_next_unpin(&mut context)
+        {
+            let Some(val) = val else {
+                break;
+            };
+            let Ok(args) = val.args() else {
+                break;
+            };
             match args.name {
                 BusName::Unique(name) => {
                     if args.new_owner.is_some() {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

