### PR TITLE
Fix "git commit unknown" in the version string

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,10 @@
 use std::process::Command;
 
 fn main() {
+    if let Ok(hash) = std::env::var("SOURCE_GIT_HASH") {
+        println!("cargo:rustc-env=GIT_HASH={}", hash);
+        return;
+    }
     if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
         let git_hash = String::from_utf8(output.stdout).unwrap();
         println!("cargo:rustc-env=GIT_HASH={}", git_hash);


### PR DESCRIPTION
Pop CI compiles cosmic-comp as tarball with no `.git`. So the current code in `build.rs` can't get the git hash.

pop-ci provides it as `SOURCE_GIT_HASH` [here](https://github.com/pop-os/pop/blob/3abdf176e05922009b39dcd0e2fa47b4b66eee7e/scripts/pop-ci/src/main.rs#L770).

This doesn't fix the version number being `1.0.0` and not updated with the tags. But it does update the git hash correctly (https://github.com/pop-os/cosmic-comp/pull/2251 still depends on `git` which won't work).
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

