### PR TITLE
fix: use saturating_sub for remaining Duration arithmetic in timings.rs

### DIFF
--- a/src/backend/kms/surface/timings.rs
+++ b/src/backend/kms/surface/timings.rs
@@ -141,7 +141,7 @@ impl Timings {
         if let Some(frame) = self.pending_frame.as_mut() {
             frame.render_duration_draw = Some(
                 Time::elapsed(&frame.render_start, clock.now())
-                    - frame.render_duration_elements.unwrap_or(Duration::ZERO),
+                    .saturating_sub(frame.render_duration_elements.unwrap_or(Duration::ZERO)),
             );
         }
     }
@@ -305,13 +305,13 @@ impl Timings {
                     now = ?orig_now,
                     ?last_presentation_time,
                     "got a 2+ early VBlank, {:?} until presentation",
-                    last_presentation_time - now,
+                    last_presentation_time.saturating_sub(now),
                 );
                 now = last_presentation_time + Duration::from_nanos(refresh_interval_ns);
             }
         }
 
-        let since_last = now - last_presentation_time;
+        let since_last = now.saturating_sub(last_presentation_time);
         let since_last_ns =
             since_last.as_secs() * 1_000_000_000 + u64::from(since_last.subsec_nanos());
         let to_next_ns = (since_last_ns / refresh_interval_ns + 1) * refresh_interval_ns;
@@ -321,7 +321,7 @@ impl Timings {
         if self.vrr && to_next_ns > refresh_interval_ns {
             Duration::ZERO
         } else {
-            last_presentation_time + Duration::from_nanos(to_next_ns) - now
+            (last_presentation_time + Duration::from_nanos(to_next_ns)).saturating_sub(now)
         }
     }
 


### PR DESCRIPTION
## Summary

PR #1308 fixed the overflow in `avg_frametime()` but left four bare `Duration` subtractions in `timings.rs` that panic with **"overflow when subtracting durations"** when the GPU returns bad timestamps.

**Observed on:** AMD GPU (amdgpu) with DMCUB firmware errors on boot. The display microcontroller returns corrupted timing data during early initialization, causing `Time::elapsed()` to return `Duration::ZERO` (via its internal saturating_sub). Subtracting a positive `render_duration_elements` from that then underflows.

### Crash backtrace
```
thread 'surface-eDP-1' panicked at 'overflow when subtracting durations'
  6: core::option::expect_failed
  7: cosmic_comp::backend::kms::surface::SurfaceThreadState::redraw
```
Immediately followed by: `amdgpu: [drm] *ERROR* dc_dmub_srv_log_diagnostic_data: DMCUB error`

### Changes

Replace all four remaining `-` operators on `Duration` with `saturating_sub()`:

1. **`draw_done()` (line 144)** — primary crash site. `Time::elapsed() - render_duration_elements` underflows when clock inverts.
2. **`next_presentation_time()` (line 308)** — early VBlank error log.
3. **`next_presentation_time()` (line 314)** — `since_last` calculation.
4. **`next_presentation_time()` (line 324)** — return value calculation.

This matches the defensive style already used elsewhere in the file (e.g. `past_min_render_time`, `next_render_time`).

Partially addresses #649.

## Test plan
- [x] Builds cleanly with `cargo build --release`
- [ ] Reboot test on affected hardware (AMD GPU with DMCUB errors)
- [ ] Confirm no panics in `journalctl -b -t cosmic-comp | grep panic`