### PR TITLE
image-copy: Fixes for cursor capture sessions

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -640,11 +640,13 @@ impl State {
 
                     for session in cursor_sessions_for_output(&shell, &output) {
                         if let Some((geometry, offset)) = seat.cursor_geometry(
-                            position.as_logical().to_buffer(
-                                output.current_scale().fractional_scale(),
-                                output.current_transform(),
-                                &output_geometry.size.to_f64().as_logical(),
-                            ),
+                            (position - output_geometry.loc.to_f64())
+                                .as_logical()
+                                .to_buffer(
+                                    output.current_scale().fractional_scale(),
+                                    output.current_transform(),
+                                    &output_geometry.size.to_f64().as_logical(),
+                                ),
                             self.common.clock.now(),
                         ) {
                             if session
@@ -676,11 +678,11 @@ impl State {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     notify_cursor_activity(self, &seat);
                     let output = seat.active_output();
-                    let geometry = output.geometry();
-                    let position = geometry.loc.to_f64()
+                    let output_geometry = output.geometry();
+                    let position = output_geometry.loc.to_f64()
                         + smithay::backend::input::AbsolutePositionEvent::position_transformed(
                             &event,
-                            geometry.size.as_logical(),
+                            output_geometry.size.as_logical(),
                         )
                         .as_global();
                     let serial = SERIAL_COUNTER.next_serial();
@@ -702,11 +704,13 @@ impl State {
                     let shell = self.common.shell.read();
                     for session in cursor_sessions_for_output(&shell, &output) {
                         if let Some((geometry, offset)) = seat.cursor_geometry(
-                            position.as_logical().to_buffer(
-                                output.current_scale().fractional_scale(),
-                                output.current_transform(),
-                                &geometry.size.to_f64().as_logical(),
-                            ),
+                            (position - output_geometry.loc.to_f64())
+                                .as_logical()
+                                .to_buffer(
+                                    output.current_scale().fractional_scale(),
+                                    output.current_transform(),
+                                    &output_geometry.size.to_f64().as_logical(),
+                                ),
                             self.common.clock.now(),
                         ) {
                             if session

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2481,6 +2481,7 @@ impl State {
     }
 }
 
+// Output and workspace sessions for the given output
 fn cursor_sessions_for_output<'a>(
     shell: &'a Shell,
     output: &'a Output,
@@ -2489,14 +2490,9 @@ fn cursor_sessions_for_output<'a>(
         .active_space(output)
         .into_iter()
         .flat_map(|workspace| {
-            let fullscreen_cursors: Vec<_> = workspace
-                .get_fullscreen_surfaces()
-                .flat_map(|f| f.surface.cursor_sessions())
-                .collect();
             workspace
                 .cursor_sessions()
                 .into_iter()
-                .chain(fullscreen_cursors)
                 .chain(output.cursor_sessions())
         })
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -64,7 +64,7 @@ use smithay::{
             protocol::{wl_shm::Format as ShmFormat, wl_surface::WlSurface},
         },
     },
-    utils::{Logical, Point, Rectangle, SERIAL_COUNTER, Serial},
+    utils::{Logical, Point, Rectangle, SERIAL_COUNTER, Serial, Size},
     wayland::{
         compositor::CompositorHandler,
         image_copy_capture::{BufferConstraints, CursorSessionRef},
@@ -654,8 +654,13 @@ impl State {
                                 .map(|constraint| constraint.size != geometry.size)
                                 .unwrap_or(true)
                             {
+                                let mut cursor_size = geometry.size;
+                                // Client shouldn't try to allocate 0x0 buffer
+                                if cursor_size == Size::new(0, 0) {
+                                    cursor_size = Size::new(1, 1);
+                                }
                                 session.update_constraints(BufferConstraints {
-                                    size: geometry.size,
+                                    size: cursor_size,
                                     shm: vec![ShmFormat::Argb8888],
                                     dma: None,
                                 });
@@ -718,8 +723,13 @@ impl State {
                                 .map(|constraint| constraint.size != geometry.size)
                                 .unwrap_or(true)
                             {
+                                let mut cursor_size = geometry.size;
+                                // Client shouldn't try to allocate 0x0 buffer
+                                if cursor_size == Size::new(0, 0) {
+                                    cursor_size = Size::new(1, 1);
+                                }
                                 session.update_constraints(BufferConstraints {
-                                    size: geometry.size,
+                                    size: cursor_size,
                                     shm: vec![ShmFormat::Argb8888],
                                     dma: None,
                                 });

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -46,7 +46,7 @@ use smithay::{
     },
     wayland::{
         compositor::{
-            SubsurfaceCachedState, SurfaceData, TraversalAction, with_states,
+            SubsurfaceCachedState, SurfaceData, TraversalAction, get_parent, with_states,
             with_surface_tree_downward,
         },
         seat::WaylandFocus,
@@ -674,38 +674,24 @@ impl CosmicSurface {
         root: &WlSurface,
         surface: &WlSurface,
     ) -> Option<Point<i32, Logical>> {
-        if root == surface {
-            return Some(Point::default());
-        }
-
-        let found = AtomicBool::new(false);
-        let mut found_offset = Point::<i32, Logical>::default();
-
-        with_surface_tree_downward(
-            root,
-            Point::<i32, Logical>::default(),
-            |s, states, parent_offset| {
-                let mut offset = *parent_offset;
-                if s != root {
-                    offset += states
+        let mut offset = Point::<i32, Logical>::default();
+        let mut parent = surface.clone();
+        loop {
+            if parent == *root {
+                return Some(offset);
+            } else if let Some(s) = get_parent(&parent) {
+                offset += with_states(&parent, |states| {
+                    states
                         .cached_state
                         .get::<SubsurfaceCachedState>()
                         .current()
-                        .location;
-                }
-                TraversalAction::DoChildren(offset)
-            },
-            |s, _, offset| {
-                if s == surface {
-                    found_offset = *offset;
-                    found.store(true, Ordering::SeqCst);
-                }
-            },
-            |_, _, _| !found.load(Ordering::SeqCst),
-        );
-
-        if found.load(Ordering::SeqCst) {
-            return Some(found_offset);
+                        .location
+                });
+                parent = s;
+            } else {
+                // `parent` is now root of subsurface tree; `surface` is not a subsurface child of `root`
+                break;
+            }
         }
 
         for (popup, popup_offset) in PopupManager::popups_for_surface(root) {

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -245,18 +245,25 @@ impl PointerFocusTarget {
         }
 
         let cursor_pos = if let Some(wl_surface) = self.wl_surface() {
-            let geometry_loc = with_states(&wl_surface, |states| {
-                states
-                    .cached_state
-                    .get::<SurfaceCachedState>()
-                    .current()
-                    .geometry
-                    .map(|g| g.loc.to_f64())
-            })
-            .unwrap_or_default();
-
+            let surface_offset = toplevel
+                .surface_offset(&wl_surface)
+                .unwrap_or(Point::from((0, 0)))
+                .to_f64();
+            let geometry_loc = toplevel
+                .wl_surface()
+                .and_then(|s| {
+                    with_states(&s, |states| {
+                        states
+                            .cached_state
+                            .get::<SurfaceCachedState>()
+                            .current()
+                            .geometry
+                            .map(|g| g.loc.to_f64())
+                    })
+                })
+                .unwrap_or_default();
             Some(
-                (event.location - geometry_loc)
+                (event.location - geometry_loc + surface_offset)
                     .to_buffer(1.0, Transform::Normal, &toplevel.geometry().size.to_f64())
                     .to_i32_round(),
             )

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -37,7 +37,10 @@ use smithay::{
         Client, DisplayHandle, Resource, backend::ObjectId, protocol::wl_surface::WlSurface,
     },
     utils::{IsAlive, Logical, Point, Serial, Transform},
-    wayland::{seat::WaylandFocus, selection::data_device::WlOfferData, session_lock::LockSurface},
+    wayland::{
+        compositor::with_states, seat::WaylandFocus, selection::data_device::WlOfferData,
+        session_lock::LockSurface, shell::xdg::SurfaceCachedState,
+    },
     xwayland::{
         X11Surface,
         xwm::{XwmId, XwmOfferData},
@@ -241,10 +244,19 @@ impl PointerFocusTarget {
             return;
         }
 
-        let cursor_pos = if let Some(_wl_surface) = self.wl_surface() {
+        let cursor_pos = if let Some(wl_surface) = self.wl_surface() {
+            let geometry_loc = with_states(&wl_surface, |states| {
+                states
+                    .cached_state
+                    .get::<SurfaceCachedState>()
+                    .current()
+                    .geometry
+                    .map(|g| g.loc.to_f64())
+            })
+            .unwrap_or_default();
+
             Some(
-                event
-                    .location
+                (event.location - geometry_loc)
                     .to_buffer(1.0, Transform::Normal, &toplevel.geometry().size.to_f64())
                     .to_i32_round(),
             )

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -241,12 +241,17 @@ impl PointerFocusTarget {
             return;
         }
 
-        let cursor_pos = Some(
-            event
-                .location
-                .to_buffer(1.0, Transform::Normal, &toplevel.geometry().size.to_f64())
-                .to_i32_round(),
-        );
+        let cursor_pos = if let Some(_wl_surface) = self.wl_surface() {
+            Some(
+                event
+                    .location
+                    .to_buffer(1.0, Transform::Normal, &toplevel.geometry().size.to_f64())
+                    .to_i32_round(),
+            )
+        } else {
+            // If cursor is in SSD, instead of a `wl_surface`, it is outside the captured bounds
+            None
+        };
 
         let cursor_hotspot = if let Some((_, hotspot)) =
             seat.cursor_geometry((0.0, 0.0), Duration::from_millis(event.time as u64).into())

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -225,6 +225,42 @@ impl PointerFocusTarget {
             _ => false,
         }
     }
+
+    // Update image copy cursor position/hotspot for enter/motion event
+    fn update_image_copy_cursor_position(
+        &self,
+        seat: &Seat<State>,
+        data: &mut State,
+        event: &PointerMotionEvent,
+    ) {
+        let Some(toplevel) = self.toplevel(&data.common.shell.read()) else {
+            return;
+        };
+        let cursor_sessions = toplevel.cursor_sessions();
+        if cursor_sessions.is_empty() {
+            return;
+        }
+
+        let cursor_pos = Some(
+            event
+                .location
+                .to_buffer(1.0, Transform::Normal, &toplevel.geometry().size.to_f64())
+                .to_i32_round(),
+        );
+
+        let cursor_hotspot = if let Some((_, hotspot)) =
+            seat.cursor_geometry((0.0, 0.0), Duration::from_millis(event.time as u64).into())
+        {
+            hotspot
+        } else {
+            Point::from((0, 0))
+        };
+
+        for session in cursor_sessions {
+            session.set_cursor_pos(cursor_pos);
+            session.set_cursor_hotspot(cursor_hotspot);
+        }
+    }
 }
 
 impl KeyboardFocusTarget {
@@ -337,47 +373,11 @@ impl IsAlive for KeyboardFocusTarget {
 
 impl PointerTarget<State> for PointerFocusTarget {
     fn enter(&self, seat: &Seat<State>, data: &mut State, event: &PointerMotionEvent) {
-        let toplevel = self.toplevel(&data.common.shell.read());
-        if let Some(element) = toplevel {
-            for session in element.cursor_sessions() {
-                session.set_cursor_pos(Some(
-                    event
-                        .location
-                        .to_buffer(1.0, Transform::Normal, &element.geometry().size.to_f64())
-                        .to_i32_round(),
-                ));
-                if let Some((_, hotspot)) = seat
-                    .cursor_geometry((0.0, 0.0), Duration::from_millis(event.time as u64).into())
-                {
-                    session.set_cursor_hotspot(hotspot);
-                } else {
-                    session.set_cursor_hotspot((0, 0));
-                }
-            }
-        }
-
+        self.update_image_copy_cursor_position(seat, data, event);
         self.inner_pointer_target().enter(seat, data, event);
     }
     fn motion(&self, seat: &Seat<State>, data: &mut State, event: &PointerMotionEvent) {
-        let toplevel = self.toplevel(&data.common.shell.read());
-        if let Some(element) = toplevel {
-            for session in element.cursor_sessions() {
-                session.set_cursor_pos(Some(
-                    event
-                        .location
-                        .to_buffer(1.0, Transform::Normal, &element.geometry().size.to_f64())
-                        .to_i32_round(),
-                ));
-                if let Some((_, hotspot)) = seat
-                    .cursor_geometry((0.0, 0.0), Duration::from_millis(event.time as u64).into())
-                {
-                    session.set_cursor_hotspot(hotspot);
-                } else {
-                    session.set_cursor_hotspot((0, 0));
-                }
-            }
-        }
-
+        self.update_image_copy_cursor_position(seat, data, event);
         self.inner_pointer_target().motion(seat, data, event);
     }
     fn relative_motion(&self, seat: &Seat<State>, data: &mut State, event: &RelativeMotionEvent) {

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -753,11 +753,15 @@ pub fn render_cursor_to_buffer(
     seat: &Seat<State>,
 ) {
     let buffer = frame.buffer();
-    let cursor_size = seat
+    let mut cursor_size = seat
         .cursor_geometry((0.0, 0.0), state.common.clock.now())
         .map(|(geo, _hotspot)| geo.size)
         .unwrap_or_else(|| Size::from((64, 64)));
     let buffer_size = buffer_dimensions(&buffer).unwrap();
+    // Client shouldn't try to allocate 0x0 buffer
+    if cursor_size == Size::new(0, 0) {
+        cursor_size = Size::new(1, 1);
+    }
     if buffer_size != cursor_size {
         let constraints = BufferConstraints {
             size: cursor_size,


### PR DESCRIPTION
We should probably handle this a bit differently, so we don't either need to duplicate the cursor session code every time `pointer.motion` is called, or have it miss out on pointer motions from "focus follows cursor" etc.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

