### PR TITLE
WIP Stop image-copy sessions immediately when output is removed

### DIFF
--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -42,7 +42,9 @@ mod render;
 mod user_data;
 pub use self::render::*;
 use self::user_data::*;
-pub use self::user_data::{FrameHolder, ImageCopySessions, SessionData, SessionHolder};
+pub use self::user_data::{
+    FrameHolder, ImageCopySessions, ImageCopySessionsData, SessionData, SessionHolder,
+};
 
 impl ImageCopyCaptureHandler for State {
     fn image_copy_capture_state(&mut self) -> &mut ImageCopyCaptureState {

--- a/src/wayland/handlers/image_copy_capture/user_data.rs
+++ b/src/wayland/handlers/image_copy_capture/user_data.rs
@@ -16,7 +16,7 @@ use smithay::{
 
 use crate::shell::{CosmicSurface, Workspace};
 
-type ImageCopySessionsData = RefCell<ImageCopySessions>;
+pub type ImageCopySessionsData = RefCell<ImageCopySessions>;
 type PendingImageCopyBuffers = Mutex<Vec<(SessionRef, Frame)>>;
 
 pub type SessionData = Mutex<SessionUserData>;

--- a/src/wayland/protocols/output_configuration/mod.rs
+++ b/src/wayland/protocols/output_configuration/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::wayland::handlers::image_copy_capture::{FrameHolder, ImageCopySessionsData};
 use calloop::{
     LoopHandle,
     timer::{TimeoutAction, Timer},
@@ -253,6 +254,12 @@ where
                     let mut inner = inner.lock().unwrap();
                     inner.enabled = false;
                     output.leave_all();
+                    output.take_pending_frames();
+                    *output
+                        .user_data()
+                        .get::<ImageCopySessionsData>()
+                        .unwrap()
+                        .borrow_mut() = Default::default();
                     if let Some(global) = inner.global.take() {
                         remove_global_with_timer(&self.dh, &self.event_loop_handle, global);
                     }


### PR DESCRIPTION
For now, this change is just for testing https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/291.

This may not be the best solution; even if we don't do this, we want to fix reference cycles like https://github.com/Smithay/smithay/pull/1976, and probably the use of strong `Ouput`s in the workspace/toplevel info protocols. And free workspace udata when the global is disabled instead of when it is removed.

Which other changes like that, this should be entirely unnecessary, though it wouldn't hurt.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

