### PR TITLE
Fix IME popup positioning for Wayland input-method-v2 clients

### DIFF
--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -197,7 +197,7 @@ impl PointerFocusTarget {
             PointerFocusTarget::WlSurface {
                 toplevel: Some(PointerFocusToplevel::Popup(PopupKind::Xdg(popup))),
                 ..
-            } => get_popup_toplevel(popup)
+            } => get_popup_toplevel(&PopupKind::Xdg(popup.clone()))
                 .and_then(|s| shell.element_for_surface(&s).map(|mapped| (mapped, s)))
                 .and_then(|(m, s)| {
                     m.windows()
@@ -243,7 +243,7 @@ impl KeyboardFocusTarget {
         match self {
             KeyboardFocusTarget::Element(mapped) => mapped.wl_surface(),
             KeyboardFocusTarget::Popup(PopupKind::Xdg(xdg)) => {
-                get_popup_toplevel(xdg).map(Cow::Owned)
+                get_popup_toplevel(&PopupKind::Xdg(xdg.clone())).map(Cow::Owned)
             }
             _ => None,
         }

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1278,7 +1278,7 @@ impl FloatingLayout {
         let Some(focused) = (match target {
             KeyboardFocusTarget::Popup(popup) => {
                 let Some(toplevel_surface) = (match popup {
-                    PopupKind::Xdg(xdg) => get_popup_toplevel(&xdg),
+                    PopupKind::Xdg(_) => get_popup_toplevel(&popup),
                     PopupKind::InputMethod(_) => unreachable!(),
                 }) else {
                     return MoveResult::None;

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -2848,7 +2848,7 @@ impl TilingLayout {
         // if the focus is currently on a popup, treat it's toplevel as the target
         if let KeyboardFocusTarget::Popup(popup) = target {
             let toplevel_surface = match popup {
-                PopupKind::Xdg(xdg) => get_popup_toplevel(&xdg),
+                PopupKind::Xdg(_) => get_popup_toplevel(&popup),
                 PopupKind::InputMethod(_) => unreachable!(),
             }?;
             let root_id = tree.root_node_id()?;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3883,7 +3883,7 @@ impl Shell {
         let Some(focused) = (match target {
             KeyboardFocusTarget::Popup(popup) => {
                 let Some(toplevel_surface) = (match popup {
-                    PopupKind::Xdg(xdg) => get_popup_toplevel(&xdg),
+                    PopupKind::Xdg(_) => get_popup_toplevel(&popup),
                     PopupKind::InputMethod(_) => unreachable!(),
                 }) else {
                     return FocusResult::None;

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -281,6 +281,10 @@ impl CompositorHandler for State {
 
         if let Some(popup) = self.common.popups.find_popup(surface) {
             xdg_popup_ensure_initial_configure(&popup);
+            // The IME popup need to be repositioned when the size changed
+            if let PopupKind::InputMethod(_) = popup {
+                shell.unconstrain_popup(&popup);
+            }
             return;
         }
 

--- a/src/wayland/handlers/input_method.rs
+++ b/src/wayland/handlers/input_method.rs
@@ -12,6 +12,11 @@ use tracing::warn;
 
 impl InputMethodHandler for State {
     fn new_popup(&mut self, surface: PopupSurface) {
+        self.common
+            .shell
+            .read()
+            .unconstrain_popup(&PopupKind::from(surface.clone()));
+
         if let Err(err) = self.common.popups.track_popup(PopupKind::from(surface)) {
             warn!("Failed to track popup: {}", err);
         }
@@ -32,7 +37,9 @@ impl InputMethodHandler for State {
             .unwrap_or_default()
     }
 
-    fn popup_repositioned(&mut self, _: PopupSurface) {}
+    fn popup_repositioned(&mut self, popup: PopupSurface) {
+        self.common.shell.read().unconstrain_popup(&popup.into());
+    }
 }
 
 delegate_input_method_manager!(State);

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -40,7 +40,10 @@ impl WlrLayerShellHandler for State {
     }
 
     fn new_popup(&mut self, _parent: WlrLayerSurface, popup: PopupSurface) {
-        self.common.shell.read().unconstrain_popup(&popup);
+        self.common
+            .shell
+            .read()
+            .unconstrain_popup(&PopupKind::from(popup.clone()));
 
         if let Err(err) = popup.send_configure() {
             tracing::warn!("Unable to configure popup. {err:?}",);

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -65,7 +65,10 @@ impl XdgShellHandler for State {
 
         if surface.get_parent_surface().is_some() {
             // let other shells deal with their popups
-            self.common.shell.read().unconstrain_popup(&surface);
+            self.common
+                .shell
+                .read()
+                .unconstrain_popup(&PopupKind::from(surface.clone()));
 
             if let Err(err) = surface.send_configure() {
                 warn!("Unable to configure popup. {err:?}",);
@@ -165,7 +168,10 @@ impl XdgShellHandler for State {
             state.positioner = positioner;
         });
 
-        self.common.shell.read().unconstrain_popup(&surface);
+        self.common
+            .shell
+            .read()
+            .unconstrain_popup(&PopupKind::from(surface.clone()));
         surface.send_repositioned(token);
     }
 

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -148,14 +148,7 @@ fn unconstrain_xdg_popup(
 ) {
     rect.loc -= window_loc;
     rect.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone())).as_global();
-    let geometry = surface.with_pending_state(|state| {
-        state
-            .positioner
-            .get_unconstrained_geometry(rect.as_logical())
-    });
-    surface.with_pending_state(|state| {
-        state.geometry = geometry;
-    });
+    position_popup_within_rect(surface, rect);
 }
 
 fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surface: &LayerSurface) {
@@ -166,8 +159,15 @@ fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surfac
     let mut relative = Rectangle::from_size(output.geometry().size).as_logical();
     relative.loc -= layer_geo.loc;
     relative.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone()));
-    let geometry =
-        surface.with_pending_state(|state| state.positioner.get_unconstrained_geometry(relative));
+    position_popup_within_rect(surface, relative.as_global());
+}
+
+fn position_popup_within_rect(surface: &PopupSurface, rect: Rectangle<i32, Global>) {
+    let geometry = surface.with_pending_state(|state| {
+        state
+            .positioner
+            .get_unconstrained_geometry(rect.as_logical())
+    });
     surface.with_pending_state(|state| {
         state.geometry = geometry;
     });

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -24,7 +24,7 @@ use tracing::warn;
 
 impl Shell {
     pub fn unconstrain_popup(&self, surface: &PopupSurface) {
-        if let Some(parent) = get_popup_toplevel(surface) {
+        if let Some(parent) = get_popup_toplevel(&PopupKind::from(surface.clone())) {
             if let Some(elem) = self.element_for_surface(&parent) {
                 let (mut element_geo, output, is_tiled) =
                     if let Some(workspace) = self.space_for(elem) {
@@ -173,8 +173,11 @@ fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surfac
     });
 }
 
-pub fn get_popup_toplevel(popup: &PopupSurface) -> Option<WlSurface> {
-    let mut parent = popup.get_parent_surface()?;
+pub fn get_popup_toplevel(popup: &PopupKind) -> Option<WlSurface> {
+    let mut parent = match popup {
+        PopupKind::Xdg(popup) => popup.get_parent_surface()?,
+        PopupKind::InputMethod(popup) => popup.get_parent()?.surface.clone(),
+    };
     while get_role(&parent) == Some(XDG_POPUP_ROLE) {
         parent = with_states(&parent, |states| {
             states

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -128,17 +128,7 @@ pub fn update_reactive_popups<'a>(
 // Attempt to constraint to tile, without resize. Return `true` if it fits.
 fn unconstrain_xdg_popup_tile(surface: &PopupSurface, mut rect: Rectangle<i32, Logical>) -> bool {
     rect.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone()));
-    let geometry = surface.with_pending_state(|state| {
-        let mut positioner_no_resize = state.positioner;
-        positioner_no_resize
-            .constraint_adjustment
-            .remove(ConstraintAdjustment::ResizeX | ConstraintAdjustment::ResizeY);
-        positioner_no_resize.get_unconstrained_geometry(rect)
-    });
-    surface.with_pending_state(|state| {
-        state.geometry = geometry;
-    });
-    rect.contains_rect(geometry)
+    position_popup_within_rect(surface, rect.as_global(), true)
 }
 
 fn unconstrain_xdg_popup(
@@ -148,7 +138,7 @@ fn unconstrain_xdg_popup(
 ) {
     rect.loc -= window_loc;
     rect.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone())).as_global();
-    position_popup_within_rect(surface, rect);
+    position_popup_within_rect(surface, rect, false);
 }
 
 fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surface: &LayerSurface) {
@@ -159,18 +149,31 @@ fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surfac
     let mut relative = Rectangle::from_size(output.geometry().size).as_logical();
     relative.loc -= layer_geo.loc;
     relative.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone()));
-    position_popup_within_rect(surface, relative.as_global());
+    position_popup_within_rect(surface, relative.as_global(), false);
 }
 
-fn position_popup_within_rect(surface: &PopupSurface, rect: Rectangle<i32, Global>) {
+fn position_popup_within_rect(
+    surface: &PopupSurface,
+    rect: Rectangle<i32, Global>,
+    is_tiled: bool,
+) -> bool {
+    let rect = rect.as_logical();
     let geometry = surface.with_pending_state(|state| {
-        state
-            .positioner
-            .get_unconstrained_geometry(rect.as_logical())
+        let positioner = if is_tiled {
+            let mut positioner_no_resize = state.positioner;
+            positioner_no_resize
+                .constraint_adjustment
+                .remove(ConstraintAdjustment::ResizeX | ConstraintAdjustment::ResizeY);
+            positioner_no_resize
+        } else {
+            state.positioner
+        };
+        positioner.get_unconstrained_geometry(rect)
     });
     surface.with_pending_state(|state| {
         state.geometry = geometry;
     });
+    rect.contains_rect(geometry)
 }
 
 pub fn get_popup_toplevel(popup: &PopupKind) -> Option<WlSurface> {

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -4,7 +4,7 @@ use crate::{shell::Shell, utils::prelude::*};
 use smithay::{
     desktop::{
         LayerSurface, PopupKind, PopupManager, WindowSurfaceType, get_popup_toplevel_coords,
-        layer_map_for_output, space::SpaceElement,
+        layer_map_for_output, space::SpaceElement, utils,
     },
     output::Output,
     reexports::{
@@ -175,7 +175,33 @@ fn position_popup_within_rect(
             });
             rect.contains_rect(geometry)
         }
-        PopupKind::InputMethod(_) => false,
+        PopupKind::InputMethod(popup) => {
+            let input_rect = popup.text_input_rectangle();
+
+            // We basically place the IME popup below the input rect.
+            let mut popup_bbox = utils::bbox_from_surface_tree(popup.wl_surface(), input_rect.loc);
+            popup_bbox.loc.y += input_rect.size.h;
+            // tracing::debug!(
+            //     "IME input_rect: {:?}, popup_bbox: {:?}",
+            //     input_rect,
+            //     popup_bbox
+            // );
+
+            // Handle the right edge overflow
+            let popup_right = popup_bbox.loc.x + popup_bbox.size.w;
+            let rect_right = rect.loc.x + rect.size.w;
+            popup_bbox.loc.x -= (popup_right - rect_right).max(0);
+
+            // Flip vertically if the bottom edge overflows
+            let popup_bottom = popup_bbox.loc.y + popup_bbox.size.h;
+            let rect_bottom = rect.loc.y + rect.size.h;
+            if popup_bottom > rect_bottom {
+                popup_bbox.loc.y = input_rect.loc.y - popup_bbox.size.h;
+            }
+
+            popup.set_location(popup_bbox.loc);
+            rect.as_logical().contains_rect(popup_bbox)
+        }
     }
 }
 

--- a/src/wayland/handlers/xdg_shell/popup.rs
+++ b/src/wayland/handlers/xdg_shell/popup.rs
@@ -15,16 +15,14 @@ use smithay::{
     wayland::{
         compositor::{get_role, with_states},
         seat::WaylandFocus,
-        shell::xdg::{
-            PopupCachedState, PopupSurface, ToplevelSurface, XDG_POPUP_ROLE, XdgPopupSurfaceData,
-        },
+        shell::xdg::{PopupCachedState, ToplevelSurface, XDG_POPUP_ROLE, XdgPopupSurfaceData},
     },
 };
 use tracing::warn;
 
 impl Shell {
-    pub fn unconstrain_popup(&self, surface: &PopupSurface) {
-        if let Some(parent) = get_popup_toplevel(&PopupKind::from(surface.clone())) {
+    pub fn unconstrain_popup(&self, surface: &PopupKind) {
+        if let Some(parent) = get_popup_toplevel(surface) {
             if let Some(elem) = self.element_for_surface(&parent) {
                 let (mut element_geo, output, is_tiled) =
                     if let Some(workspace) = self.space_for(elem) {
@@ -110,7 +108,7 @@ pub fn update_reactive_popups<'a>(
                         .find(|geo| geo.contains(anchor_point))
                         .copied()
                     {
-                        unconstrain_xdg_popup(&surface, loc, rect);
+                        unconstrain_xdg_popup(&PopupKind::from(surface.clone()), loc, rect);
                         if let Err(err) = surface.send_configure() {
                             warn!(
                                 ?err,
@@ -126,54 +124,59 @@ pub fn update_reactive_popups<'a>(
 }
 
 // Attempt to constraint to tile, without resize. Return `true` if it fits.
-fn unconstrain_xdg_popup_tile(surface: &PopupSurface, mut rect: Rectangle<i32, Logical>) -> bool {
-    rect.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone()));
+fn unconstrain_xdg_popup_tile(surface: &PopupKind, mut rect: Rectangle<i32, Logical>) -> bool {
+    rect.loc -= get_popup_toplevel_coords(surface);
     position_popup_within_rect(surface, rect.as_global(), true)
 }
 
 fn unconstrain_xdg_popup(
-    surface: &PopupSurface,
+    surface: &PopupKind,
     window_loc: Point<i32, Global>,
     mut rect: Rectangle<i32, Global>,
 ) {
     rect.loc -= window_loc;
-    rect.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone())).as_global();
+    rect.loc -= get_popup_toplevel_coords(surface).as_global();
     position_popup_within_rect(surface, rect, false);
 }
 
-fn unconstrain_layer_popup(surface: &PopupSurface, output: &Output, layer_surface: &LayerSurface) {
+fn unconstrain_layer_popup(surface: &PopupKind, output: &Output, layer_surface: &LayerSurface) {
     let map = layer_map_for_output(output);
     let layer_geo = map.layer_geometry(layer_surface).unwrap();
 
     // the output_rect represented relative to the parents coordinate system
     let mut relative = Rectangle::from_size(output.geometry().size).as_logical();
     relative.loc -= layer_geo.loc;
-    relative.loc -= get_popup_toplevel_coords(&PopupKind::Xdg(surface.clone()));
+    relative.loc -= get_popup_toplevel_coords(surface);
     position_popup_within_rect(surface, relative.as_global(), false);
 }
 
 fn position_popup_within_rect(
-    surface: &PopupSurface,
+    surface: &PopupKind,
     rect: Rectangle<i32, Global>,
     is_tiled: bool,
 ) -> bool {
-    let rect = rect.as_logical();
-    let geometry = surface.with_pending_state(|state| {
-        let positioner = if is_tiled {
-            let mut positioner_no_resize = state.positioner;
-            positioner_no_resize
-                .constraint_adjustment
-                .remove(ConstraintAdjustment::ResizeX | ConstraintAdjustment::ResizeY);
-            positioner_no_resize
-        } else {
-            state.positioner
-        };
-        positioner.get_unconstrained_geometry(rect)
-    });
-    surface.with_pending_state(|state| {
-        state.geometry = geometry;
-    });
-    rect.contains_rect(geometry)
+    match surface {
+        PopupKind::Xdg(surface) => {
+            let rect = rect.as_logical();
+            let geometry = surface.with_pending_state(|state| {
+                let positioner = if is_tiled {
+                    let mut positioner_no_resize = state.positioner;
+                    positioner_no_resize
+                        .constraint_adjustment
+                        .remove(ConstraintAdjustment::ResizeX | ConstraintAdjustment::ResizeY);
+                    positioner_no_resize
+                } else {
+                    state.positioner
+                };
+                positioner.get_unconstrained_geometry(rect)
+            });
+            surface.with_pending_state(|state| {
+                state.geometry = geometry;
+            });
+            rect.contains_rect(geometry)
+        }
+        PopupKind::InputMethod(_) => false,
+    }
 }
 
 pub fn get_popup_toplevel(popup: &PopupKind) -> Option<WlSurface> {


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/2284 and https://github.com/pop-os/cosmic-comp/issues/1530

Also, this fixes the root cause of https://github.com/pop-os/iced/pull/291 (this workarounds #1530 for only COSMIC apps)

AFAICT, this affects to [input-method-v2 protocol](https://wayland.app/protocols/input-method-unstable-v2) clients like:
- `winit` based apps including COSMIC apps
- GTK apps or Qt apps without `GTK_`/`QT_IM_MODULE` environment variable

As far as I tested, this didn't change the behavior of GTK apps under `GTK_IM_MODULE=fcitx` set or Qt apps under `QT_IM_MODULE=fcitx` set.

Basic idea is same as the [Niri's fix](https://github.com/niri-wm/niri/pull/295):

- Adapt `unconstrain_popup()` for `PopupKind::InputMethod`
- Implmenet positioning logic based on `text_input_rectangle` as code comment
- And (re-)unconstrain when the InputMethod popup is created, resized, repositioned

To fix https://github.com/pop-os/cosmic-comp/issues/2284 for COSMIC apps additionaly we need to revert
- https://github.com/pop-os/iced/pull/291
- see also:
  - https://github.com/pop-os/iced/pull/332

and re-build COSMIC apps with new libcosmic (with this iced)

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

