### PR TITLE
refactor: nix flake for build and dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#32283d76a8d0342da74c4cc022a533c52dcf378f"
+source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#32283d76a8d0342da74c4cc022a533c52dcf378f"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cosmic-config = { git = "https://github.com/pop-os/libcosmic", features = [
     "calloop",
     "macro",
 ] }
-cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = [
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = [
     "server",
 ] }
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
@@ -141,9 +141,6 @@ inherits = "release"
 
 [profile.release]
 lto = "fat"
-
-[patch."https://github.com/pop-os/cosmic-protocols"]
-cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "e3d461a" }

--- a/flake.lock
+++ b/flake.lock
@@ -2,31 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772624091,
-        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -39,7 +24,9 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1772775058,

--- a/flake.lock
+++ b/flake.lock
@@ -1,42 +1,27 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1724974107,
-        "narHash": "sha256-69+1W0Ao5K9su569YUfUPANeN/Ea7aKu7xIZP1MSl9o=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "63396562b8e08efda3b3c66e32661b8a513055de",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725067332,
-        "narHash": "sha256-bMi5zhDwR6jdmN5mBHEu9gQQf9CibIEasA/6mc34Iek=",
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "192e7407cc66e2eccc3a6c5ad3834dd62fae3800",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -46,47 +31,22 @@
         "type": "github"
       }
     },
-    "parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1725024810,
-        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "crane": "crane",
-        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "parts": "parts",
-        "rust": "rust"
+        "rust-overlay": "rust-overlay"
       }
     },
-    "rust": {
+    "rust-overlay": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1724984647,
-        "narHash": "sha256-BC6MUq0CTdmAu/cueVcdWTI+S95s0mJcn19SoEgd7gU=",
+        "lastModified": 1772775058,
+        "narHash": "sha256-i+I9RYN8kYb9/9kibkxd0avkkislD1tyWojSVgIy160=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "87b6cffc276795b46ef544d7ed8d7fed6ad9c8e4",
+        "rev": "629bbb7f9d02787a54e28398b411da849246253b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,12 @@
   description = "Compositor for the COSMIC desktop environment";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
-
-  nixConfig.bash-prompt-suffix = "[nix]: "; # shows when inside of nix shell
 
   outputs =
     {
@@ -23,18 +24,21 @@
 
       pkgsForSystem =
         system:
-        (import nixpkgs {
+        import nixpkgs {
           inherit system;
           overlays = [ (import rust-overlay) ];
-        });
+        };
 
       commonFor =
         system:
         let
-          pkgs = (pkgsForSystem system);
+          pkgs = pkgsForSystem system;
           rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        in
+        {
+          inherit pkgs rustToolchain;
+
           buildInputs = with pkgs; [
-            rustToolchain
             libdisplay-info
             libinput
             libgbm
@@ -42,8 +46,9 @@
             fontconfig
             pixman
             stdenv.cc.cc.lib
-            seatd # For libseat
-            systemd # For libudev
+            seatd
+            systemd
+            udev
             wayland
           ];
 
@@ -54,43 +59,35 @@
           ];
 
           runtimeDependencies = with pkgs; [
-            libglvnd # For libEGL
-            wayland # winit->wayland-sys wants to dlopen libwayland-egl.so
-            # for running in X11
+            libglvnd
+            wayland
             libx11
             libxcb
             libxcursor
             libxi
             libxkbcommon
-            xrdb
-            # for vulkan backend
+            xorg.xrdb
             vulkan-loader
           ];
-        in
-        {
-          inherit
-            pkgs
-            rustToolchain
-            buildInputs
-            nativeBuildInputs
-            runtimeDependencies
-            ;
         };
     in
     {
       packages = forAllSystems (
         system:
         let
-          c = (commonFor system);
+          c = commonFor system;
           rustPlatform = c.pkgs.makeRustPlatform {
             cargo = c.rustToolchain;
             rustc = c.rustToolchain;
           };
         in
-        rec {
-          default = cosmic-comp;
+        {
+          default = self.packages.${system}.cosmic-comp;
+
           cosmic-comp = rustPlatform.buildRustPackage {
-            name = "cosmic-comp";
+            pname = "cosmic-comp";
+            version = "1.0.8-dev";
+
             src = c.pkgs.lib.fileset.toSource {
               root = ./.;
               fileset = c.pkgs.lib.fileset.unions [
@@ -109,9 +106,26 @@
               allowBuiltinFetchGit = true;
             };
 
+            separateDebugInfo = true;
+
             buildInputs = c.buildInputs;
             nativeBuildInputs = c.nativeBuildInputs;
             runtimeDependencies = c.runtimeDependencies;
+
+            makeFlags = [
+              "prefix=${placeholder "out"}"
+              "CARGO_TARGET_DIR=target/${c.pkgs.stdenv.hostPlatform.rust.cargoShortTarget}"
+            ];
+
+            dontCargoInstall = true;
+
+            meta = with c.pkgs.lib; {
+              description = "Compositor for the COSMIC desktop environment";
+              homepage = "https://github.com/pop-os/cosmic-comp";
+              license = licenses.gpl3Only;
+              platforms = platforms.linux;
+              mainProgram = "cosmic-comp";
+            };
           };
         }
       );
@@ -119,17 +133,34 @@
       devShells = forAllSystems (
         system:
         let
-          c = (commonFor system);
+          c = commonFor system;
         in
         {
           default = c.pkgs.mkShell {
-            buildInputs = c.buildInputs;
             inputsFrom = [ self.packages.${system}.cosmic-comp ];
 
+            packages = with c.pkgs; [
+              c.rustToolchain
+              rust-analyzer
+              cargo-watch
+            ];
+
             LD_LIBRARY_PATH = c.pkgs.lib.makeLibraryPath c.runtimeDependencies;
-            RUSTFLAGS = "-C link-arg=-Wl,-rpath,${c.pkgs.lib.makeLibraryPath c.runtimeDependencies}";
+
+            shellHook = ''
+              echo "COSMIC Compositor development environment"
+              echo "Run 'cargo build' to build, 'cargo test' to test"
+            '';
           };
         }
       );
+
+      # Formatter for 'nix fmt'
+      formatter = forAllSystems (system: (pkgsForSystem system).nixfmt-rfc-style);
+
+      # Overlay for use in other flakes
+      overlays.default = final: prev: {
+        cosmic-comp = self.packages.${prev.system}.cosmic-comp;
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
             libxcursor
             libxi
             libxkbcommon
-            xorg.xrdb
+            xrdb
             vulkan-loader
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -91,13 +91,14 @@
             src = c.pkgs.lib.fileset.toSource {
               root = ./.;
               fileset = c.pkgs.lib.fileset.unions [
+                ./cosmic-comp-config
+                ./resources
                 ./src
-                ./build.rs
-                ./i18n.toml
                 ./Cargo.toml
                 ./Cargo.lock
-                ./resources
-                ./cosmic-comp-config
+                ./Makefile
+                ./build.rs
+                ./i18n.toml
               ];
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,7 @@
               root = ./.;
               fileset = c.pkgs.lib.fileset.unions [
                 ./cosmic-comp-config
+                ./data
                 ./resources
                 ./src
                 ./Cargo.toml

--- a/flake.nix
+++ b/flake.nix
@@ -2,54 +2,100 @@
   description = "Compositor for the COSMIC desktop environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-
-    parts.url = "github:hercules-ci/flake-parts";
-    parts.inputs.nixpkgs-lib.follows = "nixpkgs";
-
-    crane.url = "github:ipetkov/crane";
-
-    rust.url = "github:oxalica/rust-overlay";
-    rust.inputs.nixpkgs.follows = "nixpkgs";
-
-    nix-filter.url = "github:numtide/nix-filter";
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
+  nixConfig.bash-prompt-suffix = "[nix]: "; # shows when inside of nix shell
+
   outputs =
-    inputs@{
+    {
       self,
       nixpkgs,
-      parts,
-      crane,
-      rust,
-      nix-filter,
-      ...
+      rust-overlay,
     }:
-    parts.lib.mkFlake { inherit inputs; } {
-      systems = [
-        "aarch64-linux"
+    let
+      supportedSystems = [
         "x86_64-linux"
+        "aarch64-linux"
       ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      perSystem =
-        {
-          self',
-          lib,
-          system,
-          ...
-        }:
+      pkgsForSystem =
+        system:
+        (import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        });
+
+      commonFor =
+        system:
         let
-          pkgs = nixpkgs.legacyPackages.${system}.extend rust.overlays.default;
-          rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-          craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
-          craneArgs = {
-            pname = "cosmic-comp";
-            version = self.rev or "dirty";
+          pkgs = (pkgsForSystem system);
+          rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          buildInputs = with pkgs; [
+            rustToolchain
+            libdisplay-info
+            libinput
+            libgbm
+            libxkbcommon
+            fontconfig
+            pixman
+            stdenv.cc.cc.lib
+            seatd # For libseat
+            systemd # For libudev
+            wayland
+          ];
 
-            src = nix-filter.lib.filter {
+          nativeBuildInputs = with pkgs; [
+            autoPatchelfHook
+            cmake
+            pkg-config
+          ];
+
+          runtimeDependencies = with pkgs; [
+            libglvnd # For libEGL
+            wayland # winit->wayland-sys wants to dlopen libwayland-egl.so
+            # for running in X11
+            libx11
+            libxcb
+            libxcursor
+            libxi
+            libxkbcommon
+            xrdb
+            # for vulkan backend
+            vulkan-loader
+          ];
+        in
+        {
+          inherit
+            pkgs
+            rustToolchain
+            buildInputs
+            nativeBuildInputs
+            runtimeDependencies
+            ;
+        };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          c = (commonFor system);
+          rustPlatform = c.pkgs.makeRustPlatform {
+            cargo = c.rustToolchain;
+            rustc = c.rustToolchain;
+          };
+        in
+        rec {
+          default = cosmic-comp;
+          cosmic-comp = rustPlatform.buildRustPackage {
+            name = "cosmic-comp";
+            src = c.pkgs.lib.fileset.toSource {
               root = ./.;
-              include = [
+              fileset = c.pkgs.lib.fileset.unions [
                 ./src
+                ./build.rs
                 ./i18n.toml
                 ./Cargo.toml
                 ./Cargo.lock
@@ -58,59 +104,32 @@
               ];
             };
 
-            nativeBuildInputs = with pkgs; [
-              pkg-config
-              autoPatchelfHook
-              cmake
-            ];
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
 
-            buildInputs = with pkgs; [
-              wayland
-              systemd # For libudev
-              seatd # For libseat
-              libxkbcommon
-              libinput
-              mesa # For libgbm
-              fontconfig
-              stdenv.cc.cc.lib
-              pixman
-              libdisplay-info
-            ];
-
-            runtimeDependencies = with pkgs; [
-              libglvnd # For libEGL
-              wayland # winit->wayland-sys wants to dlopen libwayland-egl.so
-              # for running in X11
-              xorg.libX11
-              xorg.libXcursor
-              xorg.libxcb
-              xorg.libXi
-              libxkbcommon
-              # for vulkan backend
-              vulkan-loader
-            ];
+            buildInputs = c.buildInputs;
+            nativeBuildInputs = c.nativeBuildInputs;
+            runtimeDependencies = c.runtimeDependencies;
           };
+        }
+      );
 
-          cargoArtifacts = craneLib.buildDepsOnly craneArgs;
-          cosmic-comp = craneLib.buildPackage (craneArgs // { inherit cargoArtifacts; });
+      devShells = forAllSystems (
+        system:
+        let
+          c = (commonFor system);
         in
         {
-          apps.cosmic-comp = {
-            type = "app";
-            program = lib.getExe self'.packages.default;
+          default = c.pkgs.mkShell {
+            buildInputs = c.buildInputs;
+            inputsFrom = [ self.packages.${system}.cosmic-comp ];
+
+            LD_LIBRARY_PATH = c.pkgs.lib.makeLibraryPath c.runtimeDependencies;
+            RUSTFLAGS = "-C link-arg=-Wl,-rpath,${c.pkgs.lib.makeLibraryPath c.runtimeDependencies}";
           };
-
-          checks.cosmic-comp = cosmic-comp;
-          packages.default = cosmic-comp;
-
-          devShells.default = craneLib.devShell {
-            LD_LIBRARY_PATH = lib.makeLibraryPath (
-              __concatMap (d: d.runtimeDependencies) (__attrValues self'.checks)
-            );
-
-            # include build inputs
-            inputsFrom = [ cosmic-comp ];
-          };
-        };
+        }
+      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,6 @@
             packages = with c.pkgs; [
               c.rustToolchain
               rust-analyzer
-              cargo-watch
             ];
 
             LD_LIBRARY_PATH = c.pkgs.lib.makeLibraryPath c.runtimeDependencies;

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
             systemd
             udev
             wayland
+            xrdb
           ];
 
           nativeBuildInputs = with pkgs; [
@@ -66,7 +67,7 @@
             libxcursor
             libxi
             libxkbcommon
-            xorg.xrdb
+            xrdb
             vulkan-loader
           ];
         };
@@ -75,10 +76,10 @@
       packages = forAllSystems (
         system:
         let
-          c = commonFor system;
-          rustPlatform = c.pkgs.makeRustPlatform {
-            cargo = c.rustToolchain;
-            rustc = c.rustToolchain;
+          common = commonFor system;
+          rustPlatform = common.pkgs.makeRustPlatform {
+            cargo = common.rustToolchain;
+            rustc = common.rustToolchain;
           };
         in
         {
@@ -86,18 +87,20 @@
 
           cosmic-comp = rustPlatform.buildRustPackage {
             pname = "cosmic-comp";
-            version = "1.0.8-dev";
+            version = "1.0.0-dev";
 
-            src = c.pkgs.lib.fileset.toSource {
+            src = common.pkgs.lib.fileset.toSource {
               root = ./.;
-              fileset = c.pkgs.lib.fileset.unions [
+              fileset = common.pkgs.lib.fileset.unions [
+                ./cosmic-comp-config
+                ./data
+                ./resources
                 ./src
-                ./build.rs
-                ./i18n.toml
                 ./Cargo.toml
                 ./Cargo.lock
-                ./resources
-                ./cosmic-comp-config
+                ./Makefile
+                ./build.rs
+                ./i18n.toml
               ];
             };
 
@@ -106,20 +109,18 @@
               allowBuiltinFetchGit = true;
             };
 
-            separateDebugInfo = true;
+            dontCargoInstall = true;
 
-            buildInputs = c.buildInputs;
-            nativeBuildInputs = c.nativeBuildInputs;
-            runtimeDependencies = c.runtimeDependencies;
+            inherit (common) buildInputs nativeBuildInputs runtimeDependencies;
+
+            separateDebugInfo = true;
 
             makeFlags = [
               "prefix=${placeholder "out"}"
-              "CARGO_TARGET_DIR=target/${c.pkgs.stdenv.hostPlatform.rust.cargoShortTarget}"
+              "CARGO_TARGET_DIR=target/${common.pkgs.stdenv.hostPlatform.rust.cargoShortTarget}"
             ];
 
-            dontCargoInstall = true;
-
-            meta = with c.pkgs.lib; {
+            meta = with common.pkgs.lib; {
               description = "Compositor for the COSMIC desktop environment";
               homepage = "https://github.com/pop-os/cosmic-comp";
               license = licenses.gpl3Only;
@@ -133,19 +134,18 @@
       devShells = forAllSystems (
         system:
         let
-          c = commonFor system;
+          common = commonFor system;
         in
         {
-          default = c.pkgs.mkShell {
+          default = common.pkgs.mkShell {
             inputsFrom = [ self.packages.${system}.cosmic-comp ];
 
-            packages = with c.pkgs; [
-              c.rustToolchain
+            packages = with common.pkgs; [
+              common.rustToolchain
               rust-analyzer
-              cargo-watch
             ];
 
-            LD_LIBRARY_PATH = c.pkgs.lib.makeLibraryPath c.runtimeDependencies;
+            LD_LIBRARY_PATH = common.pkgs.lib.makeLibraryPath common.runtimeDependencies;
 
             shellHook = ''
               echo "COSMIC Compositor development environment"

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
 
           cosmic-comp = rustPlatform.buildRustPackage {
             pname = "cosmic-comp";
-            version = "1.0.0-dev";
+            version = "1.m.M-dev";
 
             src = common.pkgs.lib.fileset.toSource {
               root = ./.;


### PR DESCRIPTION
Across the Cosmic repo's the flakes are all a little different and there are various PR's (e.g: #1993  #1374) .
If the maintainers are happy to have the files, then I think it would be great to align them.

I think basic criteria should be something like:
- no unnecessary dependencies where standard nix will do (e.g: crane, flake-utils for systems)
- no optional developer tools, e.g: `bacon` or similar
- `nix build` support
- `nix develop` support
- if possible: a canonical source for nixpkgs - is this practical?

Open to suggestions and alternatives.

### AI Disclosure

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

