### PR TITLE
fix: remove keyboard grab serial check that blocks popup menus

### DIFF
--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -107,13 +107,11 @@ impl XdgShellHandler for State {
             match ret {
                 Ok(mut grab) => {
                     if let Some(keyboard) = seat.get_keyboard() {
-                        if keyboard.is_grabbed()
-                            && !(keyboard.has_grab(serial)
-                                || keyboard.has_grab(grab.previous_serial().unwrap_or(serial)))
-                        {
-                            grab.ungrab(PopupUngrabStrategy::All);
-                            return;
-                        }
+                        // Do not reject the popup grab based on keyboard grab state.
+                        // Smithay's grab_popup() already validated the popup chain.
+                        // Keyboard grabs from other subsystems (input method, stale
+                        // PopupKeyboardGrab, etc.) are unrelated to popup validity and
+                        // the new PopupKeyboardGrab will replace them.
                         Shell::set_focus(
                             self,
                             grab.current_grab().as_ref(),


### PR DESCRIPTION
## Summary

- Remove the keyboard grab serial validation in the `xdg_popup` grab handler that incorrectly rejects popup grabs when an unrelated keyboard grab is active
- The check was blocking dropdown menus and context menus in apps using input methods (IBus, Fcitx) or after a previous popup was closed

## Root Cause

The keyboard grab serial check (`keyboard.is_grabbed() && !keyboard.has_grab(serial)`) rejects popup grabs whenever **any** keyboard grab is active with a non-matching serial. Two common scenarios trigger this:

1. **Input method keyboard grab** (`zwp_input_method_v2::GrabKeyboard`): Always active when an IME is running. Its serial never matches the popup's button-press serial, so every popup grab is rejected.

2. **Stale `PopupKeyboardGrab`**: After a popup is closed, the `PopupKeyboardGrab` lingers on the keyboard until the next keyboard event (Smithay only cleans it up on `input()` or `set_focus()`). Any subsequent popup grab is rejected because the stale grab's serial doesn't match.

## Why this is safe

Smithay's `grab_popup()` already validates the popup chain (parent hierarchy, topmost popup check, dismissed parent check) **before** this code runs. The keyboard grab state is orthogonal to popup validity — it controls keyboard event routing, not whether a popup should open. The new `PopupKeyboardGrab` replaces whatever keyboard grab was active.

Other compositors (wlroots, niri) do not perform this check. wlroots disabled serial validation entirely ([wlroots#755](https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/755)).

## Affected apps

- Any app when an input method is active (Qt, GTK, wxWidgets)
- LibreOffice Writer, Calc, Math (menus stop working after first use)
- OrcaSlicer and other wxWidgets apps with focusable child widgets
- Any app where menus work once then fail on subsequent attempts

## Reproducer

```cpp
// wxWidgets minimal reproducer — menus fail after first open
#include <wx/wx.h>
class App : public wxApp {
public:
    bool OnInit() override {
        auto *f = new wxFrame(nullptr, wxID_ANY, "Test", wxDefaultPosition, wxSize(800, 600));
        auto *mb = new wxMenuBar;
        auto *fm = new wxMenu;
        fm->Append(wxID_EXIT, "Exit");
        mb->Append(fm, "&File");
        f->SetMenuBar(mb);
        new wxWindow(f, wxID_ANY);  // focusable child triggers the bug
        f->Bind(wxEVT_MENU, [f](wxCommandEvent&) { f->Close(); }, wxID_EXIT);
        f->Show();
        return true;
    }
};
wxIMPLEMENT_APP(App);
```

## Test plan

- [x] wxWidgets reproducer — File menu opens reliably on repeated attempts
- [x] LibreOffice Writer — dropdown menus work with IME active
- [x] Click-outside-to-dismiss still works (pointer grab check is unchanged)
- [x] `cargo clippy --all-features -- -D warnings` passes
- [ ] Nested submenus (File → Recent Documents → ...) work correctly
- [ ] Native COSMIC app menus still work

Fixes #1211
Fixes #1763