### PR TITLE
fix(ci): use the correct toolchain version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,12 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
             - name: Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   components: rustfmt
-            - name: Cargo cache
-              uses: actions/cache@v5
-              with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+                  rustflags: ""
             - name: Format
-              run: cargo +stable fmt --all -- --check
+              run: cargo fmt --all -- --check
 
     clippy-check:
         runs-on: ubuntu-latest
@@ -32,20 +26,14 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
             - name: Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   components: clippy
-            - name: Cargo cache
-              uses: actions/cache@v5
-              with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+                  rustflags: ""
             - name: System dependencies
               run: sudo apt-get update; sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libdisplay-info-dev
             - name: Clippy
-              run: cargo +stable clippy --all-features -- -D warnings
+              run: cargo clippy --all-features -- -D warnings
 
     check-features:
         runs-on: ubuntu-latest
@@ -53,20 +41,15 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
             - name: Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
-            - name: Cargo cache
-              uses: actions/cache@v5
+              uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+                  rustflags: ""
             - name: System dependencies
               run: sudo apt-get update; sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libseat-dev libdisplay-info-dev
-            - run: cargo +stable check --no-default-features
-            - run: cargo +stable check --features debug
-            - run: cargo +stable check --features profile-with-tracy
-            - run: cargo +stable check --features profile-with-tracy-gpu
+            - run: cargo check --no-default-features
+            - run: cargo check --features debug
+            - run: cargo check --features profile-with-tracy
+            - run: cargo check --features profile-with-tracy-gpu
 
     test:
         runs-on: ubuntu-latest
@@ -74,21 +57,11 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
             - name: Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
-            - name: Cargo cache
-              uses: actions/cache@v5
+              uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+                  rustflags: ""
             - name: System dependencies
               run: sudo apt-get update; sudo apt-get install libudev-dev libgbm-dev libxkbcommon-dev libegl1-mesa-dev libwayland-dev libinput-dev libdbus-1-dev libsystemd-dev libdisplay-info-dev libpixman-1-dev meson ninja-build
-            - name: Build cache
-              uses: actions/cache@v5
-              with:
-                  path: target
-                  key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.toml') }}
             - name: Build and install Libseat
               run: |
                   wget https://git.sr.ht/~kennylevinsen/seatd/archive/0.9.1.tar.gz -O libseat-source.tar.gz


### PR DESCRIPTION
Uses 1.90 (or whatever you set in the `rust-toolcahin.toml`) so clippy doesn't fail.

- Switched to `actions-rust-lang` so it reads the rust-toolchain.toml automatically.
- It also has a builtin cache that is based on `cargo.lock`
- Removed the "Cargo cache" step, since it's using the hash of `cargo.toml` missing minor version updates.
- Added `rustflags: ""` since it has `RUSTFLAGS=-D warnings` by default, which the old CI didn't.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

