### PR TITLE
session: Make sure to mark the socket as CLOEXEC early

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ impl State {
 
             // potentially tell the session we are setup now
             if let Err(err) =
-                session::setup_socket(self.common.event_loop_handle.clone(), &self.common)
+                session::run_socket(self.common.event_loop_handle.clone(), &self.common)
             {
                 warn!(?err, "Failed to setup cosmic-session communication");
             }
@@ -147,6 +147,11 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
     tracy_client::Client::start();
 
     utils::rlimit::increase_nofile_limit();
+    // This needs to be done before any potential program launches
+    // (e.g. Xwayland) as it handles passed file descriptors.
+    if let Err(err) = session::setup_socket() {
+        warn!("Session error: {:?}", err);
+    };
 
     // init hook globals
     hooks::HOOKS.set(hooks)

--- a/src/session.rs
+++ b/src/session.rs
@@ -72,18 +72,24 @@ pub fn get_env(common: &Common) -> Result<HashMap<String, String>> {
     Ok(env)
 }
 
-pub fn setup_socket(handle: LoopHandle<State>, common: &Common) -> Result<()> {
+pub fn setup_socket() -> Result<()> {
+    if let Ok(fd_num) = std::env::var("COSMIC_SESSION_SOCK")
+        && let Ok(fd) = fd_num.parse::<RawFd>()
+    {
+        let res = unsafe { set_cloexec(fd) }.with_context(|| "Failed to setup session socket");
+        if res.is_err() {
+            unsafe { rustix::io::close(fd) };
+        }
+        res
+    } else {
+        Ok(())
+    }
+}
+
+pub fn run_socket(handle: LoopHandle<State>, common: &Common) -> Result<()> {
     if let Ok(fd_num) = std::env::var("COSMIC_SESSION_SOCK") {
         if let Ok(fd) = fd_num.parse::<RawFd>() {
-            let mut session_socket = match unsafe { set_cloexec(fd) } {
-                // CLOEXEC worked and we can startup with session IPC
-                Ok(_) => unsafe { UnixStream::from_raw_fd(fd) },
-                // CLOEXEC didn't work, something is wrong with the fd, just close it
-                Err(err) => {
-                    unsafe { rustix::io::close(fd) };
-                    return Err(err).with_context(|| "Failed to setup session socket");
-                }
-            };
+            let mut session_socket = unsafe { UnixStream::from_raw_fd(fd) };
 
             let env = get_env(common)?;
             let message = serde_json::to_string(&Message::SetEnv { variables: env })


### PR DESCRIPTION
Presumably fixes #2156 by making sure we set `cloexec` on the inherited socket before launching Xwayland.

Not sure why this would seemingly only a single person, but the previous logic definitely wasn't correct.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

