### PR TITLE
xwayland: fix _NET_ACTIVE_WINDOW and add EWMH state support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,10 +813,10 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.2.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
 dependencies = [
  "bitflags 2.11.0",
- "cosmic-protocols",
+ "cosmic-protocols 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?rev=160b086)",
  "libc",
  "smithay-client-toolkit 0.20.0",
  "wayland-client",
@@ -834,7 +834,7 @@ dependencies = [
  "clap_lex",
  "cosmic-comp-config",
  "cosmic-config",
- "cosmic-protocols",
+ "cosmic-protocols 0.2.0 (git+https://github.com/pop-os/cosmic-protocols?branch=main)",
  "cosmic-settings-config",
  "cosmic-settings-daemon-config",
  "cosmic-text",
@@ -943,7 +943,20 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
-source = "git+https://github.com/pop-os//cosmic-protocols?branch=main#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+source = "git+https://github.com/pop-os/cosmic-protocols?branch=main#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "wayland-server",
+]
+
+[[package]]
+name = "cosmic-protocols"
+version = "0.2.0"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,7 +1242,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2722,7 +2722,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2835,7 +2835,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "770919970f7d2f74fea948900d35e2ef64f44129e8ae4015f59de1f0aca7c2a5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3445,7 +3445,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4641,7 +4641,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4936,7 +4936,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=e84a4ca#e84a4ca82d58d783839083bd48c4ab120715c4b6"
+source = "git+https://github.com/jdoss/smithay.git?rev=bd47d6e#bd47d6e9d48b923bef8510aa105d76dbdb5a5482"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -5266,7 +5266,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6285,7 +6285,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cosmic-config = { git = "https://github.com/pop-os/libcosmic", features = [
     "calloop",
     "macro",
 ] }
-cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = [
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", branch = "main", default-features = false, features = [
     "server",
 ] }
 cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
@@ -136,10 +136,6 @@ inherits = "release"
 
 [profile.release]
 lto = "fat"
-
-[patch."https://github.com/pop-os/cosmic-protocols"]
-cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
-cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
 smithay = { git = "https://github.com/smithay/smithay.git", rev = "e84a4ca" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,4 +138,4 @@ inherits = "release"
 lto = "fat"
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "e84a4ca" }
+smithay = { git = "https://github.com/jdoss/smithay.git", rev = "bd47d6e" }

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -695,7 +695,19 @@ impl KeyboardTarget<State> for KeyboardFocusTarget {
                 .x11_surface()
                 .is_some_and(|s| Some(s) == self.x11_surface())
         {
-            KeyboardTarget::leave(&replaced, seat, data, serial);
+            // When focus moves from an X11 surface to a non-X11 target,
+            // skip the X11 leave to preserve XWayland's internal keyboard
+            // focus. This allows XTest synthetic events and XRecord capture
+            // to continue working (e.g. Discord push-to-talk via iohook).
+            // Smithay's X11Surface::leave() sends SetInputFocus(None) which
+            // disables XWayland's keyboard event dispatch entirely.
+            // Exception: always leave for lock surfaces (security boundary).
+            let skip_leave = replaced.x11_surface().is_some()
+                && self.x11_surface().is_none()
+                && !matches!(self, KeyboardFocusTarget::LockSurface(_));
+            if !skip_leave {
+                KeyboardTarget::leave(&replaced, seat, data, serial);
+            }
             KeyboardTarget::enter(self, seat, data, keys, serial);
             KeyboardTarget::modifiers(self, seat, data, modifiers, serial);
         }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -1113,6 +1113,33 @@ impl XwmHandler for State {
         shell.unminimize_request(&window, &seat, &self.common.event_loop_handle);
     }
 
+    fn above_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        if window.is_override_redirect() {
+            return;
+        }
+        if let Err(err) = window.set_above(true) {
+            warn!(?err, "Failed to set _NET_WM_STATE_ABOVE");
+        }
+    }
+
+    fn unabove_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        if let Err(err) = window.set_above(false) {
+            warn!(?err, "Failed to unset _NET_WM_STATE_ABOVE");
+        }
+    }
+
+    fn below_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        if let Err(err) = window.set_below(true) {
+            warn!(?err, "Failed to set _NET_WM_STATE_BELOW");
+        }
+    }
+
+    fn unbelow_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        if let Err(err) = window.set_below(false) {
+            warn!(?err, "Failed to unset _NET_WM_STATE_BELOW");
+        }
+    }
+
     fn fullscreen_request(&mut self, _xwm: XwmId, window: X11Surface) {
         let mut shell = self.common.shell.write();
         let seat = shell.seats.last_active().clone();


### PR DESCRIPTION
## Summary

- Fix `_NET_ACTIVE_WINDOW` not updating on the X11 root window when keyboard focus changes. Smithay's existing FocusIn/FocusOut handlers were broken (wrote the frame window ID, and FocusChange events were never selected on client windows). Call `X11Wm::set_net_active_window()` directly from `xwayland_notify_focus_change()` with the correct client window ID.
- Add `_NET_WM_STATE_ABOVE`, `_NET_WM_STATE_BELOW`, `_NET_WM_STATE_SKIP_TASKBAR`, and `_NET_WM_STATE_SKIP_PAGER` support via XwmHandler callbacks, backed by a [Smithay patch](https://github.com/jdoss/smithay/tree/feature/ewmh-above-below).
- Preserve X11 keyboard focus for XTest/XRecord dispatch so input eavesdropping works for overlay apps.

This fixes XWayland overlay apps like [Awakened PoE Trade](https://github.com/SnosMe/awakened-poe-trade) (ref SnosMe/awakened-poe-trade#1746) which monitor `_NET_ACTIVE_WINDOW` to detect game window focus and depend on `_NET_WM_STATE_ABOVE` being advertised in `_NET_SUPPORTED`.

Electron overlays like Awakened PoE Trade now attach to the game window and price checking works.

**Note:** The Smithay dependency currently points to [jdoss/smithay@2d3ea79](https://github.com/jdoss/smithay/commit/2d3ea79) and should be switched back to upstream once the Smithay PR is accepted.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


## Testing

- Verified `xprop -root -display :0 _NET_SUPPORTED` includes `_NET_WM_STATE_ABOVE`, `_NET_WM_STATE_BELOW`, `_NET_WM_STATE_SKIP_TASKBAR`, `_NET_WM_STATE_SKIP_PAGER`
- Verified `_NET_ACTIVE_WINDOW` updates to the correct client window ID when focusing XWayland windows
- Verified `wmctrl -r :ACTIVE: -b add,above` sets and `remove,above` clears `_NET_WM_STATE_ABOVE`
- Launched Path of Exile via Steam/Proton, started Awakened PoE Trade — overlay attached to the game window and price checking works
- Normal window management (tiling, floating, workspaces) unaffected


