### PR TITLE
Add setting to toggle workspace wrapping

### DIFF
--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -4,13 +4,30 @@ use serde::{Deserialize, Serialize};
 
 use crate::EdidProduct;
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
     pub workspace_mode: WorkspaceMode,
     #[serde(default)]
     pub workspace_layout: WorkspaceLayout,
     #[serde(default)]
     pub action_on_typing: Action,
+    #[serde(default = "default_wraparound")]
+    pub workspace_wraparound: bool,
+}
+
+fn default_wraparound() -> bool {
+    true
+}
+
+impl Default for WorkspaceConfig {
+    fn default() -> Self {
+        Self {
+            workspace_mode: WorkspaceMode::default(),
+            workspace_layout: WorkspaceLayout::default(),
+            action_on_typing: Action::default(),
+            workspace_wraparound: default_wraparound(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -102,6 +102,12 @@ impl State {
 
     pub fn handle_swipe_action(&mut self, action: gestures::SwipeAction, seat: &Seat<State>) {
         use gestures::SwipeAction;
+        let wraparound: bool = self
+            .common
+            .config
+            .cosmic_conf
+            .workspaces
+            .workspace_wraparound;
 
         match action {
             SwipeAction::NextWorkspace => {
@@ -109,6 +115,7 @@ impl State {
                     &mut self.common.shell.write(),
                     seat,
                     true,
+                    wraparound,
                     &mut self.common.workspace_state.update(),
                 );
             }
@@ -117,6 +124,7 @@ impl State {
                     &mut self.common.shell.write(),
                     seat,
                     true,
+                    wraparound,
                     &mut self.common.workspace_state.update(),
                 );
             }
@@ -203,32 +211,26 @@ impl State {
                     &mut self.common.shell.write(),
                     seat,
                     false,
+                    self.common
+                        .config
+                        .cosmic_conf
+                        .workspaces
+                        .workspace_wraparound,
                     &mut self.common.workspace_state.update(),
                 );
-                if next.is_err() {
-                    if propagate {
-                        if let Some(inferred) = pattern.inferred_direction() {
-                            self.handle_shortcut_action(
-                                Action::SwitchOutput(inferred),
-                                seat,
-                                serial,
-                                time,
-                                pattern,
-                                direction,
-                                true,
-                            )
-                        };
-                    } else {
-                        self.handle_shortcut_action(
-                            Action::Workspace(1),
-                            seat,
-                            serial,
-                            time,
-                            pattern,
-                            direction,
-                            false,
-                        )
-                    }
+                if next.is_err()
+                    && propagate
+                    && let Some(inferred) = pattern.inferred_direction()
+                {
+                    self.handle_shortcut_action(
+                        Action::SwitchOutput(inferred),
+                        seat,
+                        serial,
+                        time,
+                        pattern,
+                        direction,
+                        true,
+                    )
                 }
             }
 
@@ -248,33 +250,27 @@ impl State {
                     &mut self.common.shell.write(),
                     seat,
                     false,
+                    self.common
+                        .config
+                        .cosmic_conf
+                        .workspaces
+                        .workspace_wraparound,
                     &mut self.common.workspace_state.update(),
                 );
-                if previous.is_err() {
-                    if propagate {
-                        if let Some(inferred) = pattern.inferred_direction() {
-                            self.handle_shortcut_action(
-                                Action::SwitchOutput(inferred),
-                                seat,
-                                serial,
-                                time,
-                                pattern,
-                                direction,
-                                true,
-                            )
-                        };
-                    } else {
-                        self.handle_shortcut_action(
-                            Action::LastWorkspace,
-                            seat,
-                            serial,
-                            time,
-                            pattern,
-                            direction,
-                            false,
-                        )
-                    }
-                }
+                if previous.is_err()
+                    && propagate
+                    && let Some(inferred) = pattern.inferred_direction()
+                {
+                    self.handle_shortcut_action(
+                        Action::SwitchOutput(inferred),
+                        seat,
+                        serial,
+                        time,
+                        pattern,
+                        direction,
+                        true,
+                    )
+                };
             }
 
             x @ Action::MoveToWorkspace(_) | x @ Action::SendToWorkspace(_) => {
@@ -398,20 +394,29 @@ impl State {
                         }
                     }
                     Err(_) => {
-                        // cycle through
-                        self.handle_shortcut_action(
-                            if matches!(x, Action::MoveToNextWorkspace) {
-                                Action::MoveToWorkspace(1)
-                            } else {
-                                Action::SendToWorkspace(1)
-                            },
-                            seat,
-                            serial,
-                            time,
-                            pattern,
-                            direction,
-                            false,
-                        )
+                        let wraparound = self
+                            .common
+                            .config
+                            .cosmic_conf
+                            .workspaces
+                            .workspace_wraparound;
+
+                        if wraparound {
+                            // cycle through
+                            self.handle_shortcut_action(
+                                if matches!(x, Action::MoveToNextWorkspace) {
+                                    Action::MoveToWorkspace(1)
+                                } else {
+                                    Action::SendToWorkspace(1)
+                                },
+                                seat,
+                                serial,
+                                time,
+                                pattern,
+                                direction,
+                                false,
+                            )
+                        }
                     }
                 }
             }
@@ -480,20 +485,29 @@ impl State {
                         }
                     }
                     Err(_) => {
-                        // cycle through
-                        self.handle_shortcut_action(
-                            if matches!(x, Action::MoveToPreviousWorkspace) {
-                                Action::MoveToLastWorkspace
-                            } else {
-                                Action::SendToLastWorkspace
-                            },
-                            seat,
-                            serial,
-                            time,
-                            pattern,
-                            direction,
-                            false,
-                        )
+                        let wraparound = self
+                            .common
+                            .config
+                            .cosmic_conf
+                            .workspaces
+                            .workspace_wraparound;
+
+                        if wraparound {
+                            // cycle through
+                            self.handle_shortcut_action(
+                                if matches!(x, Action::MoveToPreviousWorkspace) {
+                                    Action::MoveToLastWorkspace
+                                } else {
+                                    Action::SendToLastWorkspace
+                                },
+                                seat,
+                                serial,
+                                time,
+                                pattern,
+                                direction,
+                                false,
+                            )
+                        }
                     }
                 }
             }
@@ -1096,6 +1110,7 @@ fn to_next_workspace(
     shell: &mut Shell,
     seat: &Seat<State>,
     gesture: bool,
+    wraparound: bool,
     workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
 ) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
     let current_output = seat.active_output();
@@ -1103,7 +1118,7 @@ fn to_next_workspace(
     let mut workspace = active.checked_add(1).ok_or(InvalidWorkspaceIndex)?;
 
     if workspace >= shell.workspaces.len(&current_output) {
-        workspace = 0;
+        workspace = if wraparound { 0 } else { active }
     }
     if workspace == active {
         return Err(InvalidWorkspaceIndex);
@@ -1125,17 +1140,20 @@ fn to_previous_workspace(
     shell: &mut Shell,
     seat: &Seat<State>,
     gesture: bool,
+    wraparound: bool,
     workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
 ) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
     let current_output = seat.active_output();
     let active = shell.workspaces.active_num(&current_output).1;
-    let workspace = active.checked_sub(1).unwrap_or(
+    let workspace = active.checked_sub(1).unwrap_or(if wraparound {
         shell
             .workspaces
             .len(&current_output)
             .checked_sub(1)
-            .ok_or(InvalidWorkspaceIndex)?,
-    );
+            .ok_or(InvalidWorkspaceIndex)?
+    } else {
+        0
+    });
 
     if workspace == active {
         return Err(InvalidWorkspaceIndex);


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This adds a setting to disable workspace wrapping.

issue: https://github.com/pop-os/cosmic-settings/issues/1050

changes:
* Adds workspace_wraparound flag to WorkspaceConfig, similar to WorkspaceLayout
* Changes to_next_workspace and to_previous_workspace to use this value

I tested that it works with keyboard shortcuts and gestures, but did not test it with multiple monitors.

There's a visual bug where if you use a gesture while an animation is still playing, it will play the workspace switching animation despite being on the last workspace. I'm pretty sure this was also the case before wrapping was added.