### PR TITLE
fix: clean up pending_windows for surfaces that were never mapped

### DIFF
--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -315,6 +315,11 @@ impl XdgShellHandler for State {
             let mut shell = self.common.shell.write();
             let seat = shell.seats.last_active().clone();
 
+            // Clean up pending_windows for surfaces that were never mapped.
+            shell
+                .pending_windows
+                .retain(|pending| pending.surface != surface);
+
             let output = shell
                 .visible_output_for_surface(surface.wl_surface())
                 .cloned();


### PR DESCRIPTION
If Proton VPN is configured to "Start app minimized", it creates a surface and destroys it right away, which leaves the surface in "pending". Later on when you click on "show" from the context menu in the system tray, this stale pending_window will cause it to not show.
This seems to be the right fix. I tested it with Proton VPN.

- fixes https://github.com/pop-os/cosmic-epoch/issues/3079
- relevant mattermost chat https://chat.pop-os.org/pop-os/pl/u6s3uwuku7bnxy4htdq4ninwha

I had to create this PR again, since my main account keeps getting suspended by some bot. 

_____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

