### PR TITLE
image-copy: Don't panic if `ImageCaptureSourceKind` udata is undefined

### DIFF
--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -50,14 +50,13 @@ impl ImageCopyCaptureHandler for State {
     }
 
     fn capture_constraints(&mut self, source: &ImageCaptureSource) -> Option<BufferConstraints> {
-        let kind = source.user_data().get::<ImageCaptureSourceKind>().unwrap();
-        match kind {
+        match ImageCaptureSourceKind::from_source(source) {
             ImageCaptureSourceKind::Output(weak) => weak
                 .upgrade()
                 .and_then(|output| constraints_for_output(&output, &mut self.backend)),
             ImageCaptureSourceKind::Workspace(handle) => {
                 let shell = self.common.shell.read();
-                let output = shell.workspaces.space_for_handle(handle)?.output();
+                let output = shell.workspaces.space_for_handle(&handle)?.output();
                 constraints_for_output(output, &mut self.backend)
             }
             ImageCaptureSourceKind::Toplevel(window) => {
@@ -67,7 +66,7 @@ impl ImageCopyCaptureHandler for State {
                     None
                 }
             }
-            _ => None,
+            ImageCaptureSourceKind::Destroyed => None,
         }
     }
 
@@ -97,13 +96,7 @@ impl ImageCopyCaptureHandler for State {
     }
 
     fn new_session(&mut self, session: Session) {
-        let kind = session
-            .source()
-            .user_data()
-            .get::<ImageCaptureSourceKind>()
-            .unwrap()
-            .clone();
-        match kind {
+        match ImageCaptureSourceKind::from_source(&session.source()) {
             ImageCaptureSourceKind::Output(weak) => {
                 let Some(mut output) = weak.upgrade() else {
                     session.stop();
@@ -180,13 +173,7 @@ impl ImageCopyCaptureHandler for State {
             )))
         });
 
-        let kind = session
-            .source()
-            .user_data()
-            .get::<ImageCaptureSourceKind>()
-            .unwrap()
-            .clone();
-        match kind {
+        match ImageCaptureSourceKind::from_source(&session.source()) {
             ImageCaptureSourceKind::Output(weak) => {
                 let Some(mut output) = weak.upgrade() else {
                     return;
@@ -281,13 +268,7 @@ impl ImageCopyCaptureHandler for State {
     }
 
     fn frame(&mut self, session: &SessionRef, frame: Frame) {
-        let kind = session
-            .source()
-            .user_data()
-            .get::<ImageCaptureSourceKind>()
-            .unwrap()
-            .clone();
-        match kind {
+        match ImageCaptureSourceKind::from_source(&session.source()) {
             ImageCaptureSourceKind::Output(weak) => {
                 let Some(mut output) = weak.upgrade() else {
                     return;
@@ -330,13 +311,7 @@ impl ImageCopyCaptureHandler for State {
     }
 
     fn session_destroyed(&mut self, session: SessionRef) {
-        let kind = session
-            .source()
-            .user_data()
-            .get::<ImageCaptureSourceKind>()
-            .unwrap()
-            .clone();
-        match kind {
+        match ImageCaptureSourceKind::from_source(&session.source()) {
             ImageCaptureSourceKind::Output(weak) => {
                 if let Some(mut output) = weak.upgrade() {
                     output.remove_session(&session);
@@ -363,13 +338,7 @@ impl ImageCopyCaptureHandler for State {
     }
 
     fn cursor_session_destroyed(&mut self, session: CursorSessionRef) {
-        let kind = session
-            .source()
-            .user_data()
-            .get::<ImageCaptureSourceKind>()
-            .unwrap()
-            .clone();
-        match kind {
+        match ImageCaptureSourceKind::from_source(&session.source()) {
             ImageCaptureSourceKind::Output(weak) => {
                 if let Some(mut output) = weak.upgrade() {
                     output.remove_cursor_session(&session);

--- a/src/wayland/protocols/image_capture_source.rs
+++ b/src/wayland/protocols/image_capture_source.rs
@@ -37,9 +37,13 @@ pub enum ImageCaptureSourceKind {
 }
 
 impl ImageCaptureSourceKind {
-    pub fn from_resource(resource: &ExtImageCaptureSourceV1) -> Option<Self> {
-        let source = ImageCaptureSource::from_resource(resource)?;
-        source.user_data().get::<ImageCaptureSourceKind>().cloned()
+    pub fn from_source(source: &ImageCaptureSource) -> Self {
+        // If no user-data, assume source was created for a destroyed output, etc.
+        source
+            .user_data()
+            .get::<ImageCaptureSourceKind>()
+            .cloned()
+            .unwrap_or(Self::Destroyed)
     }
 }
 


### PR DESCRIPTION
We want to merge this when updating Smithay to have https://github.com/Smithay/smithay/pull/1961, so that we don't panic the the output/toplevel already has no strong references when the source is created.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

