### PR TITLE
feat: Add ColorPicker DBus interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "cosmic-text",
  "egui",
  "egui_plot",
+ "futures-channel",
  "futures-executor",
  "futures-util",
  "i18n-embed",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "cosmic-text",
  "egui",
  "egui_plot",
+ "futures-channel",
  "futures-executor",
  "futures-util",
  "i18n-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ rand = "0.10"
 clap_lex = "1.0"
 parking_lot = "0.12.5"
 logind-zbus = { version = "5.3.2", optional = true }
+futures-channel = "0.3.32"
 futures-executor = { version = "0.3.32", features = ["thread-pool"] }
 futures-util = "0.3.32"
 cgmath = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ rand = "0.10"
 clap_lex = "1.0"
 parking_lot = "0.12.5"
 logind-zbus = { version = "5.3.2", optional = true }
+futures-channel = "0.3.32"
 futures-executor = { version = "0.3.32" }
 futures-util = "0.3.32"
 cgmath = "0.18.0"

--- a/src/dbus/color_picker.rs
+++ b/src/dbus/color_picker.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// DBus interface `com.system76.CosmicComp.ColorPicker` at
+// `/com/system76/CosmicComp/ColorPicker`.
+//
+// One method: `PickPixel(output: s, x: i32, y: i32) -> (r: d, g: d, b: d)`.
+//
+// Reserved for xdg-desktop-portal-cosmic (gated via NameOwners)
+
+use calloop::channel::Sender;
+use futures_channel::oneshot;
+use futures_executor::ThreadPool;
+use std::sync::{Arc, OnceLock};
+use zbus::{fdo, message::Header, names::WellKnownName};
+
+use super::name_owners::NameOwners;
+
+const ALLOWED_NAMES: &[WellKnownName<'static>] = &[WellKnownName::from_static_str_unchecked(
+    "org.freedesktop.impl.portal.desktop.cosmic",
+)];
+
+pub enum Request {
+    PickPixel {
+        output: String,
+        x: i32,
+        y: i32,
+        reply: oneshot::Sender<Result<(f64, f64, f64), String>>,
+    },
+}
+
+#[derive(Debug)]
+pub struct ColorPickerState {
+    #[allow(dead_code)]
+    conn: Arc<OnceLock<zbus::Connection>>,
+    #[allow(dead_code)]
+    name_owners: Arc<OnceLock<NameOwners>>,
+}
+
+impl ColorPickerState {
+    pub fn new(executor: &ThreadPool, tx: Sender<Request>) -> Self {
+        let conn_cell = Arc::new(OnceLock::new());
+        let conn_cell_clone = conn_cell.clone();
+        let name_owners_cell = Arc::new(OnceLock::new());
+        let name_owners_cell_clone = name_owners_cell.clone();
+        let executor_clone = executor.clone();
+        executor.spawn_ok(async move {
+            match serve(tx, &executor_clone).await {
+                Ok((conn, name_owners)) => {
+                    let _ = conn_cell_clone.set(conn);
+                    let _ = name_owners_cell_clone.set(name_owners);
+                }
+                Err(err) => {
+                    tracing::error!("Failed to serve `com.system76.CosmicComp.ColorPicker`: {err}");
+                }
+            }
+        });
+        Self {
+            conn: conn_cell,
+            name_owners: name_owners_cell,
+        }
+    }
+}
+
+struct ColorPicker {
+    tx: Sender<Request>,
+    name_owners: NameOwners,
+}
+
+impl ColorPicker {
+    async fn check_sender_allowed(&self, sender: &zbus::names::UniqueName<'_>) -> fdo::Result<()> {
+        if self.name_owners.check_owner(sender, ALLOWED_NAMES).await {
+            Ok(())
+        } else {
+            Err(fdo::Error::AccessDenied("Access denied".to_string()))
+        }
+    }
+}
+
+#[zbus::interface(name = "com.system76.CosmicComp.ColorPicker")]
+impl ColorPicker {
+    async fn pick_pixel(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+        output: String,
+        x: i32,
+        y: i32,
+    ) -> fdo::Result<(f64, f64, f64)> {
+        let sender = header
+            .sender()
+            .ok_or_else(|| fdo::Error::AccessDenied("Missing sender".to_string()))?;
+        self.check_sender_allowed(sender).await?;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(Request::PickPixel {
+                output,
+                x,
+                y,
+                reply: reply_tx,
+            })
+            .map_err(|e| fdo::Error::Failed(format!("Failed to dispatch: {e}")))?;
+        reply_rx
+            .await
+            .map_err(|_| fdo::Error::Failed("Reply cancelled".to_string()))?
+            .map_err(fdo::Error::Failed)
+    }
+}
+
+async fn serve(
+    tx: Sender<Request>,
+    executor: &ThreadPool,
+) -> zbus::Result<(zbus::Connection, NameOwners)> {
+    let conn = zbus::Connection::session().await?;
+    let name_owners = NameOwners::new(&conn, executor).await?;
+    let color_picker = ColorPicker {
+        tx,
+        name_owners: name_owners.clone(),
+    };
+    conn.object_server()
+        .at("/com/system76/CosmicComp/ColorPicker", color_picker)
+        .await?;
+    conn.request_name("com.system76.CosmicComp").await?;
+    Ok((conn, name_owners))
+}

--- a/src/dbus/color_picker.rs
+++ b/src/dbus/color_picker.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// DBus interface `com.system76.CosmicComp.ColorPicker` at
+// `/com/system76/CosmicComp/ColorPicker`.
+//
+// One method: `ColorUnderCursor() -> (r: d, g: d, b: d)`, which samples the
+// colour of the pixel directly under the compositor's current pointer. The
+// caller sends no coordinates: the compositor is the only component that knows
+// the live pointer position and the active screen-magnifier transform, so it
+// resolves everything itself (robust to zoom, fractional scale, and rotation).
+//
+// Reserved for xdg-desktop-portal-cosmic (gated via NameOwners)
+
+use calloop::channel::Sender;
+use futures_channel::oneshot;
+use zbus::{fdo, message::Header, names::WellKnownName};
+
+use super::name_owners::NameOwners;
+
+const ALLOWED_NAMES: &[WellKnownName<'static>] = &[WellKnownName::from_static_str_unchecked(
+    "org.freedesktop.impl.portal.desktop.cosmic",
+)];
+
+#[derive(Debug)]
+pub enum Request {
+    ColorUnderCursor {
+        reply: oneshot::Sender<Result<(f64, f64, f64), String>>,
+    },
+}
+
+struct ColorPicker {
+    tx: Sender<Request>,
+    name_owners: NameOwners,
+}
+
+impl ColorPicker {
+    async fn check_sender_allowed(&self, sender: &zbus::names::UniqueName<'_>) -> fdo::Result<()> {
+        if self.name_owners.check_owner(sender, ALLOWED_NAMES).await {
+            Ok(())
+        } else {
+            Err(fdo::Error::AccessDenied("Access denied".to_string()))
+        }
+    }
+}
+
+#[zbus::interface(name = "com.system76.CosmicComp.ColorPicker")]
+impl ColorPicker {
+    async fn color_under_cursor(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+    ) -> fdo::Result<(f64, f64, f64)> {
+        let sender = header
+            .sender()
+            .ok_or_else(|| fdo::Error::AccessDenied("Missing sender".to_string()))?;
+        self.check_sender_allowed(sender).await?;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(Request::ColorUnderCursor { reply: reply_tx })
+            .map_err(|e| fdo::Error::Failed(format!("Failed to dispatch: {e}")))?;
+        reply_rx
+            .await
+            .map_err(|_| fdo::Error::Failed("Reply cancelled".to_string()))?
+            .map_err(fdo::Error::Failed)
+    }
+}
+
+/// Register the `com.system76.CosmicComp.ColorPicker` interface on the shared
+/// session connection. `tx` dispatches [`Request`]s to the main thread, which
+/// owns the renderer needed to sample a pixel.
+pub async fn init(
+    conn: &zbus::Connection,
+    name_owners: &NameOwners,
+    tx: Sender<Request>,
+) -> zbus::Result<()> {
+    let color_picker = ColorPicker {
+        tx,
+        name_owners: name_owners.clone(),
+    };
+    conn.object_server()
+        .at("/com/system76/CosmicComp/ColorPicker", color_picker)
+        .await?;
+    conn.request_name("com.system76.CosmicComp").await?;
+    Ok(())
+}

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -12,6 +12,7 @@ use tracing::{error, warn};
 use zbus::blocking::{Connection, fdo::DBusProxy};
 
 pub mod a11y_keyboard_monitor;
+pub mod color_picker;
 #[cfg(feature = "systemd")]
 pub mod logind;
 mod name_owners;

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -14,6 +14,7 @@ use tracing::{error, warn};
 
 pub mod a11y_keyboard_monitor;
 use a11y_keyboard_monitor::A11yKeyboardMonitorState;
+pub mod color_picker;
 #[cfg(feature = "logind")]
 pub mod logind;
 mod name_owners;
@@ -29,10 +30,14 @@ struct DBusStateInner {
     session_conn: zbus::Result<zbus::Connection>,
     system_conn: zbus::Result<zbus::Connection>,
     a11y_keyboard_monitor: RefCell<Option<a11y_keyboard_monitor::A11yKeyboardMonitorState>>,
+    color_picker_tx: calloop::channel::Sender<color_picker::Request>,
 }
 
 impl DBusState {
-    pub fn init(evlh: &LoopHandle<'static, State>) -> Self {
+    pub fn init(
+        evlh: &LoopHandle<'static, State>,
+        color_picker_tx: calloop::channel::Sender<color_picker::Request>,
+    ) -> Self {
         let (source, executor) = calloop::futures::executor().unwrap();
         let session_conn = futures_executor::block_on(zbus::Connection::session());
         let system_conn = futures_executor::block_on(zbus::Connection::system());
@@ -42,6 +47,7 @@ impl DBusState {
             session_conn,
             system_conn,
             a11y_keyboard_monitor: RefCell::new(None),
+            color_picker_tx,
         }));
         evlh.insert_source(source, |_, _, _| {}).unwrap();
         let state_clone = state.clone();
@@ -85,6 +91,7 @@ async fn init_session(state: &DBusState) -> zbus::Result<()> {
     let a11y_keyboard_monitor_state =
         A11yKeyboardMonitorState::new(conn, &name_owners, &state.0.executor).await?;
     *state.0.a11y_keyboard_monitor.borrow_mut() = Some(a11y_keyboard_monitor_state);
+    color_picker::init(conn, &name_owners, state.0.color_picker_tx.clone()).await?;
     Ok(())
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,7 +8,7 @@ use crate::{
         x11::X11State,
     },
     config::{CompOutputConfig, Config, ScreenFilter},
-    dbus::a11y_keyboard_monitor::A11yKeyboardMonitorState,
+    dbus::{a11y_keyboard_monitor::A11yKeyboardMonitorState, color_picker::ColorPickerState},
     input::{PointerFocusState, gestures::GestureState},
     shell::{CosmicSurface, SeatExt, Shell, grabs::SeatMoveGrabState},
     utils::prelude::OutputExt,
@@ -279,6 +279,7 @@ pub struct Common {
     pub overlap_notify_state: OverlapNotifyState,
     pub a11y_state: A11yState,
     pub a11y_keyboard_monitor_state: A11yKeyboardMonitorState,
+    pub color_picker_state: ColorPickerState,
 
     // shell-related wayland state
     pub xdg_shell_state: XdgShellState,
@@ -736,6 +737,28 @@ impl State {
 
         let a11y_keyboard_monitor_state = A11yKeyboardMonitorState::new(&async_executor);
 
+        let (color_picker_tx, color_picker_rx) =
+            calloop::channel::channel::<crate::dbus::color_picker::Request>();
+        if let Err(err) = handle.insert_source(color_picker_rx, |event, _, state| {
+            if let calloop::channel::Event::Msg(req) = event {
+                match req {
+                    crate::dbus::color_picker::Request::PickPixel {
+                        output,
+                        x,
+                        y,
+                        reply,
+                    } => {
+                        let res = crate::utils::pick_pixel::pick_pixel(state, &output, x, y)
+                            .map_err(|e| e.to_string());
+                        let _ = reply.send(res);
+                    }
+                }
+            }
+        }) {
+            tracing::warn!(?err, "Failed to insert color picker event source");
+        }
+        let color_picker_state = ColorPickerState::new(&async_executor, color_picker_tx);
+
         State {
             common: Common {
                 config,
@@ -794,6 +817,7 @@ impl State {
                 workspace_state,
                 a11y_state,
                 a11y_keyboard_monitor_state,
+                color_picker_state,
                 xwayland_scale: None,
                 xwayland_state: None,
                 xwayland_shell_state,

--- a/src/state.rs
+++ b/src/state.rs
@@ -729,7 +729,23 @@ impl State {
 
         let a11y_state = A11yState::new::<State, _>(dh, client_not_sandboxed);
 
-        let dbus_state = DBusState::init(&handle);
+        let (color_picker_tx, color_picker_rx) =
+            calloop::channel::channel::<crate::dbus::color_picker::Request>();
+        if let Err(err) = handle.insert_source(color_picker_rx, |event, _, state| {
+            if let calloop::channel::Event::Msg(req) = event {
+                match req {
+                    crate::dbus::color_picker::Request::ColorUnderCursor { reply } => {
+                        let res = crate::utils::color_under_cursor::color_under_cursor(state)
+                            .map_err(|e| e.to_string());
+                        let _ = reply.send(res);
+                    }
+                }
+            }
+        }) {
+            tracing::warn!(?err, "Failed to insert color picker event source");
+        }
+
+        let dbus_state = DBusState::init(&handle, color_picker_tx);
 
         State {
             common: Common {

--- a/src/utils/color_under_cursor.rs
+++ b/src/utils/color_under_cursor.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Off-screen single-pixel colour sample for the PickColor portal.
+//
+// Renders the given output's active workspace to a disposable offscreen
+// renderbuffer, reads back a single pixel, and returns it as f64 RGB in [0, 1].
+
+use anyhow::{Context, anyhow};
+use smithay::{
+    backend::{
+        allocator::Fourcc,
+        drm::DrmNode,
+        renderer::{
+            ExportMem, ImportAll, Offscreen, Renderer, damage::OutputDamageTracker,
+            element::RenderElement, gles::GlesRenderbuffer,
+        },
+    },
+    output::Output,
+    utils::{Rectangle, Transform},
+};
+
+use crate::{
+    backend::render::{
+        CursorMode, ElementFilter, RendererRef,
+        element::{AsGlowRenderer, CosmicElement, FromGlesError},
+        render_workspace,
+    },
+    shell::{CosmicMappedRenderElement, WorkspaceRenderElement},
+    state::{BackendData, State},
+    utils::prelude::*,
+};
+
+/// Sample the colour of the real pixel directly under the pointer.
+///
+/// The pointer location, the output it is on, and the output-local coordinate
+/// are all resolved here from the compositor's own state, so the caller never
+/// has to send coordinates.
+pub fn color_under_cursor(state: &mut State) -> anyhow::Result<(f64, f64, f64)> {
+    // Resolve the output and output-local coordinate under the pointer.
+    let (output, x, y) = {
+        let shell = state.common.shell.read();
+        let pointer = shell
+            .seats
+            .last_active()
+            .get_pointer()
+            .ok_or_else(|| anyhow!("Active seat has no pointer"))?;
+        let loc = pointer.current_location().as_global();
+        let output = shell
+            .outputs()
+            .find(|o| o.geometry().to_f64().contains(loc))
+            .cloned()
+            .ok_or_else(|| anyhow!("Pointer is not over any output"))?;
+        let local = loc.to_local(&output);
+        (output, local.x.floor() as i32, local.y.floor() as i32)
+    };
+
+    let geo = output.geometry();
+    if x < 0 || y < 0 || x >= geo.size.w || y >= geo.size.h {
+        return Err(anyhow!(
+            "Pointer ({x}, {y}) is outside output bounds {:?}",
+            geo.size
+        ));
+    }
+
+    if matches!(state.backend, BackendData::Unset) {
+        return Err(anyhow!("Backend not yet initialised"));
+    }
+
+    let gpu: Option<DrmNode> = match &state.backend {
+        BackendData::Kms(kms) => *kms.primary_node.read().unwrap(),
+        _ => None,
+    };
+
+    let now = state.common.clock.now();
+    let shell = state.common.shell.clone();
+
+    let current = {
+        let shell_ref = shell.read();
+        let workspace = shell_ref
+            .workspaces
+            .active(&output)
+            .ok_or_else(|| anyhow!("No active workspace for output"))?
+            .1;
+        let (_, idx) = shell_ref.workspaces.active_num(&output);
+        (workspace.handle, idx)
+    };
+
+    let renderer = state
+        .backend
+        .offscreen_renderer(|_kms| gpu.map(crate::state::KmsNodes::from))
+        .with_context(|| "Failed to acquire offscreen renderer")?;
+
+    match renderer {
+        RendererRef::Glow(renderer) => {
+            pick_pixel_with(renderer, &shell, now, &output, current, gpu.as_ref(), x, y)
+        }
+        RendererRef::GlMulti(mut renderer) => pick_pixel_with(
+            &mut renderer,
+            &shell,
+            now,
+            &output,
+            current,
+            gpu.as_ref(),
+            x,
+            y,
+        ),
+    }
+}
+
+fn pick_pixel_with<R>(
+    renderer: &mut R,
+    shell: &std::sync::Arc<parking_lot::RwLock<crate::shell::Shell>>,
+    now: smithay::utils::Time<smithay::utils::Monotonic>,
+    output: &Output,
+    current: (crate::wayland::protocols::workspace::WorkspaceHandle, usize),
+    gpu: Option<&DrmNode>,
+    x: i32,
+    y: i32,
+) -> anyhow::Result<(f64, f64, f64)>
+where
+    R: Renderer + ImportAll + Offscreen<GlesRenderbuffer> + ExportMem + AsGlowRenderer,
+    R::TextureId: Send + Clone + 'static,
+    R::Error: FromGlesError + Send + Sync + 'static,
+    CosmicElement<R>: RenderElement<R>,
+    CosmicMappedRenderElement<R>: RenderElement<R>,
+    WorkspaceRenderElement<R>: RenderElement<R>,
+{
+    let mode = output
+        .current_mode()
+        .ok_or_else(|| anyhow!("Output has no mode"))?;
+    let transform = output.current_transform();
+    let scale = output.current_scale().fractional_scale();
+
+    // Buffer is laid out without transform, matching the image_copy_capture convention.
+    let _ = transform;
+    let buffer_size = mode.size.to_logical(1).to_buffer(1, Transform::Normal);
+
+    let format = Fourcc::Abgr8888;
+    let mut render_buffer =
+        Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, buffer_size)
+            .map_err(|e| anyhow!("Failed to create offscreen buffer: {e}"))?;
+    let mut fb = renderer
+        .bind(&mut render_buffer)
+        .map_err(|e| anyhow!("Failed to bind offscreen buffer: {e}"))?;
+
+    let mut damage_tracker = OutputDamageTracker::from_output(output);
+
+    let res = render_workspace(
+        gpu,
+        renderer,
+        &mut fb,
+        &mut damage_tracker,
+        0,
+        None,
+        shell,
+        None,
+        now,
+        output,
+        None,
+        current,
+        CursorMode::None,
+        ElementFilter::All,
+    )
+    .map_err(|e| anyhow!("render_workspace failed: {e}"))?;
+    renderer
+        .wait(&res.0.sync)
+        .map_err(|e| anyhow!("Failed to wait on render sync: {e}"))?;
+
+    // Logical output-local coord -> buffer coord.
+    let px = (x as f64 * scale).floor() as i32;
+    let py = (y as f64 * scale).floor() as i32;
+    let region = Rectangle::new((px, py).into(), (1, 1).into());
+
+    let mapping = renderer
+        .copy_framebuffer(&fb, region, format)
+        .map_err(|e| anyhow!("copy_framebuffer failed: {e}"))?;
+    let bytes = renderer
+        .map_texture(&mapping)
+        .map_err(|e| anyhow!("map_texture failed: {e}"))?;
+    if bytes.len() < 4 {
+        return Err(anyhow!("Unexpected pixel data length: {}", bytes.len()));
+    }
+
+    let r = bytes[0] as f64 / 255.0;
+    let g = bytes[1] as f64 / 255.0;
+    let b = bytes[2] as f64 / 255.0;
+    Ok((r, g, b))
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,7 @@ mod ids;
 pub(crate) use self::ids::id_gen;
 pub mod geometry;
 pub mod iced;
+pub mod pick_pixel;
 pub mod prelude;
 pub mod quirks;
 pub mod rlimit;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@
 pub mod env;
 mod ids;
 pub(crate) use self::ids::id_gen;
+pub mod color_under_cursor;
 pub mod geometry;
 pub mod iced;
 pub mod prelude;

--- a/src/utils/pick_pixel.rs
+++ b/src/utils/pick_pixel.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Off-screen single-pixel colour sample for the PickColor portal.
+//
+// Renders the given output's active workspace to a disposable offscreen
+// renderbuffer, reads back a single pixel, and returns it as f64 RGB in [0, 1].
+
+use anyhow::{Context, anyhow};
+use smithay::{
+    backend::{
+        allocator::Fourcc,
+        drm::DrmNode,
+        renderer::{
+            ExportMem, ImportAll, Offscreen, Renderer, damage::OutputDamageTracker,
+            element::RenderElement, gles::GlesRenderbuffer,
+        },
+    },
+    output::Output,
+    utils::{Rectangle, Transform},
+};
+
+use crate::{
+    backend::render::{
+        CursorMode, ElementFilter, RendererRef,
+        element::{AsGlowRenderer, CosmicElement, FromGlesError},
+        render_workspace,
+    },
+    shell::{CosmicMappedRenderElement, WorkspaceRenderElement},
+    state::{BackendData, State},
+    utils::prelude::OutputExt,
+};
+
+/// Sample the colour at logical output-local coordinates `(x, y)` on `output`.
+pub fn pick_pixel(
+    state: &mut State,
+    output_name: &str,
+    x: i32,
+    y: i32,
+) -> anyhow::Result<(f64, f64, f64)> {
+    let output = state
+        .common
+        .shell
+        .read()
+        .outputs()
+        .find(|o| o.name() == output_name)
+        .cloned()
+        .ok_or_else(|| anyhow!("No output named {}", output_name))?;
+
+    let geo = output.geometry();
+    if x < 0 || y < 0 || x >= geo.size.w || y >= geo.size.h {
+        return Err(anyhow!(
+            "Coordinates ({x}, {y}) are outside output bounds {:?}",
+            geo.size
+        ));
+    }
+
+    if matches!(state.backend, BackendData::Unset) {
+        return Err(anyhow!("Backend not yet initialised"));
+    }
+
+    let gpu: Option<DrmNode> = match &state.backend {
+        BackendData::Kms(kms) => *kms.primary_node.read().unwrap(),
+        _ => None,
+    };
+
+    let now = state.common.clock.now();
+    let shell = state.common.shell.clone();
+
+    let (current, zoom_state) = {
+        let shell_ref = shell.read();
+        let workspace = shell_ref
+            .workspaces
+            .active(&output)
+            .ok_or_else(|| anyhow!("No active workspace for output"))?
+            .1;
+        let (_, idx) = shell_ref.workspaces.active_num(&output);
+        let zoom_state = shell_ref.zoom_state().cloned();
+        ((workspace.handle, idx), zoom_state)
+    };
+
+    let renderer = state
+        .backend
+        .offscreen_renderer(|_kms| gpu.map(crate::state::KmsNodes::from))
+        .with_context(|| "Failed to acquire offscreen renderer")?;
+
+    match renderer {
+        RendererRef::Glow(renderer) => pick_pixel_with(
+            renderer,
+            &shell,
+            zoom_state.as_ref(),
+            now,
+            &output,
+            current,
+            gpu.as_ref(),
+            x,
+            y,
+        ),
+        RendererRef::GlMulti(mut renderer) => pick_pixel_with(
+            &mut renderer,
+            &shell,
+            zoom_state.as_ref(),
+            now,
+            &output,
+            current,
+            gpu.as_ref(),
+            x,
+            y,
+        ),
+    }
+}
+
+fn pick_pixel_with<R>(
+    renderer: &mut R,
+    shell: &std::sync::Arc<parking_lot::RwLock<crate::shell::Shell>>,
+    zoom_state: Option<&crate::shell::zoom::ZoomState>,
+    now: smithay::utils::Time<smithay::utils::Monotonic>,
+    output: &Output,
+    current: (crate::wayland::protocols::workspace::WorkspaceHandle, usize),
+    gpu: Option<&DrmNode>,
+    x: i32,
+    y: i32,
+) -> anyhow::Result<(f64, f64, f64)>
+where
+    R: Renderer + ImportAll + Offscreen<GlesRenderbuffer> + ExportMem + AsGlowRenderer,
+    R::TextureId: Send + Clone + 'static,
+    R::Error: FromGlesError + Send + Sync + 'static,
+    CosmicElement<R>: RenderElement<R>,
+    CosmicMappedRenderElement<R>: RenderElement<R>,
+    WorkspaceRenderElement<R>: RenderElement<R>,
+{
+    let mode = output
+        .current_mode()
+        .ok_or_else(|| anyhow!("Output has no mode"))?;
+    let transform = output.current_transform();
+    let scale = output.current_scale().fractional_scale();
+
+    // Buffer is laid out without transform, matching the image_copy_capture convention.
+    let _ = transform;
+    let buffer_size = mode.size.to_logical(1).to_buffer(1, Transform::Normal);
+
+    let format = Fourcc::Abgr8888;
+    let mut render_buffer =
+        Offscreen::<GlesRenderbuffer>::create_buffer(renderer, format, buffer_size)
+            .map_err(|e| anyhow!("Failed to create offscreen buffer: {e}"))?;
+    let mut fb = renderer
+        .bind(&mut render_buffer)
+        .map_err(|e| anyhow!("Failed to bind offscreen buffer: {e}"))?;
+
+    let mut damage_tracker = OutputDamageTracker::from_output(output);
+
+    let res = render_workspace(
+        gpu,
+        renderer,
+        &mut fb,
+        &mut damage_tracker,
+        0,
+        None,
+        shell,
+        zoom_state,
+        now,
+        output,
+        None,
+        current,
+        CursorMode::None,
+        ElementFilter::All,
+    )
+    .map_err(|e| anyhow!("render_workspace failed: {e}"))?;
+    renderer
+        .wait(&res.0.sync)
+        .map_err(|e| anyhow!("Failed to wait on render sync: {e}"))?;
+
+    // Logical output-local coord -> buffer coord.
+    let px = (x as f64 * scale).floor() as i32;
+    let py = (y as f64 * scale).floor() as i32;
+    let region = Rectangle::new((px, py).into(), (1, 1).into());
+
+    let mapping = renderer
+        .copy_framebuffer(&fb, region, format)
+        .map_err(|e| anyhow!("copy_framebuffer failed: {e}"))?;
+    let bytes = renderer
+        .map_texture(&mapping)
+        .map_err(|e| anyhow!("map_texture failed: {e}"))?;
+    if bytes.len() < 4 {
+        return Err(anyhow!("Unexpected pixel data length: {}", bytes.len()));
+    }
+
+    let r = bytes[0] as f64 / 255.0;
+    let g = bytes[1] as f64 / 255.0;
+    let b = bytes[2] as f64 / 255.0;
+    Ok((r, g, b))
+}


### PR DESCRIPTION
Adds a DBus interface that allows `xdg-desktop-portal-cosmic` to ask for the color of a pixel.


~~Note: this does not work with "zoom" and I have no idea how to make it work.~~
I changed the API, instead of `pick_pixel(coords)` it's now `color_under_cursor` so the user won't send the coords. The compositor knows what's under the cursor, if the screen is zoomed in, scaled, rotated,... 
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

