### PR TITLE
floating: don't panic if window disappears mid-unminimize

### DIFF
--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -623,6 +623,10 @@ impl FloatingLayout {
         from: Rectangle<i32, Local>,
         position: Point<i32, Local>,
     ) {
+        if !mapped.alive() {
+            return;
+        }
+
         let output = self.space.outputs().next().unwrap().clone();
         let layers = layer_map_for_output(&output);
         let geometry = layers.non_exclusive_zone().as_local();
@@ -642,14 +646,7 @@ impl FloatingLayout {
         self.space
             .map_element(mapped.clone(), position.as_logical(), true);
         self.space.refresh();
-        // The window can disappear between `map_element` and the geometry
-        // lookup if the client crashes mid-unminimize (race observed in
-        // pop-os/cosmic-comp#2332). Skip the animation rather than panic —
-        // the window is already gone, there's nothing to animate.
-        let Some(target_geometry) = self.space.element_geometry(&mapped) else {
-            return;
-        };
-        let target_geometry = target_geometry.as_local();
+        let target_geometry = self.space.element_geometry(&mapped).unwrap().as_local();
 
         self.animations.insert(
             mapped,

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -636,7 +636,14 @@ impl FloatingLayout {
         self.space
             .map_element(mapped.clone(), position.as_logical(), true);
         self.space.refresh();
-        let target_geometry = self.space.element_geometry(&mapped).unwrap().as_local();
+        // The window can disappear between `map_element` and the geometry
+        // lookup if the client crashes mid-unminimize (race observed in
+        // pop-os/cosmic-comp#2332). Skip the animation rather than panic —
+        // the window is already gone, there's nothing to animate.
+        let Some(target_geometry) = self.space.element_geometry(&mapped) else {
+            return;
+        };
+        let target_geometry = target_geometry.as_local();
 
         self.animations.insert(
             mapped,

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -642,7 +642,14 @@ impl FloatingLayout {
         self.space
             .map_element(mapped.clone(), position.as_logical(), true);
         self.space.refresh();
-        let target_geometry = self.space.element_geometry(&mapped).unwrap().as_local();
+        // The window can disappear between `map_element` and the geometry
+        // lookup if the client crashes mid-unminimize (race observed in
+        // pop-os/cosmic-comp#2332). Skip the animation rather than panic —
+        // the window is already gone, there's nothing to animate.
+        let Some(target_geometry) = self.space.element_geometry(&mapped) else {
+            return;
+        };
+        let target_geometry = target_geometry.as_local();
 
         self.animations.insert(
             mapped,


### PR DESCRIPTION
Fixes #2332.

`remap_minimized` calls `self.space.element_geometry(&mapped).unwrap()` after `map_element`. If the client crashes between those two calls (the race the user saw, `Apr 30 13:56:40 ... panicked at floating/mod.rs:639` followed by EGL_BAD_DISPLAY tearing the rest of the desktop down), `element_geometry` returns `None` and the unwrap brings down the compositor with it. Skip the animation in that case, the window is already gone, there's nothing to animate.