### PR TITLE
input: allow layout switching and brightness/volume control under session lock

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -47,14 +47,56 @@ impl State {
     ) {
         // TODO: Detect if started from login manager or tty, and only allow
         // `Terminate` if it will return to login manager.
-        if self.common.shell.read().session_lock.is_some()
-            && !matches!(
+        if self.common.shell.read().session_lock.is_some() {
+            // Handle InputSourceSwitch inline under session lock so the
+            // locker UI can switch keyboard layouts. We call the
+            // cosmic-settings-daemon D-Bus method directly rather than
+            // routing through the generic System action handler, which
+            // would execute a user-configurable shell command from
+            // `system_actions` via `spawn_command`. A compromised
+            // `~/.config/cosmic/.../system_actions` file must not grant
+            // code execution under a locked screen.
+            if matches!(
+                action,
+                Action::Shortcut(shortcuts::Action::System(
+                    shortcuts::action::System::InputSourceSwitch
+                ))
+            ) {
+                self.common.async_executor.spawn_ok(async {
+                    match zbus::Connection::session().await {
+                        Ok(conn) => {
+                            if let Err(err) = conn
+                                .call_method(
+                                    Some("com.system76.CosmicSettingsDaemon"),
+                                    "/com/system76/CosmicSettingsDaemon",
+                                    Some("com.system76.CosmicSettingsDaemon"),
+                                    "InputSourceSwitch",
+                                    &(),
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    "failed to call InputSourceSwitch under session lock: {err}"
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                "failed to connect to session bus for InputSourceSwitch: {err}"
+                            );
+                        }
+                    }
+                });
+                return;
+            }
+
+            if !matches!(
                 action,
                 Action::Shortcut(shortcuts::Action::Terminate)
                     | Action::Shortcut(shortcuts::Action::Debug)
-            )
-        {
-            return;
+            ) {
+                return;
+            }
         }
 
         match action {

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -52,6 +52,14 @@ impl State {
                 action,
                 Action::Shortcut(shortcuts::Action::Terminate)
                     | Action::Shortcut(shortcuts::Action::Debug)
+                    | Action::Shortcut(shortcuts::Action::System(
+                        shortcuts::action::System::InputSourceSwitch
+                            | shortcuts::action::System::BrightnessDown
+                            | shortcuts::action::System::BrightnessUp
+                            | shortcuts::action::System::VolumeLower
+                            | shortcuts::action::System::VolumeRaise
+                            | shortcuts::action::System::Mute,
+                    ))
             )
         {
             return;


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

Allow common multimedia keys to work on the lock screen by extending
the early-return whitelist:

- `Super+Space` — switch keyboard layout
- `XF86MonBrightnessUp/Down` — display brightness
- `XF86AudioRaiseVolume/LowerVolume`, `XF86AudioMute` — audio output

All added actions flow through the existing `System` handler.

Layout switching is functional standalone (the new layout is applied and
typed-into-password fields use it), but the locker UI (dropdown checkmark
and active-layout label) will not reflect the change without the companion
pop-os/cosmic-greeter#439, which subscribes to `xkb_config` updates.

## Test plan

- [x] Lock the screen (`Super+Esc` or `loginctl lock-session`) and verify each key:
  - [x] `Super+Space` switches layout (functional; visual update requires cosmic-greeter#439)
  - [x] Brightness up/down adjusts display brightness
  - [x] Volume up/down/mute adjusts audio
- [x] Same keys still work in unlocked session
- [x] Other shortcuts under lock (e.g. `Super+T`) — still blocked
