### PR TITLE
kms: Try to re-open devices after resume on permission errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,7 +4924,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=0d14cd6#0d14cd655f6e905ad5110ff0384400da223f2cab"
+source = "git+https://github.com/smithay/smithay.git?rev=774f2ab#774f2ab010e080a2f79176d0e12eb63d5e09d680"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1540,7 +1540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2710,7 +2710,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2823,7 +2823,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "770919970f7d2f74fea948900d35e2ef64f44129e8ae4015f59de1f0aca7c2a5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3433,7 +3433,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4629,7 +4629,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4924,7 +4924,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=211c19d#211c19d712dc5f1b78eb879f1c195715801e37ff"
+source = "git+https://github.com/smithay/smithay.git?rev=0d14cd6#0d14cd655f6e905ad5110ff0384400da223f2cab"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -5254,7 +5254,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6273,7 +6273,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,4 +143,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "211c19d" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "0d14cd6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,4 +143,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "0d14cd6" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "774f2ab" }

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -28,7 +28,7 @@ use smithay::{
         },
         egl::{EGLContext, EGLDevice, EGLDisplay, context::ContextPriority},
         renderer::glow::GlowRenderer,
-        session::Session,
+        session::{Session, libseat::LibSeatSession},
     },
     desktop::utils::OutputPresentationFeedback,
     output::{Mode as OutputMode, Output, PhysicalProperties, Scale, Subpixel},
@@ -40,7 +40,10 @@ use smithay::{
         wayland_server::DisplayHandle,
     },
     utils::{Clock, DevPath, DeviceFd, Monotonic, Point, Transform},
-    wayland::drm_lease::{DrmLease, DrmLeaseState},
+    wayland::{
+        drm_lease::{DrmLease, DrmLeaseState},
+        drm_syncobj::supports_syncobj_eventfd,
+    },
 };
 use tracing::{error, info, warn};
 use wayland_backend::server::ClientId;
@@ -97,6 +100,20 @@ pub struct Device {
     pub texture_formats: FormatSet,
     event_token: Option<RegistrationToken>,
     pub socket: Option<Socket>,
+}
+
+#[derive(Debug)]
+struct ReusableDevice {
+    leasing_global: Option<DrmLeaseState>,
+    active_clients: HashSet<ClientId>,
+    socket: Option<Socket>,
+}
+
+#[derive(Debug)]
+struct OldDeviceState {
+    fd: DeviceFd,
+    outputs: HashMap<connector::Handle, Output>,
+    leased_connectors: HashSet<connector::Handle>,
 }
 
 #[derive(Debug)]
@@ -222,138 +239,14 @@ impl State {
             }
         }
 
-        let fd = DrmDeviceFd::new(DeviceFd::from(
-            self.backend
-                .kms()
-                .session
-                .open(
-                    path,
-                    OFlags::RDWR | OFlags::CLOEXEC | OFlags::NOCTTY | OFlags::NONBLOCK,
-                )
-                .with_context(|| {
-                    format!(
-                        "Failed to optain file descriptor for drm device: {}",
-                        path.display()
-                    )
-                })?,
-        ));
-        let (drm, notifier) = DrmDevice::new(fd.clone(), false)
-            .with_context(|| format!("Failed to initialize drm device for: {}", path.display()))?;
-        let drm_node = DrmNode::from_dev_id(dev)?;
-        let supports_atomic = drm.is_atomic();
-
-        let gbm = GbmDevice::new(fd)
-            .with_context(|| format!("Failed to initialize GBM device for {}", path.display()))?;
-        let (render_node, render_formats, texture_formats, is_software) = {
-            let egl = init_egl(&gbm)?;
-
-            let render_node = egl
-                .device
-                .try_get_render_node()
-                .ok()
-                .and_then(std::convert::identity)
-                .unwrap_or(drm_node);
-            let render_formats = egl.context.dmabuf_render_formats().clone();
-            let texture_formats = egl.context.dmabuf_texture_formats().clone();
-
-            (
-                render_node,
-                render_formats,
-                texture_formats,
-                egl.device.is_software(),
-            )
-        };
-
-        let token = self
-            .common
-            .event_loop_handle
-            .insert_source(
-                notifier,
-                move |event, metadata, state: &mut State| match event {
-                    DrmEvent::VBlank(crtc) => {
-                        if let Some(device) = state.backend.kms().drm_devices.get_mut(&drm_node)
-                            && let Some(surface) = device.inner.surfaces.get_mut(&crtc)
-                        {
-                            surface.on_vblank(metadata.take());
-                        }
-                    }
-                    DrmEvent::Error(err) => {
-                        warn!(?err, "Failed to read events of device {:?}.", dev);
-                    }
-                },
-            )
-            .with_context(|| format!("Failed to add drm device to event loop: {}", dev))?;
-
-        let socket = match (!is_software)
-            .then(|| self.create_socket(dh, render_node, texture_formats.clone()))
-            .transpose()
-        {
-            Ok(socket) => socket,
-            Err(err) => {
-                warn!(
-                    ?err,
-                    "Failed to initialize hardware-acceleration for clients on {}.", render_node,
-                );
-                None
-            }
-        };
-
-        let leasing_global = match (!is_software)
-            .then(|| DrmLeaseState::new::<State>(dh, &drm_node))
-            .transpose()
-        {
-            Ok(global) => global,
-            Err(err) => {
-                // TODO: replace with inspect_err, once stable
-                warn!(
-                    ?err,
-                    "Failed to initialize drm lease global for: {}", drm_node
-                );
-                None
-            }
-        };
-
-        let drm = GbmDrmOutputManager::new(
-            drm,
-            GbmAllocator::new(
-                gbm.clone(),
-                GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT,
-            ),
-            GbmFramebufferExporter::new(gbm.clone(), render_node.into()),
-            Some(gbm.clone()),
-            [
-                Fourcc::Abgr2101010,
-                Fourcc::Argb2101010,
-                Fourcc::Abgr8888,
-                Fourcc::Argb8888,
-            ],
-            render_formats,
-        );
-
-        let mut device = Device {
-            drm,
-            inner: InnerDevice {
-                dev_node: drm_node,
-                render_node,
-                is_software,
-                egl: None,
-
-                outputs: HashMap::new(),
-                surfaces: HashMap::new(),
-                gbm,
-
-                leased_connectors: Vec::new(),
-                leasing_global,
-                active_leases: Vec::new(),
-                active_clients: HashSet::new(),
-            },
-
-            supports_atomic,
-            texture_formats,
-            event_token: Some(token),
-            socket,
-        };
-
+        let mut device = Device::new(
+            dev,
+            path,
+            &mut self.backend.kms().session,
+            &mut self.common,
+            dh,
+            None,
+        )?;
         let connectors = device.enumerate_surfaces()?.added; // There are no removed outputs on newly added devices
         let mut wl_outputs = Vec::new();
         let mut w = self.common.shell.read().global_space().size.w as u32;
@@ -387,7 +280,7 @@ impl State {
             // TODO atomic commit all surfaces together and drop surfaces, if it fails due to bandwidth
 
             let kms = self.backend.kms();
-            kms.drm_devices.insert(drm_node, device);
+            kms.drm_devices.insert(device.inner.dev_node, device);
         }
 
         self.common
@@ -489,6 +382,218 @@ impl State {
         Ok(outputs_added)
     }
 
+    pub fn reopen_device(
+        &mut self,
+        dev: dev_t,
+        path: &Path,
+        dh: &DisplayHandle,
+    ) -> Result<Vec<Output>> {
+        let backend = self.backend.kms();
+        let drm_node = backend
+            .drm_devices
+            .values()
+            .find_map(|device| {
+                (device.inner.dev_node.dev_id() == dev).then_some(device.inner.dev_node)
+            })
+            .with_context(|| format!("Couldn't find drm node for {}", dev))?;
+
+        if let Some(mut device) = backend.drm_devices.shift_remove(&drm_node) {
+            let is_primary = backend
+                .primary_node
+                .read()
+                .unwrap()
+                .is_some_and(|node| node == device.inner.render_node);
+
+            // all drm resources become inert
+            if let Some(token) = device.event_token.take() {
+                self.common.event_loop_handle.remove(token);
+            }
+            for (_, surface) in device.inner.surfaces.drain() {
+                surface.drop_and_join();
+            }
+            if let Some(leasing_global) = device.inner.leasing_global.as_mut() {
+                for (connector, _) in &device.inner.leased_connectors {
+                    leasing_global.withdraw_connector(*connector);
+                }
+                device.inner.active_leases.clear();
+            }
+
+            // These contain a reference to the file descriptor
+            backend.api.as_mut().remove_node(&device.inner.render_node);
+            // trigger enumeration
+            let _ = backend.api.devices();
+
+            for surface in backend
+                .drm_devices
+                .values_mut()
+                .flat_map(|device| device.inner.surfaces.values_mut())
+            {
+                surface.remove_node(device.inner.render_node);
+            }
+            let syncobj_guard =
+                if is_primary && let Some(syncobj_state) = backend.syncobj_state.as_mut() {
+                    Some(syncobj_state.close_device())
+                } else {
+                    None
+                };
+
+            let (reusable, mut old_state) = device.reuse();
+
+            match TryInto::<OwnedFd>::try_into(old_state.fd) {
+                Ok(fd) => {
+                    if let Err(err) = backend.session.close(fd) {
+                        warn!("Failed to close drm device fd: {}", err);
+                    }
+                }
+                Err(_) => {
+                    warn!(?drm_node, "Unable to close drm device fd cleanly.");
+                }
+            };
+
+            let mut new_device = Device::new(
+                dev,
+                path,
+                &mut backend.session,
+                &mut self.common,
+                dh,
+                Some(reusable),
+            )?;
+
+            if let Some(guard) = syncobj_guard {
+                let import_device = new_device.drm.device().device_fd().clone();
+                if supports_syncobj_eventfd(&import_device) {
+                    guard.update_device(import_device);
+                } else {
+                    drop(guard);
+                    dh.remove_global::<State>(backend.syncobj_state.take().unwrap().into_global());
+                }
+            }
+
+            let connectors = new_device.enumerate_surfaces()?.added;
+            let mut outputs_added = Vec::new();
+            let mut w = self.common.shell.read().global_space().size.w as u32;
+
+            {
+                for (conn, maybe_crtc) in connectors {
+                    if let Some(output) = old_state.outputs.remove(&conn) {
+                        let has_surface = if old_state.leased_connectors.contains(&conn) {
+                            if let Some(crtc) = maybe_crtc {
+                                new_device.inner.leased_connectors.push((conn, crtc));
+                                info!(
+                                    "Connector {} is non-desktop, setting up for leasing",
+                                    output.name()
+                                );
+                                if let Some(lease_state) = new_device.inner.leasing_global.as_mut()
+                                {
+                                    let physical = output.physical_properties();
+                                    lease_state.add_connector::<State>(
+                                        conn,
+                                        output.name(),
+                                        format!("{} {}", physical.make, physical.model),
+                                    );
+                                }
+                            } else {
+                                warn!(
+                                    "Connector {} is non-desktop, but we don't have a free crtc: not leasing",
+                                    output.name()
+                                );
+                            }
+                            false
+                        } else {
+                            let loc = output.current_location();
+                            populate_modes(
+                                new_device.drm.device_mut(),
+                                &output,
+                                conn,
+                                true,
+                                (loc.x as u32, loc.y as u32),
+                            )
+                            .with_context(|| "Failed to enumerate connector modes")?;
+
+                            if let Some(crtc) = maybe_crtc {
+                                match Surface::new(
+                                    &output,
+                                    crtc,
+                                    conn,
+                                    backend.primary_node.clone(),
+                                    new_device.inner.dev_node,
+                                    new_device.inner.render_node,
+                                    &self.common.event_loop_handle,
+                                    self.common.config.dynamic_conf.screen_filter().clone(),
+                                    self.common.shell.clone(),
+                                    self.common.startup_done.clone(),
+                                ) {
+                                    Ok(data) => {
+                                        new_device.inner.surfaces.insert(crtc, data);
+                                        true
+                                    }
+                                    Err(err) => {
+                                        error!(?crtc, "Failed to initialize surface: {}", err);
+                                        false
+                                    }
+                                }
+                            } else {
+                                false
+                            }
+                        };
+
+                        if !has_surface {
+                            output
+                                .user_data()
+                                .get::<RefCell<OutputConfig>>()
+                                .unwrap()
+                                .borrow_mut()
+                                .enabled = OutputState::Disabled;
+                        }
+                        new_device.inner.outputs.insert(conn, output);
+                    } else {
+                        match new_device.inner.connector_added(
+                            new_device.drm.device_mut(),
+                            backend.primary_node.clone(),
+                            conn,
+                            maybe_crtc,
+                            (w, 0),
+                            &self.common.event_loop_handle,
+                            self.common.config.dynamic_conf.screen_filter().clone(),
+                            self.common.shell.clone(),
+                            self.common.startup_done.clone(),
+                        ) {
+                            Ok((output, should_expose)) => {
+                                if should_expose {
+                                    w += output.geometry().size.w as u32;
+                                    outputs_added.push(output.clone());
+                                }
+
+                                new_device.inner.outputs.insert(conn, output);
+                            }
+                            Err(err) => {
+                                warn!(?err, "Failed to initialize output, skipping");
+                            }
+                        }
+                    }
+                }
+            }
+
+            self.common
+                .output_configuration_state
+                .remove_heads(old_state.outputs.values());
+            self.common
+                .output_configuration_state
+                .add_heads(outputs_added.iter());
+
+            for output in old_state.outputs.values() {
+                self.common.remove_output(output);
+            }
+
+            backend.drm_devices.insert(drm_node, new_device);
+            backend.refresh_used_devices()?;
+
+            Ok(outputs_added)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
     pub fn device_removed(&mut self, dev: dev_t, dh: &DisplayHandle) -> Result<()> {
         let backend = self.backend.kms();
         // we can't use DrmNode::from_node_id, because that assumes the node is still on sysfs
@@ -581,6 +686,158 @@ pub struct OutputChanges {
 }
 
 impl Device {
+    fn new(
+        dev: dev_t,
+        path: impl AsRef<Path>,
+        session: &mut LibSeatSession,
+        common: &mut Common,
+        dh: &DisplayHandle,
+        reuse: Option<ReusableDevice>,
+    ) -> Result<Self> {
+        let path = path.as_ref();
+        let fd = DrmDeviceFd::new(DeviceFd::from(
+            session
+                .open(
+                    path,
+                    OFlags::RDWR | OFlags::CLOEXEC | OFlags::NOCTTY | OFlags::NONBLOCK,
+                )
+                .with_context(|| {
+                    format!(
+                        "Failed to optain file descriptor for drm device: {}",
+                        path.display()
+                    )
+                })?,
+        ));
+        let (drm, notifier) = DrmDevice::new(fd.clone(), false)
+            .with_context(|| format!("Failed to initialize drm device for: {}", path.display()))?;
+        let dev_node = DrmNode::from_dev_id(dev)?;
+        let supports_atomic = drm.is_atomic();
+
+        let gbm = GbmDevice::new(fd)
+            .with_context(|| format!("Failed to initialize GBM device for {}", path.display()))?;
+        let (render_node, render_formats, texture_formats, is_software) = {
+            let egl = init_egl(&gbm)?;
+
+            let render_node = egl
+                .device
+                .try_get_render_node()
+                .ok()
+                .and_then(std::convert::identity)
+                .unwrap_or(dev_node);
+            let render_formats = egl.context.dmabuf_render_formats().clone();
+            let texture_formats = egl.context.dmabuf_texture_formats().clone();
+
+            (
+                render_node,
+                render_formats,
+                texture_formats,
+                egl.device.is_software(),
+            )
+        };
+
+        let token = common
+            .event_loop_handle
+            .insert_source(
+                notifier,
+                move |event, metadata, state: &mut State| match event {
+                    DrmEvent::VBlank(crtc) => {
+                        if let Some(device) = state.backend.kms().drm_devices.get_mut(&dev_node)
+                            && let Some(surface) = device.inner.surfaces.get_mut(&crtc)
+                        {
+                            surface.on_vblank(metadata.take());
+                        }
+                    }
+                    DrmEvent::Error(err) => {
+                        warn!(?err, "Failed to read events of device {:?}.", dev);
+                    }
+                },
+            )
+            .with_context(|| format!("Failed to add drm device to event loop: {}", dev))?;
+
+        let ReusableDevice {
+            leasing_global,
+            active_clients,
+            socket,
+        } = reuse.unwrap_or_else(|| {
+            let socket = match (!is_software)
+                .then(|| common.create_socket(dh, render_node, texture_formats.clone()))
+                .transpose()
+            {
+                Ok(socket) => socket,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        "Failed to initialize hardware-acceleration for clients on {}.",
+                        render_node,
+                    );
+                    None
+                }
+            };
+
+            let leasing_global = match (!is_software)
+                .then(|| DrmLeaseState::new::<State>(dh, &dev_node))
+                .transpose()
+            {
+                Ok(global) => global,
+                Err(err) => {
+                    // TODO: replace with inspect_err, once stable
+                    warn!(
+                        ?err,
+                        "Failed to initialize drm lease global for: {}", dev_node
+                    );
+                    None
+                }
+            };
+
+            ReusableDevice {
+                leasing_global,
+                active_clients: HashSet::new(),
+                socket,
+            }
+        });
+
+        let drm = GbmDrmOutputManager::new(
+            drm,
+            GbmAllocator::new(
+                gbm.clone(),
+                GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT,
+            ),
+            GbmFramebufferExporter::new(gbm.clone(), render_node.into()),
+            Some(gbm.clone()),
+            [
+                Fourcc::Abgr2101010,
+                Fourcc::Argb2101010,
+                Fourcc::Abgr8888,
+                Fourcc::Argb8888,
+            ],
+            render_formats,
+        );
+
+        Ok(Device {
+            drm,
+            inner: InnerDevice {
+                dev_node,
+                render_node,
+                is_software,
+                egl: None,
+
+                outputs: HashMap::new(),
+                surfaces: HashMap::new(),
+                gbm,
+
+                leased_connectors: Vec::new(),
+                leasing_global,
+                active_leases: Vec::new(),
+                active_clients,
+            },
+
+            supports_atomic,
+            texture_formats,
+            event_token: Some(token),
+            socket,
+        })
+    }
+
     pub fn enumerate_surfaces(&mut self) -> Result<OutputChanges> {
         // enumerate our outputs
         let config =
@@ -633,6 +890,27 @@ impl Device {
             inner: &mut self.inner,
             drm: self.drm.lock(),
         }
+    }
+
+    fn reuse(self) -> (ReusableDevice, OldDeviceState) {
+        let device = ReusableDevice {
+            leasing_global: self.inner.leasing_global,
+            active_clients: self.inner.active_clients,
+            socket: self.socket,
+        };
+
+        let state = OldDeviceState {
+            fd: self.drm.device().device_fd().device_fd(),
+            outputs: self.inner.outputs,
+            leased_connectors: self
+                .inner
+                .leased_connectors
+                .iter()
+                .map(|(conn, _)| *conn)
+                .collect(),
+        };
+
+        (device, state)
     }
 }
 

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -394,15 +394,37 @@ impl State {
                         continue;
                     }
                 };
+                let dh = state.common.display_handle.clone();
+
                 if state.backend.kms().drm_devices.contains_key(&drm_node) {
                     match state.device_changed(dev) {
                         Ok(outputs) => added.extend(outputs),
                         Err(err) => {
-                            error!(?err, "Failed to update drm device {}.", path.display(),)
+                            error!(
+                                ?err,
+                                "Failed to update drm device {}. Re-opening",
+                                path.display(),
+                            );
+                            match state.reopen_device(dev, path, &dh) {
+                                Ok(outputs) => added.extend(outputs),
+                                Err(err) => {
+                                    error!(
+                                        ?err,
+                                        "Failed to re-open drm device {}. Device lost",
+                                        path.display(),
+                                    );
+                                    if let Err(err) = state.device_removed(dev, &dh) {
+                                        error!(
+                                            ?err,
+                                            "Failed to close drm device {}.",
+                                            path.display(),
+                                        );
+                                    };
+                                }
+                            }
                         }
                     }
                 } else {
-                    let dh = state.common.display_handle.clone();
                     match state.device_added(dev, path, &dh) {
                         Ok(outputs) => added.extend(outputs),
                         Err(err) => error!(?err, "Failed to add drm device {}.", path.display(),),

--- a/src/backend/kms/socket.rs
+++ b/src/backend/kms/socket.rs
@@ -18,7 +18,7 @@ use smithay::{
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use crate::state::{ClientState, State, advertised_node_for_client};
+use crate::state::{ClientState, Common, State, advertised_node_for_client};
 
 #[derive(Debug)]
 pub struct Socket {
@@ -27,7 +27,7 @@ pub struct Socket {
     pub dmabuf_global: DmabufGlobal,
 }
 
-impl State {
+impl Common {
     pub(super) fn create_socket(
         &mut self,
         dh: &DisplayHandle,
@@ -36,7 +36,7 @@ impl State {
     ) -> Result<Socket> {
         let socket_name = format!(
             "{}-{}",
-            &self.common.socket.to_string_lossy(),
+            &self.socket.to_string_lossy(),
             render_node
                 .dev_path()
                 .unwrap()
@@ -53,33 +53,28 @@ impl State {
             .with_context(|| "Failed to create drm format shared memory table")?;
 
         let dmabuf_global = self
-            .common
             .dmabuf_state
             .create_global_with_filter_and_default_feedback::<State, _>(dh, &feedback, filter);
 
-        let drm_global_id = self
-            .common
-            .wl_drm_state
-            .create_global_with_filter::<State, _>(
-                dh,
-                render_node
-                    .dev_path_with_type(NodeType::Render)
-                    .or_else(|| render_node.dev_path())
-                    .ok_or(anyhow!(
-                        "Could not determine path for gpu node: {}",
-                        render_node
-                    ))?,
-                formats,
-                &dmabuf_global,
-                filter,
-            );
+        let drm_global_id = self.wl_drm_state.create_global_with_filter::<State, _>(
+            dh,
+            render_node
+                .dev_path_with_type(NodeType::Render)
+                .or_else(|| render_node.dev_path())
+                .ok_or(anyhow!(
+                    "Could not determine path for gpu node: {}",
+                    render_node
+                ))?,
+            formats,
+            &dmabuf_global,
+            filter,
+        );
 
         // add a special socket for the gpu
         let listener = ListeningSocketSource::with_name(&socket_name)
             .with_context(|| format!("Failed to bind socket to {}", socket_name))?;
         let socket_name_clone = socket_name.clone();
         let token = self
-            .common
             .event_loop_handle
             .insert_source(listener, move |client_stream, _, state: &mut State| {
                 if let Err(err) = state.common.display_handle.insert_client(

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -464,7 +464,7 @@ impl Surface {
 
     pub fn drop_and_join(mut self) {
         let thread = self.thread.take();
-        let _ = self;
+        std::mem::drop(self);
         if let Some(thread) = thread {
             let name = thread.thread().name().unwrap().to_string();
             let _ = thread.join();

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -470,6 +470,9 @@ impl CosmicSurface {
             .get_or_insert_threadsafe(Sticky::default)
             .0
             .store(sticky, Ordering::SeqCst);
+        if let WindowSurface::X11(surface) = self.0.underlying_surface() {
+            let _ = surface.set_sticky(sticky);
+        }
     }
 
     pub fn set_suspended(&self, suspended: bool) {

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -453,10 +453,6 @@ impl CosmicSurface {
             .store(minimized, Ordering::SeqCst);
         if let WindowSurface::X11(surface) = self.0.underlying_surface() {
             let _ = surface.set_hidden(minimized);
-            if !minimized && surface.is_fullscreen() {
-                let _ = surface.set_mapped(false);
-                let _ = surface.set_mapped(true);
-            }
         }
     }
 

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -235,7 +235,7 @@ impl CosmicSurface {
                 toplevel.with_pending_state(|state| state.size = Some(geo.size.as_logical()))
             }
             WindowSurface::X11(surface) => {
-                let _ = surface.configure(geo.as_logical());
+                let _ = surface.configure_with_sync(geo.as_logical(), None);
             }
         }
     }
@@ -342,7 +342,7 @@ impl CosmicSurface {
                     state.is_some_and(|state| state.states.contains(ToplevelState::Resizing))
                 }))
             }
-            WindowSurface::X11(_surface) => None,
+            WindowSurface::X11(surface) => surface.pending_geometry().map(|_| true),
         }
     }
 
@@ -589,7 +589,7 @@ impl CosmicSurface {
                     }
                 })
             }
-            WindowSurface::X11(_) => true,
+            WindowSurface::X11(surface) => surface.pending_geometry().is_none(),
         }
     }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -249,6 +249,7 @@ pub struct PendingWindow {
     pub seat: Seat<State>,
     pub fullscreen: Option<Output>,
     pub maximized: bool,
+    pub sticky: bool,
 }
 
 #[derive(Debug)]
@@ -2684,23 +2685,19 @@ impl Shell {
             seat,
             fullscreen: output,
             maximized: should_be_maximized,
+            sticky: mut should_be_sticky,
         } = self.pending_windows.remove(pos);
 
-        let parent_is_sticky = if let Some(toplevel) = window.0.toplevel() {
-            if let Some(parent) = toplevel.parent() {
-                if let Some(elem) = self.element_for_surface(&parent) {
-                    self.workspaces
-                        .sets
-                        .values()
-                        .any(|set| set.sticky_layer.mapped().any(|m| m == elem))
-                } else {
-                    false
-                }
-            } else {
-                false
-            }
-        } else {
-            false
+        if !should_be_sticky
+            && let Some(toplevel) = window.0.toplevel()
+            && let Some(parent) = toplevel.parent()
+            && let Some(elem) = self.element_for_surface(&parent)
+        {
+            should_be_sticky = self
+                .workspaces
+                .sets
+                .values()
+                .any(|set| set.sticky_layer.mapped().any(|m| m == elem));
         };
 
         let pending_activation = self.pending_activations.remove(&(&window).into());
@@ -2814,7 +2811,7 @@ impl Shell {
                 .map(mapped.clone(), Some(focus_stack.iter()), None);
         }
 
-        if parent_is_sticky {
+        if should_be_sticky {
             self.toggle_sticky(&seat, &mapped);
         }
 
@@ -2824,7 +2821,7 @@ impl Shell {
 
         let new_target = if (workspace_output == seat.active_output()
             && active_handle == workspace_handle)
-            || parent_is_sticky
+            || should_be_sticky
         {
             // TODO: enforce focus stealing prevention by also checking the same rules as for the else case.
             Some(KeyboardFocusTarget::from(mapped.clone()))
@@ -2955,6 +2952,7 @@ impl Shell {
                     seat: seat.clone(),
                     fullscreen: None,
                     maximized: false,
+                    sticky: false,
                 });
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -224,6 +224,7 @@ pub struct State {
     pub ready: Once,
     pub last_refresh: LastRefresh,
 }
+smithay::delegate_dispatch2!(State);
 
 #[derive(Debug)]
 pub struct Common {

--- a/src/wayland/handlers/alpha_modifier.rs
+++ b/src/wayland/handlers/alpha_modifier.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_alpha_modifier;
-
-delegate_alpha_modifier!(State);

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -7,7 +7,6 @@ use smithay::{
         element::{Kind, surface::KindEvaluation},
         utils::{on_commit_buffer_handler, with_renderer_surface_state},
     },
-    delegate_compositor,
     desktop::{LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output},
     reexports::wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
     utils::{Clock, Logical, Monotonic, SERIAL_COUNTER, Size, Time},
@@ -434,5 +433,3 @@ impl State {
         false
     }
 }
-
-delegate_compositor!(State);

--- a/src/wayland/handlers/data_control/ext.rs
+++ b/src/wayland/handlers/data_control/ext.rs
@@ -1,13 +1,8 @@
 use crate::state::State;
-use smithay::{
-    delegate_ext_data_control,
-    wayland::selection::ext_data_control::{DataControlHandler, DataControlState},
-};
+use smithay::wayland::selection::ext_data_control::{DataControlHandler, DataControlState};
 
 impl DataControlHandler for State {
     fn data_control_state(&mut self) -> &mut DataControlState {
         &mut self.common.ext_data_control_state
     }
 }
-
-delegate_ext_data_control!(State);

--- a/src/wayland/handlers/data_control/wlr.rs
+++ b/src/wayland/handlers/data_control/wlr.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_data_control,
-    wayland::selection::wlr_data_control::{DataControlHandler, DataControlState},
-};
+use smithay::wayland::selection::wlr_data_control::{DataControlHandler, DataControlState};
 
 impl DataControlHandler for State {
     fn data_control_state(&mut self) -> &mut DataControlState {
         &mut self.common.wlr_data_control_state
     }
 }
-
-delegate_data_control!(State);

--- a/src/wayland/handlers/data_device.rs
+++ b/src/wayland/handlers/data_device.rs
@@ -2,7 +2,6 @@
 
 use crate::{state::State, utils::prelude::SeatExt};
 use smithay::{
-    delegate_data_device,
     input::{
         Seat,
         dnd::{DnDGrab, DndGrabHandler, DndTarget, GrabType},
@@ -135,5 +134,3 @@ impl DataDeviceHandler for State {
         &mut self.common.data_device_state
     }
 }
-
-delegate_data_device!(State);

--- a/src/wayland/handlers/decoration.rs
+++ b/src/wayland/handlers/decoration.rs
@@ -1,7 +1,6 @@
 use std::{cell::RefCell, sync::Mutex};
 
 use smithay::{
-    delegate_kde_decoration, delegate_xdg_decoration,
     desktop::Window,
     reexports::{
         wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1::Mode as XdgMode,
@@ -186,6 +185,3 @@ impl KdeDecorationHandler for State {
         });
     }
 }
-
-delegate_xdg_decoration!(State);
-delegate_kde_decoration!(State);

--- a/src/wayland/handlers/dmabuf.rs
+++ b/src/wayland/handlers/dmabuf.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use smithay::{
     backend::{allocator::dmabuf::Dmabuf, renderer::element::Kind},
-    delegate_dmabuf,
     desktop::WindowSurfaceType,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::{
@@ -89,5 +88,3 @@ impl DmabufHandler for State {
         }))
     }
 }
-
-delegate_dmabuf!(State);

--- a/src/wayland/handlers/drm_lease.rs
+++ b/src/wayland/handlers/drm_lease.rs
@@ -3,7 +3,6 @@
 use crate::state::State;
 use smithay::{
     backend::drm::DrmNode,
-    delegate_drm_lease,
     wayland::drm_lease::{
         DrmLease, DrmLeaseBuilder, DrmLeaseHandler, DrmLeaseRequest, DrmLeaseState, LeaseRejected,
     },
@@ -134,5 +133,3 @@ impl DrmLeaseHandler for State {
         }
     }
 }
-
-delegate_drm_lease!(State);

--- a/src/wayland/handlers/drm_syncobj.rs
+++ b/src/wayland/handlers/drm_syncobj.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::{BackendData, State};
-use smithay::{
-    delegate_drm_syncobj,
-    wayland::drm_syncobj::{DrmSyncobjHandler, DrmSyncobjState},
-};
+use smithay::wayland::drm_syncobj::{DrmSyncobjHandler, DrmSyncobjState};
 
 impl DrmSyncobjHandler for State {
     fn drm_syncobj_state(&mut self) -> Option<&mut DrmSyncobjState> {
@@ -15,5 +12,3 @@ impl DrmSyncobjHandler for State {
         kms.syncobj_state.as_mut()
     }
 }
-
-delegate_drm_syncobj!(State);

--- a/src/wayland/handlers/fixes.rs
+++ b/src/wayland/handlers/fixes.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_fixes;
-
-delegate_fixes!(State);

--- a/src/wayland/handlers/foreign_toplevel_list.rs
+++ b/src/wayland/handlers/foreign_toplevel_list.rs
@@ -10,5 +10,3 @@ impl ForeignToplevelListHandler for State {
         &mut self.toplevel_info_state_mut().foreign_toplevel_list
     }
 }
-
-smithay::delegate_foreign_toplevel_list!(State);

--- a/src/wayland/handlers/fractional_scale.rs
+++ b/src/wayland/handlers/fractional_scale.rs
@@ -1,6 +1,5 @@
 use crate::{state::State, utils::prelude::SeatExt};
 use smithay::{
-    delegate_fractional_scale,
     desktop::utils::surface_primary_scanout_output,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::{
@@ -55,5 +54,3 @@ impl FractionalScaleHandler for State {
         });
     }
 }
-
-delegate_fractional_scale!(State);

--- a/src/wayland/handlers/idle_inhibit.rs
+++ b/src/wayland/handlers/idle_inhibit.rs
@@ -1,5 +1,5 @@
 use smithay::{
-    delegate_idle_inhibit, reexports::wayland_server::protocol::wl_surface::WlSurface,
+    reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::idle_inhibit::IdleInhibitHandler,
 };
 
@@ -16,4 +16,3 @@ impl IdleInhibitHandler for State {
         self.common.refresh_idle_inhibit();
     }
 }
-delegate_idle_inhibit!(State);

--- a/src/wayland/handlers/idle_notify.rs
+++ b/src/wayland/handlers/idle_notify.rs
@@ -1,4 +1,4 @@
-use smithay::{delegate_idle_notify, wayland::idle_notify::IdleNotifierHandler};
+use smithay::wayland::idle_notify::IdleNotifierHandler;
 
 use crate::state::State;
 
@@ -9,4 +9,3 @@ impl IdleNotifierHandler for State {
         &mut self.common.idle_notifier_state
     }
 }
-delegate_idle_notify!(State);

--- a/src/wayland/handlers/image_capture_source.rs
+++ b/src/wayland/handlers/image_capture_source.rs
@@ -3,8 +3,7 @@
 use crate::{
     state::State,
     wayland::protocols::{
-        image_capture_source::{ImageCaptureSourceKind, delegate_cosmic_image_capture_source},
-        toplevel_info::window_from_ext,
+        image_capture_source::ImageCaptureSourceKind, toplevel_info::window_from_ext,
     },
 };
 use smithay::{
@@ -51,9 +50,3 @@ impl ToplevelCaptureSourceHandler for State {
         source.user_data().insert_if_missing(|| data);
     }
 }
-
-smithay::delegate_image_capture_source!(State);
-smithay::delegate_output_capture_source!(State);
-smithay::delegate_toplevel_capture_source!(State);
-
-delegate_cosmic_image_capture_source!(State);

--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -449,5 +449,3 @@ fn constraints_for_renderer(
 
     constraints
 }
-
-smithay::delegate_image_copy_capture!(State);

--- a/src/wayland/handlers/input_method.rs
+++ b/src/wayland/handlers/input_method.rs
@@ -2,7 +2,6 @@
 
 use crate::state::State;
 use smithay::{
-    delegate_input_method_manager,
     desktop::{PopupKind, PopupManager, space::SpaceElement},
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::Rectangle,
@@ -41,5 +40,3 @@ impl InputMethodHandler for State {
         self.common.shell.read().unconstrain_popup(&popup.into());
     }
 }
-
-delegate_input_method_manager!(State);

--- a/src/wayland/handlers/keyboard_shortcuts_inhibit.rs
+++ b/src/wayland/handlers/keyboard_shortcuts_inhibit.rs
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_keyboard_shortcuts_inhibit,
-    wayland::keyboard_shortcuts_inhibit::{
-        KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
-    },
+use smithay::wayland::keyboard_shortcuts_inhibit::{
+    KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
 };
 
 impl KeyboardShortcutsInhibitHandler for State {
@@ -18,5 +15,3 @@ impl KeyboardShortcutsInhibitHandler for State {
         inhibitor.activate();
     }
 }
-
-delegate_keyboard_shortcuts_inhibit!(State);

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -2,7 +2,6 @@
 
 use crate::{shell::PendingLayer, utils::prelude::*};
 use smithay::{
-    delegate_layer_shell,
     desktop::{LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output},
     output::Output,
     reexports::wayland_server::protocol::wl_output::WlOutput,
@@ -82,5 +81,3 @@ impl WlrLayerShellHandler for State {
         }
     }
 }
-
-delegate_layer_shell!(State);

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 pub mod a11y;
-pub mod alpha_modifier;
 pub mod buffer;
 pub mod compositor;
 pub mod corner_radius;
@@ -12,7 +11,6 @@ pub mod dmabuf;
 pub mod drm;
 pub mod drm_lease;
 pub mod drm_syncobj;
-pub mod fixes;
 pub mod foreign_toplevel_list;
 pub mod fractional_scale;
 pub mod idle_inhibit;
@@ -27,22 +25,15 @@ pub mod output_configuration;
 pub mod output_power;
 pub mod overlap_notify;
 pub mod pointer_constraints;
-pub mod pointer_gestures;
-pub mod presentation;
 pub mod primary_selection;
-pub mod relative_pointer;
 pub mod seat;
 pub mod security_context;
 pub mod selection;
 pub mod session_lock;
 pub mod shm;
-pub mod single_pixel_buffer;
 pub mod tablet_manager;
-pub mod text_input;
 pub mod toplevel_info;
 pub mod toplevel_management;
-pub mod viewporter;
-pub mod virtual_keyboard;
 pub mod workspace;
 pub mod xdg_activation;
 pub mod xdg_foreign;

--- a/src/wayland/handlers/output.rs
+++ b/src/wayland/handlers/output.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{delegate_output, wayland::output::OutputHandler};
+use smithay::wayland::output::OutputHandler;
 
 impl OutputHandler for State {}
-
-delegate_output!(State);

--- a/src/wayland/handlers/pointer_constraints.rs
+++ b/src/wayland/handlers/pointer_constraints.rs
@@ -2,7 +2,6 @@
 
 use crate::state::State;
 use smithay::{
-    delegate_pointer_constraints,
     input::pointer::PointerHandle,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::{Logical, Point},
@@ -34,4 +33,3 @@ impl PointerConstraintsHandler for State {
         // TODO
     }
 }
-delegate_pointer_constraints!(State);

--- a/src/wayland/handlers/pointer_gestures.rs
+++ b/src/wayland/handlers/pointer_gestures.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_pointer_gestures;
-
-delegate_pointer_gestures!(State);

--- a/src/wayland/handlers/presentation.rs
+++ b/src/wayland/handlers/presentation.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_presentation;
-
-delegate_presentation!(State);

--- a/src/wayland/handlers/primary_selection.rs
+++ b/src/wayland/handlers/primary_selection.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_primary_selection,
-    wayland::selection::primary_selection::{PrimarySelectionHandler, PrimarySelectionState},
+use smithay::wayland::selection::primary_selection::{
+    PrimarySelectionHandler, PrimarySelectionState,
 };
 
 impl PrimarySelectionHandler for State {
@@ -11,5 +10,3 @@ impl PrimarySelectionHandler for State {
         &mut self.common.primary_selection_state
     }
 }
-
-delegate_primary_selection!(State);

--- a/src/wayland/handlers/relative_pointer.rs
+++ b/src/wayland/handlers/relative_pointer.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_relative_pointer;
-
-delegate_relative_pointer!(State);

--- a/src/wayland/handlers/seat.rs
+++ b/src/wayland/handlers/seat.rs
@@ -6,10 +6,7 @@ use crate::{
     state::State,
     utils::prelude::SeatExt,
 };
-use smithay::{
-    delegate_cursor_shape, delegate_seat,
-    input::{SeatHandler, SeatState, keyboard::LedState, pointer::CursorImageStatus},
-};
+use smithay::input::{SeatHandler, SeatState, keyboard::LedState, pointer::CursorImageStatus};
 
 impl SeatHandler for State {
     type KeyboardFocus = KeyboardFocusTarget;
@@ -37,6 +34,3 @@ impl SeatHandler for State {
         devices.update_led_state(led_state);
     }
 }
-
-delegate_seat!(State);
-delegate_cursor_shape!(State);

--- a/src/wayland/handlers/security_context.rs
+++ b/src/wayland/handlers/security_context.rs
@@ -1,7 +1,6 @@
 use crate::state::{ClientState, State};
 use smithay::{
     backend::drm::DrmNode,
-    delegate_security_context,
     wayland::security_context::{
         SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
     },
@@ -54,4 +53,3 @@ impl SecurityContextHandler for State {
             .expect("Failed to init the wayland socket source.");
     }
 }
-delegate_security_context!(State);

--- a/src/wayland/handlers/session_lock.rs
+++ b/src/wayland/handlers/session_lock.rs
@@ -2,7 +2,6 @@
 
 use crate::{shell::SessionLock, state::State, utils::prelude::*};
 use smithay::{
-    delegate_session_lock,
     output::Output,
     reexports::wayland_server::{Resource, protocol::wl_output::WlOutput},
     utils::Size,
@@ -68,5 +67,3 @@ impl SessionLockHandler for State {
         }
     }
 }
-
-delegate_session_lock!(State);

--- a/src/wayland/handlers/shm.rs
+++ b/src/wayland/handlers/shm.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_shm,
-    wayland::shm::{ShmHandler, ShmState},
-};
+use smithay::wayland::shm::{ShmHandler, ShmState};
 
 impl ShmHandler for State {
     fn shm_state(&self) -> &ShmState {
         &self.common.shm_state
     }
 }
-
-delegate_shm!(State);

--- a/src/wayland/handlers/single_pixel_buffer.rs
+++ b/src/wayland/handlers/single_pixel_buffer.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_single_pixel_buffer;
-
-delegate_single_pixel_buffer!(State);

--- a/src/wayland/handlers/tablet_manager.rs
+++ b/src/wayland/handlers/tablet_manager.rs
@@ -2,8 +2,8 @@
 
 use crate::state::State;
 use smithay::{
-    backend::input::TabletToolDescriptor, delegate_tablet_manager,
-    input::pointer::CursorImageStatus, wayland::tablet_manager::TabletSeatHandler,
+    backend::input::TabletToolDescriptor, input::pointer::CursorImageStatus,
+    wayland::tablet_manager::TabletSeatHandler,
 };
 
 impl TabletSeatHandler for State {
@@ -11,5 +11,3 @@ impl TabletSeatHandler for State {
         // TODO display cursor for each tablet tool
     }
 }
-
-delegate_tablet_manager!(State);

--- a/src/wayland/handlers/text_input.rs
+++ b/src/wayland/handlers/text_input.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_text_input_manager;
-
-delegate_text_input_manager!(State);

--- a/src/wayland/handlers/viewporter.rs
+++ b/src/wayland/handlers/viewporter.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_viewporter;
-
-delegate_viewporter!(State);

--- a/src/wayland/handlers/virtual_keyboard.rs
+++ b/src/wayland/handlers/virtual_keyboard.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_virtual_keyboard_manager;
-
-delegate_virtual_keyboard_manager!(State);

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -6,7 +6,6 @@ use crate::{
     wayland::protocols::workspace::{State as WState, WorkspaceHandle},
 };
 use smithay::{
-    delegate_xdg_activation,
     input::Seat,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::xdg_activation::{
@@ -246,5 +245,3 @@ impl State {
         };
     }
 }
-
-delegate_xdg_activation!(State);

--- a/src/wayland/handlers/xdg_foreign.rs
+++ b/src/wayland/handlers/xdg_foreign.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_xdg_foreign,
-    wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState},
-};
+use smithay::wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState};
 
 impl XdgForeignHandler for State {
     fn xdg_foreign_state(&mut self) -> &mut XdgForeignState {
         &mut self.common.xdg_foreign_state
     }
 }
-
-delegate_xdg_foreign!(State);

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -51,6 +51,7 @@ impl XdgShellHandler for State {
                 seat,
                 fullscreen: None,
                 maximized: false,
+                sticky: false,
             })
         }
         // We will position the window after the first commit, when we know its size hints

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use smithay::desktop::layer_map_for_output;
 use smithay::{
-    delegate_xdg_shell,
     desktop::{
         PopupGrab, PopupKeyboardGrab, PopupKind, PopupPointerGrab, PopupUngrabStrategy,
         WindowSurfaceType, find_popup_root_surface,
@@ -391,5 +390,3 @@ impl XdgShellHandler for State {
         }
     }
 }
-
-delegate_xdg_shell!(State);

--- a/src/wayland/handlers/xwayland_keyboard_grab.rs
+++ b/src/wayland/handlers/xwayland_keyboard_grab.rs
@@ -2,7 +2,6 @@
 
 use crate::{shell::focus::target::KeyboardFocusTarget, state::State};
 use smithay::{
-    delegate_xwayland_keyboard_grab,
     input::Seat,
     reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface},
     wayland::xwayland_keyboard_grab::{XWaylandKeyboardGrab, XWaylandKeyboardGrabHandler},
@@ -49,5 +48,3 @@ impl XWaylandGrabSeat for Seat<State> {
             .is_some_and(|(s, g)| g.grab().is_alive() && s == surface)
     }
 }
-
-delegate_xwayland_keyboard_grab!(State);

--- a/src/wayland/handlers/xwayland_shell.rs
+++ b/src/wayland/handlers/xwayland_shell.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_xwayland_shell,
-    wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState},
-};
+use smithay::wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState};
 
 impl XWaylandShellHandler for State {
     fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState {
         &mut self.common.xwayland_shell_state
     }
 }
-
-delegate_xwayland_shell!(State);

--- a/src/wayland/protocols/image_capture_source.rs
+++ b/src/wayland/protocols/image_capture_source.rs
@@ -15,7 +15,7 @@ use smithay::{
     reexports::wayland_server::{
         Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
     },
-    wayland::image_capture_source::{ImageCaptureSource, ImageCaptureSourceData},
+    wayland::{image_capture_source::{ImageCaptureSource, ImageCaptureSourceData}, Dispatch2, GlobalDispatch2},
 };
 use wayland_backend::server::GlobalId;
 
@@ -53,7 +53,7 @@ impl CosmicImageCaptureSourceState {
         D: GlobalDispatch<
                 ZcosmicWorkspaceImageCaptureSourceManagerV1,
                 WorkspaceImageCaptureSourceManagerGlobalData,
-            > + Dispatch<ZcosmicWorkspaceImageCaptureSourceManagerV1, ()>
+            > + Dispatch<ZcosmicWorkspaceImageCaptureSourceManagerV1, CaptureSourceManagerData>
             + Dispatch<ExtImageCaptureSourceV1, ImageCaptureSourceData>
             + WorkspaceHandler
             + 'static,
@@ -75,53 +75,41 @@ impl CosmicImageCaptureSourceState {
     }
 }
 
-impl<D>
-    GlobalDispatch<
-        ZcosmicWorkspaceImageCaptureSourceManagerV1,
-        WorkspaceImageCaptureSourceManagerGlobalData,
-        D,
-    > for CosmicImageCaptureSourceState
+pub struct CaptureSourceManagerData;
+
+impl<D> GlobalDispatch2<ZcosmicWorkspaceImageCaptureSourceManagerV1, D>
+    for WorkspaceImageCaptureSourceManagerGlobalData
 where
-    D: GlobalDispatch<
-            ZcosmicWorkspaceImageCaptureSourceManagerV1,
-            WorkspaceImageCaptureSourceManagerGlobalData,
-        > + Dispatch<ZcosmicWorkspaceImageCaptureSourceManagerV1, ()>
+    D: Dispatch<ZcosmicWorkspaceImageCaptureSourceManagerV1, CaptureSourceManagerData>
         + Dispatch<ExtImageCaptureSourceV1, ImageCaptureSourceData>
         + 'static,
 {
     fn bind(
+        &self,
         _state: &mut D,
         _handle: &DisplayHandle,
         _client: &Client,
         resource: New<ZcosmicWorkspaceImageCaptureSourceManagerV1>,
-        _global_data: &WorkspaceImageCaptureSourceManagerGlobalData,
         data_init: &mut DataInit<'_, D>,
     ) {
-        data_init.init(resource, ());
+        data_init.init(resource, CaptureSourceManagerData);
     }
 
-    fn can_view(
-        client: Client,
-        global_data: &WorkspaceImageCaptureSourceManagerGlobalData,
-    ) -> bool {
-        (global_data.filter)(&client)
+    fn can_view(&self, client: &Client) -> bool {
+        (self.filter)(client)
     }
 }
 
-impl<D> Dispatch<ZcosmicWorkspaceImageCaptureSourceManagerV1, (), D>
-    for CosmicImageCaptureSourceState
+impl<D> Dispatch2<ZcosmicWorkspaceImageCaptureSourceManagerV1, D> for CaptureSourceManagerData
 where
-    D: Dispatch<ZcosmicWorkspaceImageCaptureSourceManagerV1, ()>
-        + Dispatch<ExtImageCaptureSourceV1, ImageCaptureSourceData>
-        + WorkspaceHandler
-        + 'static,
+    D: Dispatch<ExtImageCaptureSourceV1, ImageCaptureSourceData> + WorkspaceHandler + 'static,
 {
     fn request(
+        &self,
         state: &mut D,
         _client: &Client,
         _resource: &ZcosmicWorkspaceImageCaptureSourceManagerV1,
         request: <ZcosmicWorkspaceImageCaptureSourceManagerV1 as Resource>::Request,
-        _data: &(),
         _dhandle: &DisplayHandle,
         data_init: &mut DataInit<'_, D>,
     ) {
@@ -146,15 +134,3 @@ where
         }
     }
 }
-
-macro_rules! delegate_cosmic_image_capture_source {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            cosmic_protocols::image_capture_source::v1::server::zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1: $crate::wayland::protocols::image_capture_source::WorkspaceImageCaptureSourceManagerGlobalData
-        ] => $crate::wayland::protocols::image_capture_source::CosmicImageCaptureSourceState);
-        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            cosmic_protocols::image_capture_source::v1::server::zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1: ()
-        ] => $crate::wayland::protocols::image_capture_source::CosmicImageCaptureSourceState);
-    };
-}
-pub(crate) use delegate_cosmic_image_capture_source;

--- a/src/wayland/protocols/overlap_notify.rs
+++ b/src/wayland/protocols/overlap_notify.rs
@@ -16,7 +16,10 @@ use smithay::{
     desktop::{LayerSurface, layer_map_for_output},
     output::Output,
     reexports::{
-        wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        wayland_protocols::ext::foreign_toplevel_list::v1::server::{
+            ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+            ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        },
         wayland_protocols_wlr::layer_shell::v1::server::{
             zwlr_layer_shell_v1::Layer as WlrLayer, zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
         },
@@ -24,7 +27,9 @@ use smithay::{
     },
     utils::{Logical, Rectangle},
     wayland::{
-        foreign_toplevel_list::ForeignToplevelListHandler,
+        foreign_toplevel_list::{
+            ForeignToplevelHandle, ForeignToplevelListGlobalData, ForeignToplevelListHandler,
+        },
         shell::wlr_layer::{ExclusiveZone, Layer},
     },
 };
@@ -75,6 +80,8 @@ impl OverlapNotifyState {
     pub fn refresh<D, W>(state: &mut D)
     where
         D: GlobalDispatch<ZcosmicOverlapNotifyV1, OverlapNotifyGlobalData>
+            + GlobalDispatch<ExtForeignToplevelListV1, ForeignToplevelListGlobalData>
+            + Dispatch<ExtForeignToplevelHandleV1, ForeignToplevelHandle>
             + Dispatch<ZcosmicOverlapNotifyV1, ()>
             + Dispatch<ZcosmicOverlapNotificationV1, ()>
             + OverlapNotifyHandler

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -5,7 +5,10 @@ use std::{collections::HashSet, sync::Mutex};
 use smithay::{
     output::Output,
     reexports::{
-        wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        wayland_protocols::ext::foreign_toplevel_list::v1::server::{
+            ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+            ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        },
         wayland_server::{
             Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
             backend::{ClientId, GlobalId},
@@ -14,7 +17,8 @@ use smithay::{
     },
     utils::{IsAlive, Logical, Rectangle, user_data::UserDataMap},
     wayland::foreign_toplevel_list::{
-        ForeignToplevelHandle, ForeignToplevelListHandler, ForeignToplevelListState,
+        ForeignToplevelHandle, ForeignToplevelListGlobalData, ForeignToplevelListHandler,
+        ForeignToplevelListState,
     },
 };
 
@@ -300,6 +304,8 @@ pub fn toplevel_leave_workspace(toplevel: &impl Window, workspace: &WorkspaceHan
 impl<D, W> ToplevelInfoState<D, W>
 where
     D: GlobalDispatch<ZcosmicToplevelInfoV1, ToplevelInfoGlobalData>
+        + GlobalDispatch<ExtForeignToplevelListV1, ForeignToplevelListGlobalData>
+        + Dispatch<ExtForeignToplevelHandleV1, ForeignToplevelHandle>
         + Dispatch<ZcosmicToplevelInfoV1, ()>
         + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
         + ForeignToplevelListHandler

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -815,6 +815,7 @@ impl XwmHandler for State {
                 seat,
                 fullscreen: None,
                 maximized: false,
+                sticky: false,
             })
         }
     }
@@ -1164,6 +1165,28 @@ impl XwmHandler for State {
             .find(|pending| pending.surface.x11_surface() == Some(&window))
         {
             pending.fullscreen.take();
+        }
+    }
+
+    fn stick_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        let mut shell = self.common.shell.write();
+        if let Some(pending) = shell
+            .pending_windows
+            .iter_mut()
+            .find(|pending| pending.surface.x11_surface() == Some(&window))
+        {
+            pending.sticky = true;
+        }
+    }
+
+    fn unstick_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        let mut shell = self.common.shell.write();
+        if let Some(pending) = shell
+            .pending_windows
+            .iter_mut()
+            .find(|pending| pending.surface.x11_surface() == Some(&window))
+        {
+            pending.sticky = false;
         }
     }
 


### PR DESCRIPTION
Draft until https://github.com/Smithay/smithay/pull/2025 is merged.

---

`libseat` [recommends to re-open file descriptors](https://git.sr.ht/~kennylevinsen/seatd/tree/master/item/include/libseat.h#L17) after suspend/resume, since they might have been permanently revoked.

We currently don't do this, which might lead to permanently blocked drm devices. Instead if we encounter any errors on resume for a particular device, try to re-open it.

Special care has been taken to:
1. Continue using the fast path, which destroys fewer resources, where possible.
2. Try to make 100% sure we can close the old file descriptor, since otherwise we fail the open call.
3. Try to keep as many resources (globals, outputs, shell state) untouched as possible to not potentially disrupt workspace arrangements or similar on resume.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

