### PR TITLE
feat(input): add 4-finger swipe to toggle workspace overview

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -120,6 +120,9 @@ impl State {
                     &mut self.common.workspace_state.update(),
                 );
             }
+            SwipeAction::WorkspaceOverview => {
+                // Handled at gesture end, not during progressive updates
+            }
         }
     }
 

--- a/src/input/gestures/mod.rs
+++ b/src/input/gestures/mod.rs
@@ -16,6 +16,7 @@ pub struct SwipeEvent {
 pub enum SwipeAction {
     NextWorkspace,
     PrevWorkspace,
+    WorkspaceOverview,
 }
 
 #[derive(Debug, Clone)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -979,7 +979,10 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    if event.fingers() >= 3 && !workspace_overview_is_open(&seat.active_output()) {
+                    if event.fingers() >= 3
+                        && (!workspace_overview_is_open(&seat.active_output())
+                            || event.fingers() >= 4)
+                    {
                         self.common.gesture_state = Some(GestureState::new(event.fingers()));
                     } else {
                         let serial = SERIAL_COUNTER.next_serial();
@@ -1024,7 +1027,13 @@ impl State {
                             activate_action = match gesture_state.fingers {
                                 3 => None, // TODO: 3 finger gestures
                                 4 => {
-                                    if self.common.config.cosmic_conf.workspaces.workspace_layout
+                                    if workspace_overview_is_open(&seat.active_output()) {
+                                        // Overview is open: swipe down to close it
+                                        match gesture_state.direction {
+                                            Some(Direction::Down) => Some(SwipeAction::WorkspaceOverview),
+                                            _ => None,
+                                        }
+                                    } else if self.common.config.cosmic_conf.workspaces.workspace_layout
                                         == WorkspaceLayout::Horizontal
                                     {
                                         match gesture_state.direction {
@@ -1042,7 +1051,8 @@ impl State {
                                                     Some(SwipeAction::NextWorkspace)
                                                 }
                                             }
-                                            _ => None, // TODO: Other actions
+                                            Some(Direction::Up) => Some(SwipeAction::WorkspaceOverview),
+                                            _ => None,
                                         }
                                     } else {
                                         match gesture_state.direction {
@@ -1060,7 +1070,7 @@ impl State {
                                                     Some(SwipeAction::NextWorkspace)
                                                 }
                                             }
-                                            _ => None, // TODO: Other actions
+                                            _ => None,
                                         }
                                     }
                                 }
@@ -1124,6 +1134,12 @@ impl State {
                                     norm_velocity,
                                     &mut self.common.workspace_state.update(),
                                 );
+                            }
+                            Some(SwipeAction::WorkspaceOverview) => {
+                                use cosmic_settings_config::shortcuts::action::System;
+                                if let Some(command) = self.common.config.system_actions.get(&System::WorkspaceOverview) {
+                                    self.spawn_command(command.clone());
+                                }
                             }
                             _ => {}
                         }


### PR DESCRIPTION
 Hello team!
 
 
 **Description:**
This PR maps 4-finger vertical touchpad swipes (Up/Down) to toggle the Workspace Overview.

While I've seen it on your roadmap  that gesture functionality is coming in the future, this is a minimal change designed to help users right now. Many of them  (myself included) are coming from macOS, Windows, or GNOME , and are used to a vertical swipe to view all workspaces. Not having this imho is quite an annoyance. This minor addition provides immediate usability while the long-term gesture architecture is built.

**Implementation Details**
This hooks into the existing system action codepaths with minimal changes:
In horizontal layout, mapped 4-finger Direction::Up to a new WorkspaceOverview swipe action.
When inside the overview, 4-finger Direction::Down maps to WorkspaceOverview (to close it).
At the end of the swipe, the compositor spawns the configured System::WorkspaceOverview command, mimicking the exact behavior of the Super+W keyboard shortcut handler.
Checklist
 
 **Changes to be committed:**
	modified:   src/input/actions.rs
	modified:   src/input/gestures/mod.rs
	modified:   src/input/mod.rs
Includes Ai generated code, that was code reviewed manually and fully understood before submission.

- [ x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x ] I understand these changes in full and will be able to respond to review comments.
- [ x] My change is accurately described in the commit message.
- [ x] My contribution is tested and working as described.
- [ x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

