### PR TITLE
feat: WindowRules Workspace Assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.2.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
 dependencies = [
  "bitflags 2.11.0",
  "cosmic-protocols",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#e37160f14d1e7ee428f973cd2848b4e95f83dfe1"
+source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#eb7d841467b83f4915fd8a09d345b3a461025e94"
 dependencies = [
  "cosmic-config",
  "ron 0.11.0",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#e37160f14d1e7ee428f973cd2848b4e95f83dfe1"
+source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#eb7d841467b83f4915fd8a09d345b3a461025e94"
 dependencies = [
  "cosmic-config",
  "cosmic-theme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#eb7d841467b83f4915fd8a09d345b3a461025e94"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon?rev=refs%2Fpull%2F137%2Fhead#ccc11cdf28b86ee367982fb9fc93164076e3c941"
 dependencies = [
  "cosmic-config",
  "ron 0.11.0",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon-config"
 version = "0.1.0"
-source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#eb7d841467b83f4915fd8a09d345b3a461025e94"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon?rev=refs%2Fpull%2F137%2Fhead#ccc11cdf28b86ee367982fb9fc93164076e3c941"
 dependencies = [
  "cosmic-config",
  "cosmic-theme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#e37160f14d1e7ee428f973cd2848b4e95f83dfe1"
+source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#bf74a86d301881ec7d57678c417a3bea495b7b60"
 dependencies = [
  "cosmic-config",
  "ron 0.11.0",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-settings-daemon#e37160f14d1e7ee428f973cd2848b4e95f83dfe1"
+source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#bf74a86d301881ec7d57678c417a3bea495b7b60"
 dependencies = [
  "cosmic-config",
  "cosmic-theme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
-source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#bf74a86d301881ec7d57678c417a3bea495b7b60"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon?rev=refs%2Fpull%2F137%2Fhead#875511967217707ded550794621edd688b388a4a"
 dependencies = [
  "cosmic-config",
  "ron 0.11.0",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon-config"
 version = "0.1.0"
-source = "git+https://github.com/karlskewes/cosmic-settings-daemon?branch=workspace-pinning#bf74a86d301881ec7d57678c417a3bea495b7b60"
+source = "git+https://github.com/pop-os/cosmic-settings-daemon?rev=refs%2Fpull%2F137%2Fhead#875511967217707ded550794621edd688b388a4a"
 dependencies = [
  "cosmic-config",
  "cosmic-theme",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,9 +138,15 @@ inherits = "release"
 [profile.release]
 lto = "fat"
 
-[patch."https://github.com/pop-os/cosmic-protocols"]
-cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
-cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
-
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "211c19d" }
+
+# TODO: karl - local dev
+# [patch."https://github.com/pop-os/cosmic-settings-daemon"]
+# cosmic-settings-config = { path = "../cosmic-settings-daemon/config" }
+# cosmic-settings-daemon-config = { path = "../cosmic-settings-daemon/cosmic-settings-daemon-config" }
+
+# TODO: karl - via remote dev for easier nix build
+[patch."https://github.com/pop-os/cosmic-settings-daemon"]
+cosmic-settings-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }
+cosmic-settings-daemon-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,12 +141,7 @@ lto = "fat"
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "211c19d" }
 
-# TODO: karl - local dev
-# [patch."https://github.com/pop-os/cosmic-settings-daemon"]
-# cosmic-settings-config = { path = "../cosmic-settings-daemon/config" }
-# cosmic-settings-daemon-config = { path = "../cosmic-settings-daemon/cosmic-settings-daemon-config" }
-
-# TODO: karl - via remote dev for easier nix build
+# TODO(karlskewes): Change back to upstream OSS when PR merged: https://github.com/pop-os/cosmic-settings-daemon/pull/137
 [patch."https://github.com/pop-os/cosmic-settings-daemon"]
 cosmic-settings-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }
 cosmic-settings-daemon-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ cosmic-config = { git = "https://github.com/pop-os/libcosmic", features = [
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = [
     "server",
 ] }
-cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
-cosmic-settings-daemon-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", features = [
+# TODO(karlskewes): Change back to upstream OSS when PR merged: https://github.com/pop-os/cosmic-settings-daemon/pull/137
+cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", rev ="refs/pull/137/head"}
+cosmic-settings-daemon-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", rev = "refs/pull/137/head", features = [
     "greeter",
 ] }
 cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", features = [
@@ -140,8 +141,3 @@ lto = "fat"
 
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "211c19d" }
-
-# TODO(karlskewes): Change back to upstream OSS when PR merged: https://github.com/pop-os/cosmic-settings-daemon/pull/137
-[patch."https://github.com/pop-os/cosmic-settings-daemon"]
-cosmic-settings-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }
-cosmic-settings-daemon-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,3 +146,7 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "5fb12b8" }
+
+[patch."https://github.com/pop-os/cosmic-settings-daemon"]
+cosmic-settings-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }
+cosmic-settings-daemon-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "5fb12b8" }
 
+# TODO(karlskewes): Change back to upstream OSS when PR merged: https://github.com/pop-os/cosmic-settings-daemon/pull/137
 [patch."https://github.com/pop-os/cosmic-settings-daemon"]
 cosmic-settings-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }
 cosmic-settings-daemon-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ cosmic-config = { git = "https://github.com/pop-os/libcosmic", features = [
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = [
     "server",
 ] }
-cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
-cosmic-settings-daemon-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", features = [
+# TODO(karlskewes): Change back to upstream OSS when PR merged: https://github.com/pop-os/cosmic-settings-daemon/pull/137
+cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", rev ="refs/pull/137/head"}
+cosmic-settings-daemon-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", rev = "refs/pull/137/head", features = [
     "greeter",
 ] }
 cosmic-text = { version = "0.19", features = [
@@ -146,8 +147,3 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "5fb12b8" }
-
-# TODO(karlskewes): Change back to upstream OSS when PR merged: https://github.com/pop-os/cosmic-settings-daemon/pull/137
-[patch."https://github.com/pop-os/cosmic-settings-daemon"]
-cosmic-settings-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }
-cosmic-settings-daemon-config = { git = "https://github.com/karlskewes/cosmic-settings-daemon", branch = "workspace-pinning" }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use anyhow::Context;
 use cosmic_config::{ConfigGet, CosmicConfigEntry};
-use cosmic_settings_config::window_rules::ApplicationException;
+use cosmic_settings_config::window_rules::{ApplicationException, WorkspaceAssignment};
 use cosmic_settings_config::{Shortcuts, shortcuts, window_rules};
 use serde::{Deserialize, Serialize};
 use smithay::utils::{Clock, Monotonic};
@@ -70,6 +70,8 @@ pub struct Config {
     pub tiling_exceptions: Vec<ApplicationException>,
     /// System actions from `com.system76.CosmicSettings.Shortcuts`
     pub system_actions: BTreeMap<shortcuts::action::System, String>,
+    // Workspace assignments from `com.system76.CosmicSettings.WindowRules`
+    pub workspace_assignments: Vec<WorkspaceAssignment>,
 }
 
 #[derive(Debug)]
@@ -282,6 +284,7 @@ impl Config {
         let window_rules_context =
             window_rules::context().expect("Failed to load window rules config");
         let tiling_exceptions = window_rules::tiling_exceptions(&window_rules_context);
+        let workspace_assignments = window_rules::workspace_assignments(&window_rules_context);
 
         match cosmic_config::calloop::ConfigWatchSource::new(&window_rules_context) {
             Ok(source) => {
@@ -293,6 +296,17 @@ impl Config {
                                 state.common.config.tiling_exceptions = new_exceptions;
                                 state.common.shell.write().update_tiling_exceptions(
                                     state.common.config.tiling_exceptions.iter(),
+                                );
+                            }
+                            // TODO(karlskewes): Confirm
+                            // "..WindowRules/v1/workspace_assignment_defaults" is likely and
+                            // match on it here. Or should use simpler
+                            // "..WindowRules/v1/workspace_assignment" filename.
+                            "workspace_assignment_custom" => {
+                                let assignments = window_rules::workspace_assignments(&config);
+                                state.common.config.workspace_assignments = assignments;
+                                state.common.shell.write().update_workspace_assignments(
+                                    state.common.config.workspace_assignments.iter(),
                                 );
                             }
                             _ => (),
@@ -331,6 +345,7 @@ impl Config {
             shortcuts,
             system_actions,
             tiling_exceptions,
+            workspace_assignments,
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::Context;
 use cosmic_config::{ConfigGet, CosmicConfigEntry};
-use cosmic_settings_config::window_rules::ApplicationException;
+use cosmic_settings_config::window_rules::{ApplicationException, WorkspaceAssignment};
 use cosmic_settings_config::{Shortcuts, shortcuts, window_rules};
 use serde::{Deserialize, Serialize};
 use smithay::utils::{Clock, Monotonic};
@@ -71,6 +71,8 @@ pub struct Config {
     pub tiling_exceptions: Vec<ApplicationException>,
     /// System actions from `com.system76.CosmicSettings.Shortcuts`
     pub system_actions: BTreeMap<shortcuts::action::System, String>,
+    // Workspace assignments from `com.system76.CosmicSettings.WindowRules`
+    pub workspace_assignments: Vec<WorkspaceAssignment>,
 }
 
 #[derive(Debug)]
@@ -283,6 +285,7 @@ impl Config {
         let window_rules_context =
             window_rules::context().expect("Failed to load window rules config");
         let tiling_exceptions = window_rules::tiling_exceptions(&window_rules_context);
+        let workspace_assignments = window_rules::workspace_assignments(&window_rules_context);
 
         match cosmic_config::calloop::ConfigWatchSource::new(&window_rules_context) {
             Ok(source) => {
@@ -294,6 +297,17 @@ impl Config {
                                 state.common.config.tiling_exceptions = new_exceptions;
                                 state.common.shell.write().update_tiling_exceptions(
                                     state.common.config.tiling_exceptions.iter(),
+                                );
+                            }
+                            // TODO(karlskewes): Confirm
+                            // "..WindowRules/v1/workspace_assignment_defaults" is likely and
+                            // match on it here. Or should use simpler
+                            // "..WindowRules/v1/workspace_assignment" filename.
+                            "workspace_assignment_custom" => {
+                                let assignments = window_rules::workspace_assignments(&config);
+                                state.common.config.workspace_assignments = assignments;
+                                state.common.shell.write().update_workspace_assignments(
+                                    state.common.config.workspace_assignments.iter(),
                                 );
                             }
                             _ => (),
@@ -332,6 +346,7 @@ impl Config {
             shortcuts,
             system_actions,
             tiling_exceptions,
+            workspace_assignments,
         }
     }
 

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -101,3 +101,61 @@ pub fn has_floating_exception(exceptions: &TilingExceptions, window: &CosmicSurf
 
     false
 }
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceAssignment {
+    app_id: Regex,
+    title: Regex,
+    workspace_id: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceAssignments {
+    assignments: Vec<WorkspaceAssignment>,
+}
+
+impl WorkspaceAssignments {
+    pub fn new<'a, I>(assignments_config: I) -> Self
+    where
+        I: Iterator<Item = &'a cosmic_settings_config::window_rules::WorkspaceAssignment>,
+    {
+        let assignments = assignments_config
+            .filter_map(|assignment| {
+                let app_id = match Regex::new(&assignment.appid) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!("Invalid regex for appid: {}, {}", assignment.appid, e);
+                        return None;
+                    }
+                };
+
+                let title = match Regex::new(&assignment.title) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!("Invalid regex for title: {}, {}", assignment.title, e);
+                        return None;
+                    }
+                };
+
+                Some(WorkspaceAssignment {
+                    app_id,
+                    title,
+                    workspace_id: assignment.workspace_id.clone(),
+                })
+            })
+            .collect();
+
+        Self { assignments }
+    }
+}
+
+pub fn get_workspace_assignment(
+    assignments: &WorkspaceAssignments,
+    window: &CosmicSurface,
+) -> Option<String> {
+    assignments
+        .assignments
+        .iter()
+        .find(|a| a.app_id.is_match(&window.app_id()) && a.title.is_match(&window.title()))
+        .map(|a| a.workspace_id.clone())
+}

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -106,7 +106,7 @@ pub fn has_floating_exception(exceptions: &TilingExceptions, window: &CosmicSurf
 pub struct WorkspaceAssignment {
     app_id: Regex,
     title: Regex,
-    workspace_id: String,
+    workspace_name: String,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -140,7 +140,7 @@ impl WorkspaceAssignments {
                 Some(WorkspaceAssignment {
                     app_id,
                     title,
-                    workspace_id: assignment.workspace_id.clone(),
+                    workspace_name: assignment.workspace_name.clone(),
                 })
             })
             .collect();
@@ -157,5 +157,5 @@ pub fn get_workspace_assignment(
         .assignments
         .iter()
         .find(|a| a.app_id.is_match(&window.app_id()) && a.title.is_match(&window.title()))
-        .map(|a| a.workspace_id.clone())
+        .map(|a| a.workspace_name.clone())
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -67,6 +67,7 @@ use smithay::{
     xwayland::X11Surface,
 };
 use tracing::error;
+use tracing::warn;
 
 use crate::{
     backend::render::animations::spring::{Spring, SpringParams},
@@ -2712,10 +2713,32 @@ impl Shell {
         };
 
         let pending_activation = self.pending_activations.remove(&(&window).into());
-        let workspace_handle = match pending_activation {
+        let mut workspace_handle = match pending_activation {
             Some(ActivationContext::Workspace(handle)) => Some(handle),
             _ => None,
         };
+
+        let pinned_workspace_id =
+            layout::get_workspace_assignment(&self.workspace_assignments, &window);
+
+        let pinned_workspace_handle = pinned_workspace_id //
+            .as_deref()
+            .and_then(|target_id| {
+                self.workspaces
+                    .spaces()
+                    .find(|ws| ws.id.as_deref() == Some(target_id))
+                    .map(|ws| ws.handle)
+            });
+
+        if let Some(id) = pinned_workspace_id
+            && pinned_workspace_handle.is_none()
+        {
+            warn!("Assigned workspace id not found: {}", id);
+        };
+
+        // override the pending activation handle if we have a matching pinned workspace.
+        // NOTE: if the pinned workspace is not active, it will not be made active.
+        workspace_handle = pinned_workspace_handle.or(workspace_handle);
 
         let should_be_fullscreen = output.is_some();
         let mut output = output.unwrap_or_else(|| seat.active_output());

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -12,7 +12,11 @@ use std::{
 use wayland_backend::server::ClientId;
 
 use crate::{
-    shell::{focus::FocusTarget, grabs::fullscreen_items, layout::tiling::PlaceholderType},
+    shell::{
+        focus::FocusTarget,
+        grabs::fullscreen_items,
+        layout::{WorkspaceAssignments, tiling::PlaceholderType},
+    },
     wayland::{
         handlers::data_device::{self, get_dnd_icon},
         protocols::workspace::{State as WState, WorkspaceCapabilities},
@@ -25,7 +29,10 @@ use cosmic_comp_config::{
 use cosmic_config::ConfigSet;
 use cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::TilingState;
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection, ResizeDirection};
-use cosmic_settings_config::{shortcuts, window_rules::ApplicationException};
+use cosmic_settings_config::{
+    shortcuts,
+    window_rules::{ApplicationException, WorkspaceAssignment},
+};
 use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
     backend::{input::TouchSlot, renderer::element::RenderElementStates},
@@ -289,7 +296,7 @@ pub struct Shell {
     zoom_state: Option<ZoomState>,
     appearance_conf: AppearanceConfig,
     tiling_exceptions: TilingExceptions,
-
+    workspace_assignments: WorkspaceAssignments,
     #[cfg(feature = "debug")]
     pub debug_active: bool,
 }
@@ -1579,6 +1586,9 @@ impl Shell {
 
         let tiling_exceptions = layout::TilingExceptions::new(config.tiling_exceptions.iter());
 
+        let workspace_assignments =
+            layout::WorkspaceAssignments::new(config.workspace_assignments.iter());
+
         Shell {
             workspaces: Workspaces::new(config, theme.clone()),
             seats: Seats::new(),
@@ -1601,6 +1611,7 @@ impl Shell {
             appearance_conf: config.cosmic_conf.appearance_settings,
             zoom_state: None,
             tiling_exceptions,
+            workspace_assignments,
 
             #[cfg(feature = "debug")]
             debug_active: false,
@@ -4842,6 +4853,13 @@ impl Shell {
         I: Iterator<Item = &'a ApplicationException>,
     {
         self.tiling_exceptions = layout::TilingExceptions::new(exceptions);
+    }
+
+    pub fn update_workspace_assignments<'a, I>(&mut self, assignments: I)
+    where
+        I: Iterator<Item = &'a WorkspaceAssignment>,
+    {
+        self.workspace_assignments = layout::WorkspaceAssignments::new(assignments);
     }
 
     pub fn take_presentation_feedback(

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -13,8 +13,10 @@ use wayland_backend::server::ClientId;
 
 use crate::{
     shell::{
-        element::CosmicStack, focus::FocusTarget, grabs::fullscreen_items,
-        layout::tiling::PlaceholderType,
+        element::CosmicStack,
+        focus::FocusTarget,
+        grabs::fullscreen_items,
+        layout::{WorkspaceAssignments, tiling::PlaceholderType},
     },
     utils,
     wayland::{
@@ -29,7 +31,10 @@ use cosmic_comp_config::{
 use cosmic_config::ConfigSet;
 use cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::TilingState;
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection, ResizeDirection};
-use cosmic_settings_config::{shortcuts, window_rules::ApplicationException};
+use cosmic_settings_config::{
+    shortcuts,
+    window_rules::{ApplicationException, WorkspaceAssignment},
+};
 use keyframe::{ease, functions::EaseInOutCubic};
 use smithay::{
     backend::{input::TouchSlot, renderer::element::RenderElementStates},
@@ -296,7 +301,7 @@ pub struct Shell {
     zoom_state: Option<ZoomState>,
     appearance_conf: AppearanceConfig,
     tiling_exceptions: TilingExceptions,
-
+    workspace_assignments: WorkspaceAssignments,
     #[cfg(feature = "debug")]
     pub debug_active: bool,
 }
@@ -1691,6 +1696,9 @@ impl Shell {
 
         let tiling_exceptions = layout::TilingExceptions::new(config.tiling_exceptions.iter());
 
+        let workspace_assignments =
+            layout::WorkspaceAssignments::new(config.workspace_assignments.iter());
+
         Shell {
             workspaces: Workspaces::new(config, theme.clone()),
             seats: Seats::new(),
@@ -1713,6 +1721,7 @@ impl Shell {
             appearance_conf: config.cosmic_conf.appearance_settings,
             zoom_state: None,
             tiling_exceptions,
+            workspace_assignments,
 
             #[cfg(feature = "debug")]
             debug_active: false,
@@ -5014,6 +5023,13 @@ impl Shell {
         I: Iterator<Item = &'a ApplicationException>,
     {
         self.tiling_exceptions = layout::TilingExceptions::new(exceptions);
+    }
+
+    pub fn update_workspace_assignments<'a, I>(&mut self, assignments: I)
+    where
+        I: Iterator<Item = &'a WorkspaceAssignment>,
+    {
+        self.workspace_assignments = layout::WorkspaceAssignments::new(assignments);
     }
 
     pub fn take_presentation_feedback(

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -72,6 +72,7 @@ use smithay::{
     xwayland::X11Surface,
 };
 use tracing::error;
+use tracing::warn;
 
 use crate::{
     backend::render::animations::spring::{Spring, SpringParams},
@@ -2854,10 +2855,32 @@ impl Shell {
         };
 
         let pending_activation = self.pending_activations.remove(&(&window).into());
-        let workspace_handle = match pending_activation {
+        let mut workspace_handle = match pending_activation {
             Some(ActivationContext::Workspace(handle)) => Some(handle),
             _ => None,
         };
+
+        let pinned_workspace_id =
+            layout::get_workspace_assignment(&self.workspace_assignments, &window);
+
+        let pinned_workspace_handle = pinned_workspace_id //
+            .as_deref()
+            .and_then(|target_id| {
+                self.workspaces
+                    .spaces()
+                    .find(|ws| ws.id.as_deref() == Some(target_id))
+                    .map(|ws| ws.handle)
+            });
+
+        if let Some(id) = pinned_workspace_id
+            && pinned_workspace_handle.is_none()
+        {
+            warn!("Assigned workspace id not found: {}", id);
+        };
+
+        // override the pending activation handle if we have a matching pinned workspace.
+        // NOTE: if the pinned workspace is not active, it will not be made active.
+        workspace_handle = pinned_workspace_handle.or(workspace_handle);
 
         let should_be_fullscreen = output.is_some();
         let mut output = output.unwrap_or_else(|| seat.active_output());

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2860,22 +2860,22 @@ impl Shell {
             _ => None,
         };
 
-        let pinned_workspace_id =
+        let pinned_workspace_name =
             layout::get_workspace_assignment(&self.workspace_assignments, &window);
 
-        let pinned_workspace_handle = pinned_workspace_id //
+        let pinned_workspace_handle = pinned_workspace_name //
             .as_deref()
-            .and_then(|target_id| {
+            .and_then(|target_name| {
                 self.workspaces
                     .spaces()
-                    .find(|ws| ws.id.as_deref() == Some(target_id))
+                    .find(|ws| ws.name.as_deref() == Some(target_name))
                     .map(|ws| ws.handle)
             });
 
-        if let Some(id) = pinned_workspace_id
+        if let Some(name) = pinned_workspace_name
             && pinned_workspace_handle.is_none()
         {
-            warn!("Assigned workspace id not found: {}", id);
+            warn!("Assigned workspace name not found: {}", name);
         };
 
         // override the pending activation handle if we have a matching pinned workspace.


### PR DESCRIPTION
### Related issues

- Part of: https://github.com/pop-os/cosmic-epoch/issues/847
- Closes: https://github.com/pop-os/cosmic-epoch/issues/1819
- Closes: https://github.com/pop-os/cosmic-epoch/issues/1395
- Closes: https://github.com/pop-os/cosmic-epoch/discussions/1129
- Closes: https://github.com/pop-os/cosmic-workspaces-epoch/issues/186

### Feature

Extend `WindowRules` enabling launching applications on specific pinned workspaces instead of the current active workspace.

Requires: https://github.com/pop-os/cosmic-settings-daemon/pull/137

### How to use

Get Application ID and Title:

Deprecated but works, see: https://github.com/pop-os/cosmic-protocols/issues/70#issuecomment-3521490214

```sh
$ nix-shell -p wayland pkg-config

[nix-shell:~/path/to/cosmic-protocols]$  cargo run --example toplevel-list
     Running `target/debug/examples/toplevel-list`
Toplevel ObjectId(zcosmic_toplevel_handle_v1@4278190080)
	Title: Some("cargo run --example toplevel-list")
	App ID: Some("kitty")
	States: [Activated]
	Outputs: []
	Workspaces: []
Toplevel ObjectId(zcosmic_toplevel_handle_v1@4278190082)
	Title: Some("Some webpage — Mozilla Firefox")
	App ID: Some("firefox")
	States: []
	Outputs: []
	Workspaces: []
```

Pin workspaces ~using UI or~ via file (so can set `name` field):

```sh
$ cat ~/.config/cosmic/com.system76.CosmicComp/v1/pinned_workspaces 
[
    (
        output: (
            name: "eDP-1",
            edid: None,
        ),
        tiling_enabled: true,
        id: Some("foo"),
        name: Some("terminal"),
    ),
    (
        output: (
            name: "eDP-1",
            edid: None,
        ),
        tiling_enabled: true,
        id: Some("bar"),
        name: Some("browser"),
    ),
]
```

Define Workspace Assignment configuration file with matching `name`'s, regex supported:

```sh
$ cat ~/.config/cosmic/com.system76.CosmicSettings.WindowRules/v1/workspace_assignment_custom
[
  (
    enabled: true,
    appid: "kitty",
    title: ".*",
    workspace_name: "terminal"
  ),
  (
    enabled: true,
    appid: "firefox",
    title: ".*",
    workspace_name: "browser"
  )
]
```

Disable the window rule by setting `enabled: false`.

### Behaviours

1. Workspaces are NOT created if the assigned workspace name doesn't exist. A warning will be logged and the window will be launched on the current active workspace as if the assignment didn't exist.
   For example, if workspaces `a` and `b` exist but the application config pins to `c`, then workspace `c` will NOT be added. 
   `2026-03-20T21:37:45.920671Z  WARN cosmic_comp::shell: Assigned workspace name not found: foobar1`
2. Active workspace changes if the window is launched on a different workspace. For example, on workspace `b`, launch Firefox pinned to `c`, active workspace switches to `c`.
3. `workspace_assignment_custom` is auto-reloaded when the file changes however existing windows are not moved if the assigned workspace name was changed.
4. Declarative workspace_name's: Must define in `pinned_workspaces` per #2427. Doesn't reload but does load on login. 
   - there's no code for reloading this file (I could add if desired). Changes to the file take effect on next login.
   - workspace `id` are not required for this feature but should be set to something as the UI does: `let id = crate::shell::random_workspace_id();` in `Request::SetPin` event handling here: `src/wayland/handlers/workspace.rs`

### Testing

### `flake.nix` -> `nix develop`

When rebased onto: https://github.com/pop-os/cosmic-comp/pull/2219 and using https://github.com/pop-os/cosmic-settings-daemon/pull/138

```sh
# enter dev environment
nix develop

v ~/.config/cosmic/com.system76.CosmicSettings.WindowRules/v1/workspace_assignment_custom

COSMIC_COMP=winnit cargo run

# active workspace is the first pinned one
WAYLAND_DISPLAY=2 kitty & # launches on active
WAYLAND_DISPLAY=2 firefox & # launches on workspace in background (not active)
WAYLAND_DISPLAY=wayland-2 cosmic-ext-calculator # launches on active
```

#### `flake.nix` -> `nix build`

When rebased onto: https://github.com/pop-os/cosmic-comp/pull/2219 and using https://github.com/pop-os/cosmic-settings-daemon/pull/138

```sh
# build cosmic-comp
nix build
```

Can't run the resulting binary because of missing dependencies/version clashes.

#### NixOS package overlay

1. Patching the NixOS package source with fork and branch. 
2. Build and install. 
3. Use appropriate config file. 
4. Launch applications and observe they are autostarted on workspaces other than the current active workspace.

### UI Component

Whilst the configuration file support in this PR is sufficient for my use case, I saw mention of UI support for a similar feature in: https://github.com/pop-os/cosmic-comp/issues/1292#issuecomment-3341722374
> There will be UI to do this from cosmic-settings and the tiling applet eventually.

Could that be this? https://github.com/pop-os/cosmic-settings/issues/438

Something I could pickup next perhaps. Or other window rules.

### Note to reviewers

This is my first contribution to Cosmic and I may have misunderstood or completely missed project structure/styling or other conventions. Please let me know and I'll rework accordingly. Thank you!

- "workspace assignment" naming chosen based off i3wm:
   `assign [class="<application_class>"] <workspace_number>`
- separate file `path/to/WindowRules/workspace_assignment_custom` because it appears to be convention to have a file per feature, rather than a catch all `../WindowRules/window_rules` with features: sticky, tiling exceptions, workspace assignment, etc
- left `workspace_assignment_defaults` free for implementation if required.


### AI Disclosure

No AI generated code in the development of this PR.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

