### PR TITLE
fix(input): eagerly activate pointer constraints on motion events

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -324,27 +324,42 @@ impl State {
                         .as_ref()
                         .and_then(|(target, l)| Some((target.wl_surface()?, l)))
                     {
-                        with_pointer_constraint(&surface, &ptr, |constraint| match constraint {
-                            Some(constraint) if constraint.is_active() => {
-                                // Constraint does not apply if not within region
-                                if !constraint.region().is_none_or(|x| {
-                                    x.contains(
-                                        (ptr.current_location() - *surface_loc).to_i32_round(),
-                                    )
-                                }) {
-                                    return;
-                                }
-                                match &*constraint {
-                                    PointerConstraint::Locked(_locked) => {
-                                        pointer_locked = true;
-                                    }
-                                    PointerConstraint::Confined(confine) => {
-                                        pointer_confined = true;
-                                        confine_region = confine.region().cloned();
-                                    }
+                        with_pointer_constraint(&surface, &ptr, |constraint| {
+                            let Some(constraint) = constraint else { return };
+                            // Eagerly activate if the pointer is already within the constraint
+                            // region but the constraint hasn't been activated yet (e.g., the
+                            // constraint was created before the first pointer motion event).
+                            if !constraint.is_active() {
+                                let region = match &*constraint {
+                                    PointerConstraint::Locked(locked) => locked.region(),
+                                    PointerConstraint::Confined(confined) => confined.region(),
+                                };
+                                let point =
+                                    (ptr.current_location() - *surface_loc).to_i32_round();
+                                if region.is_none_or(|r| r.contains(point)) {
+                                    constraint.activate();
                                 }
                             }
-                            _ => {}
+                            if !constraint.is_active() {
+                                return;
+                            }
+                            // Constraint does not apply if not within region
+                            if !constraint.region().is_none_or(|x| {
+                                x.contains(
+                                    (ptr.current_location() - *surface_loc).to_i32_round(),
+                                )
+                            }) {
+                                return;
+                            }
+                            match &*constraint {
+                                PointerConstraint::Locked(_locked) => {
+                                    pointer_locked = true;
+                                }
+                                PointerConstraint::Confined(confine) => {
+                                    pointer_confined = true;
+                                    confine_region = confine.region().cloned();
+                                }
+                            }
                         });
                     }
                     let original_position = position;

--- a/src/wayland/handlers/pointer_constraints.rs
+++ b/src/wayland/handlers/pointer_constraints.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::state::State;
+use crate::{state::State, utils::prelude::*};
 use smithay::{
     delegate_pointer_constraints,
     input::pointer::PointerHandle,
@@ -14,11 +14,30 @@ use smithay::{
 
 impl PointerConstraintsHandler for State {
     fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
-        // XXX region
-        if pointer
+        // Activate immediately if the pointer's tracked focus matches this surface.
+        let focus_matches = pointer
             .current_focus()
-            .is_some_and(|x| x.wl_surface().as_deref() == Some(surface))
-        {
+            .is_some_and(|x| x.wl_surface().as_deref() == Some(surface));
+
+        // Also activate if the pointer is physically over this surface but
+        // current_focus() is stale (e.g., pointer hasn't moved since the window
+        // received keyboard focus and requested the constraint).
+        let physically_over = if !focus_matches {
+            let pos = pointer.current_location().as_global();
+            let shell = self.common.shell.read();
+            shell
+                .outputs()
+                .find(|o| o.geometry().to_f64().contains(pos))
+                .or_else(|| shell.outputs().next())
+                .cloned()
+                .and_then(|output| State::surface_under(pos, &output, &shell))
+                .map(|(t, _)| t.wl_surface().as_deref().is_some_and(|s| s == surface))
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
+        if focus_matches || physically_over {
             with_pointer_constraint(surface, pointer, |constraint| {
                 constraint.unwrap().activate();
             });


### PR DESCRIPTION
Hey I'm Ryan -- thanks for PopOS, it is pretty slick.  I have ran into very few issues using it thus far.  I mostly game, but have also spent a lot of time developing after ditching windows...too much BS to program in general, let alone for linux on windows.

Anyways, I was playing the new Guild Wars remake and I couldn't use the camera properly.  My mouse dragging was not registering in the way it should, and I have noticed this in one other game but cannot recall what it was.  I have played about 20 others in the past couple of months since switching and have only noticed it once before.

The issue comes down to the way the pointer is registered in the compositor.  There is a race condition where a constraint is being called prior to be fully active which would block proper mouse input for moving the camera in the environment. There is also a fix to the logic to ensure that the data behind the current_focus() call is fresh.  We also will fetch the current physical position of the pointer when we notice the cache is stale.

## Problem

FPS/3D games on XWayland hit an invisible camera rotation wall in one direction. The cursor reaches the screen edge and stays there — subsequent XWarpPointer calls can no longer produce a delta, so the camera stops rotating.

Reported in #1874 and pop-os/cosmic-epoch#2871.

## Root cause

A one-frame race condition in `PointerMotion`: the constraint activation check ran **after** `ptr.motion()` was dispatched. On the very first mouse movement after a constraint was created, the constraint was not yet active, so the motion was processed normally and the cursor could reach the screen edge. The constraint then activated at the end of that same event — one frame too late.

`new_constraint()` is supposed to activate immediately, but only does so when `current_focus()` matches the surface. If the pointer hasn't moved since the window received focus (e.g. game launches fullscreen, user hasn't wiggled the mouse yet, or after suspend/resume), `current_focus()` is stale and the constraint is left inactive.  

## Fix

**`src/input/mod.rs`**: At the top of the `PointerMotion` handler, before checking whether a constraint is active, attempt to activate any inactive constraint if the pointer is already within the constraint region. This ensures no motion event is ever processed while a valid constraint is waiting to activate.

**`src/wayland/handlers/pointer_constraints.rs`**: `new_constraint()` now also checks physical pointer position via `surface_under()` as a fallback when `current_focus()` doesn't match. This covers stale-focus scenarios: post-suspend, after alt-tab, or when a constraint is requested before the first mouse movement.

## Testing

Tested on Pop!_OS 24.04 with COSMIC DE, NVIDIA 4070ti Super, games via Proton/XWayland. Camera rotation confirmed working without gamescope workaround on previously affected titles.  Specifically here, Guild Wars: Reforged.  Working great with the patched file.

> **Note:** This fix was developed with AI assistance (Claude). I understand the changes and can respond to review feedback.

- [ ] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


Thanks! -- Ryan