### PR TITLE
shell: implement pointer-constraints-unstable-v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,7 +4924,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=774f2ab#774f2ab010e080a2f79176d0e12eb63d5e09d680"
+source = "git+https://github.com/smithay/smithay.git?rev=df73da7#df73da7183c365b00eb4558690a48061462053f2"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,7 +4924,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=df73da7#df73da7183c365b00eb4558690a48061462053f2"
+source = "git+https://github.com/smithay/smithay.git?rev=85f83ab#85f83ab61711e725aa1f3481df4f4dc5370e925b"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,4 +143,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "774f2ab" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "df73da7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,4 +143,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "df73da7" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "85f83ab" }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2168,14 +2168,14 @@ impl State {
                     }
                     Stage::StickyPopups(layout) => {
                         if let Some(element) =
-                            layout.popup_element_under(global_pos.to_local(output))
+                            layout.popup_element_under(global_pos.to_local(output), seat)
                         {
                             return ControlFlow::Break(Ok(Some(element)));
                         }
                     }
                     Stage::Sticky(layout) => {
                         if let Some(element) =
-                            layout.toplevel_element_under(global_pos.to_local(output))
+                            layout.toplevel_element_under(global_pos.to_local(output), seat)
                         {
                             return ControlFlow::Break(Ok(Some(element)));
                         }
@@ -2330,7 +2330,7 @@ impl State {
                     }
                     Stage::StickyPopups(floating_layer) => {
                         if let Some(under) = floating_layer
-                            .popup_surface_under(relative_pos)
+                            .popup_surface_under(relative_pos, seat)
                             .map(|(target, point)| (target, point.to_global(output)))
                         {
                             return ControlFlow::Break(Ok(Some(under)));
@@ -2338,7 +2338,7 @@ impl State {
                     }
                     Stage::Sticky(floating_layer) => {
                         if let Some(under) = floating_layer
-                            .toplevel_surface_under(relative_pos)
+                            .toplevel_surface_under(relative_pos, seat)
                             .map(|(target, point)| (target, point.to_global(output)))
                         {
                             return ControlFlow::Break(Ok(Some(under)));
@@ -2392,11 +2392,8 @@ impl State {
                 let window_size = geometry.size.to_f64();
 
                 let is_legal = |p: Point<f64, Logical>| {
-                    let in_window = p.x >= 0.0
-                        && p.y >= 0.0
-                        // hack: prevent the cursor from touching the edge of the window
-                        && p.x <= window_size.w - 1.
-                        && p.y <= window_size.h - 1.;
+                    let in_window =
+                        p.x >= 0.0 && p.y >= 0.0 && p.x < window_size.w && p.y < window_size.h;
                     if !in_window {
                         return false;
                     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -505,12 +505,12 @@ impl State {
                             let new_under = State::surface_under(pos, &output, shell)
                                 .map(|(target, pos)| (target, pos.as_logical()));
 
-                            //We should only check size, not the surface, so that we can move the mouse over the OSD in confined mode
-                            // if new_under.as_ref().and_then(|(under, _)| under.wl_surface())
-                            //     != surface.wl_surface()
-                            // {
-                            //     return (false, None);
-                            // }
+                            // TODO: We might need a solution that allows constraints to bypass the surface without affecting the constraints themselves
+                            if new_under.as_ref().and_then(|(under, _)| under.wl_surface())
+                                != surface.wl_surface()
+                            {
+                                return (false, None);
+                            }
 
                             match surface {
                                 PointerFocusTarget::WlSurface { surface, .. } => {
@@ -2375,11 +2375,10 @@ impl State {
         pointer: &PointerHandle<Self>,
         mut location: Point<f64, Logical>,
     ) {
-        if let Some(client) = surface.client() {
-            let scale = self.client_compositor_state(&client).client_scale();
-            location.x /= scale;
-            location.y /= scale;
-        }
+        let Some(client) = surface.client() else {
+            return;
+        };
+        location = location.downscale(self.client_compositor_state(&client).client_scale());
 
         let point_and_output = {
             let shell = self.common.shell.read();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -52,16 +52,21 @@ use smithay::{
             AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent,
             GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
             GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent, MotionEvent,
-            PointerGrab, RelativeMotionEvent,
+            PointerGrab, PointerHandle, RelativeMotionEvent,
         },
         touch::{DownEvent, MotionEvent as TouchMotionEvent, UpEvent},
     },
     output::Output,
     reexports::{
-        input::Device as InputDevice, wayland_server::protocol::wl_shm::Format as ShmFormat,
+        input::Device as InputDevice,
+        wayland_server::{
+            Resource as _,
+            protocol::{wl_shm::Format as ShmFormat, wl_surface::WlSurface},
+        },
     },
-    utils::{Point, Rectangle, SERIAL_COUNTER, Serial},
+    utils::{Logical, Point, Rectangle, SERIAL_COUNTER, Serial},
     wayland::{
+        compositor::CompositorHandler,
         image_copy_capture::{BufferConstraints, CursorSessionRef},
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
         pointer_constraints::{PointerConstraint, with_pointer_constraint},
@@ -2316,6 +2321,130 @@ impl State {
         )
         .ok()
         .flatten()
+    }
+
+    pub fn apply_cursor_hint(
+        &mut self,
+        surface: &WlSurface,
+        pointer: &PointerHandle<Self>,
+        mut location: Point<f64, Logical>,
+    ) {
+        if let Some(client) = surface.client() {
+            let scale = self.client_compositor_state(&client).client_scale();
+            location.x /= scale;
+            location.y /= scale;
+        }
+
+        let point_and_output = {
+            let shell = self.common.shell.read();
+            let found = shell.workspaces.sets.iter().find_map(|(out, set)| {
+                set.surface_geometry_offset_from_toplevel(surface)
+                    .map(|(geometry, surface_offset)| (out, geometry, surface_offset))
+            });
+
+            if let Some((output, geometry, surface_offset)) = found {
+                let mut pos_in_element = location + surface_offset.to_f64();
+                let window_size = geometry.size.to_f64();
+
+                let is_legal = |p: Point<f64, Logical>| {
+                    let in_window = p.x >= 0.0
+                        && p.y >= 0.0
+                        // hack: prevent the cursor from touching the edge of the window
+                        && p.x <= window_size.w - 1.
+                        && p.y <= window_size.h - 1.;
+                    if !in_window {
+                        return false;
+                    }
+
+                    with_pointer_constraint(surface, pointer, |constraint| {
+                        if let Some(constraint) = constraint
+                            && let Some(region) = constraint.region()
+                        {
+                            let point_in_surface = (p - surface_offset.to_f64()).to_i32_round();
+                            return region.contains(point_in_surface);
+                        }
+                        true
+                    })
+                };
+
+                let workspace_origin = output.geometry().loc.to_f64();
+                let origin = geometry.loc.to_f64();
+
+                if !is_legal(pos_in_element) {
+                    let original_global = pointer.current_location();
+
+                    let original_pos_in_element = Point::new(
+                        original_global.x - workspace_origin.x - origin.x,
+                        original_global.y - workspace_origin.y - origin.y,
+                    );
+
+                    let y_only_pos = Point::new(original_pos_in_element.x, pos_in_element.y);
+                    let x_only_pos = Point::new(pos_in_element.x, original_pos_in_element.y);
+
+                    if is_legal(y_only_pos) {
+                        pos_in_element = y_only_pos;
+                    } else if is_legal(x_only_pos) {
+                        pos_in_element = x_only_pos;
+                    } else {
+                        pos_in_element = original_pos_in_element;
+                    }
+                }
+
+                let x = workspace_origin.x + origin.x + pos_in_element.x;
+                let y = workspace_origin.y + origin.y + pos_in_element.y;
+                Some((Point::new(x, y), output.clone()))
+            } else {
+                None
+            }
+        };
+
+        if let Some((point, output)) = point_and_output {
+            let original_position = pointer.current_location();
+            pointer.set_location(point);
+
+            let mut shell = self.common.shell.write();
+            shell.update_pointer_position(point.as_global().to_local(&output), &output);
+
+            let seat = shell
+                .seats
+                .iter()
+                .find(|s| s.get_pointer().as_ref() == Some(pointer))
+                .cloned();
+
+            if let Some(seat) = seat {
+                shell.update_focal_point(
+                    &seat,
+                    original_position.as_global(),
+                    self.common.config.cosmic_conf.accessibility_zoom.view_moves,
+                );
+
+                let output_geometry = output.geometry();
+                for session in cursor_sessions_for_output(&shell, &output) {
+                    if let Some((geometry, offset)) = seat.cursor_geometry(
+                        point.to_buffer(
+                            output.current_scale().fractional_scale(),
+                            output.current_transform(),
+                            &output_geometry.size.to_f64().as_logical(),
+                        ),
+                        self.common.clock.now(),
+                    ) {
+                        if session
+                            .current_constraints()
+                            .map(|constraint| constraint.size != geometry.size)
+                            .unwrap_or(true)
+                        {
+                            session.update_constraints(BufferConstraints {
+                                size: geometry.size,
+                                shm: vec![ShmFormat::Argb8888],
+                                dma: None,
+                            });
+                        }
+                        session.set_cursor_hotspot(offset);
+                        session.set_cursor_pos(Some(geometry.loc));
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -354,27 +354,6 @@ impl State {
                             _ => {}
                         });
                     }
-                    let original_position = position;
-                    position += event.delta().as_global();
-
-                    let output = shell
-                        .outputs()
-                        .find(|output| output.geometry().to_f64().contains(position))
-                        .cloned()
-                        .unwrap_or(current_output.clone());
-
-                    let output_geometry = output.geometry();
-                    position.x = position.x.clamp(
-                        output_geometry.loc.x as f64,
-                        (output_geometry.loc.x + output_geometry.size.w - 1) as f64,
-                    );
-                    position.y = position.y.clamp(
-                        output_geometry.loc.y as f64,
-                        (output_geometry.loc.y + output_geometry.size.h - 1) as f64,
-                    );
-
-                    let new_under = State::surface_under(position, &output, &shell)
-                        .map(|(target, pos)| (target, pos.as_logical()));
 
                     std::mem::drop(shell);
                     ptr.relative_motion(
@@ -391,6 +370,25 @@ impl State {
                         ptr.frame(self);
                         return;
                     }
+
+                    let original_position = position;
+                    position += event.delta().as_global();
+                    let shell = self.common.shell.read();
+                    let output = shell
+                        .outputs()
+                        .find(|output| output.geometry().to_f64().contains(position))
+                        .cloned()
+                        .unwrap_or(current_output.clone());
+                    drop(shell);
+                    let output_geometry = output.geometry();
+                    position.x = position.x.clamp(
+                        output_geometry.loc.x as f64,
+                        (output_geometry.loc.x + output_geometry.size.w - 1) as f64,
+                    );
+                    position.y = position.y.clamp(
+                        output_geometry.loc.y as f64,
+                        (output_geometry.loc.y + output_geometry.size.h - 1) as f64,
+                    );
 
                     if ptr.is_grabbed() {
                         if seat
@@ -499,50 +497,90 @@ impl State {
                         }
                     }
 
-                    // If confined, don't move pointer if it would go outside surface or region
-                    if pointer_confined && let Some((surface, surface_loc)) = &under {
-                        if new_under.as_ref().and_then(|(under, _)| under.wl_surface())
-                            != surface.wl_surface()
-                        {
-                            ptr.frame(self);
-                            return;
-                        }
-                        match surface {
-                            PointerFocusTarget::WlSurface { surface, .. } => {
-                                if under_from_surface_tree(
-                                    surface,
-                                    position.as_logical() - surface_loc.to_f64(),
-                                    (0, 0),
-                                    WindowSurfaceType::ALL,
-                                )
-                                .is_none()
-                                {
-                                    ptr.frame(self);
-                                    return;
-                                }
-                            }
-                            PointerFocusTarget::X11Surface { surface, .. } => {
-                                if surface
-                                    .surface_under(
+                    // If confined, help user to update valid coordinates can improve user experience
+                    let shell = self.common.shell.read();
+                    let new_under = if pointer_confined && let Some((surface, surface_loc)) = &under
+                    {
+                        let is_legal = |pos: Point<f64, Global>, shell: &Shell| {
+                            let new_under = State::surface_under(pos, &output, shell)
+                                .map(|(target, pos)| (target, pos.as_logical()));
+
+                            //We should only check size, not the surface, so that we can move the mouse over the OSD in confined mode
+                            // if new_under.as_ref().and_then(|(under, _)| under.wl_surface())
+                            //     != surface.wl_surface()
+                            // {
+                            //     return (false, None);
+                            // }
+
+                            match surface {
+                                PointerFocusTarget::WlSurface { surface, .. } => {
+                                    if under_from_surface_tree(
+                                        surface,
                                         position.as_logical() - surface_loc.to_f64(),
                                         (0, 0),
                                         WindowSurfaceType::ALL,
                                     )
                                     .is_none()
-                                {
-                                    ptr.frame(self);
-                                    return;
+                                    {
+                                        return (false, None);
+                                    }
+                                }
+                                PointerFocusTarget::X11Surface { surface, .. } => {
+                                    if surface
+                                        .surface_under(
+                                            position.as_logical() - surface_loc.to_f64(),
+                                            (0, 0),
+                                            WindowSurfaceType::ALL,
+                                        )
+                                        .is_none()
+                                    {
+                                        return (false, None);
+                                    }
+                                }
+                                _ => {}
+                            }
+
+                            if let Some(region) = &confine_region
+                                && !region
+                                    .contains((pos.as_logical() - *surface_loc).to_i32_round())
+                            {
+                                return (false, None);
+                            }
+                            (true, new_under)
+                        };
+
+                        match is_legal(position, &shell) {
+                            (true, under) => under,
+                            _ => {
+                                let y_only_pos = Point::new(original_position.x, position.y);
+                                let x_only_pos = Point::new(position.x, original_position.y);
+                                match is_legal(y_only_pos, &shell) {
+                                    (true, under) => {
+                                        position = y_only_pos;
+                                        under
+                                    }
+                                    _ => match is_legal(x_only_pos, &shell) {
+                                        (true, under) => {
+                                            position = x_only_pos;
+                                            under
+                                        }
+                                        _ => {
+                                            position = original_position;
+                                            None
+                                        }
+                                    },
                                 }
                             }
-                            _ => {}
                         }
-                        if let Some(region) = confine_region
-                            && !region
-                                .contains((position.as_logical() - *surface_loc).to_i32_round())
-                        {
-                            ptr.frame(self);
-                            return;
-                        }
+                    } else {
+                        State::surface_under(position, &output, &shell)
+                            .map(|(target, pos)| (target, pos.as_logical()))
+                    };
+
+                    drop(shell);
+                    if pointer_confined && new_under.is_none() {
+                        ptr.frame(self);
+                        return;
                     }
 
                     let serial = SERIAL_COUNTER.next_serial();
@@ -557,24 +595,32 @@ impl State {
                     );
                     ptr.frame(self);
 
-                    // If pointer is now in a constraint region, activate it
+                    // If pointer is now in a constraint region and window is in focused, activate it
                     if let Some((under, surface_location)) = new_under
                         .and_then(|(target, loc)| Some((target.wl_surface()?.into_owned(), loc)))
                     {
-                        with_pointer_constraint(&under, &ptr, |constraint| match constraint {
-                            Some(constraint) if !constraint.is_active() => {
-                                let region = match &*constraint {
-                                    PointerConstraint::Locked(locked) => locked.region(),
-                                    PointerConstraint::Confined(confined) => confined.region(),
-                                };
-                                let point =
-                                    (ptr.current_location() - surface_location).to_i32_round();
-                                if region.is_none_or(|region| region.contains(point)) {
-                                    constraint.activate();
+                        let shell = self.common.shell.read();
+                        let is_focused = seat
+                            .get_keyboard()
+                            .and_then(|k| k.current_focus())
+                            .is_some_and(|f| f.has_surface(&shell, &under));
+
+                        if is_focused {
+                            with_pointer_constraint(&under, &ptr, |constraint| match constraint {
+                                Some(constraint) if !constraint.is_active() => {
+                                    let region = match &*constraint {
+                                        PointerConstraint::Locked(locked) => locked.region(),
+                                        PointerConstraint::Confined(confined) => confined.region(),
+                                    };
+                                    let point =
+                                        (ptr.current_location() - surface_location).to_i32_round();
+                                    if region.is_none_or(|region| region.contains(point)) {
+                                        constraint.activate();
+                                    }
                                 }
-                            }
-                            _ => {}
-                        });
+                                _ => {}
+                            });
+                        }
                     }
 
                     let mut shell = self.common.shell.write();

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -254,6 +254,14 @@ impl CosmicMapped {
             .any(|(w, _)| w.has_surface(surface, surface_type))
     }
 
+    pub fn surface_offset(&self, surface: &WlSurface) -> Option<Point<i32, Logical>> {
+        self.windows().find_map(|(window, window_offset)| {
+            window
+                .surface_offset(surface)
+                .map(|offset| window_offset + offset)
+        })
+    }
+
     /// Give the pointer target under a relative offset into this element.
     ///
     /// Returns Target + Offset relative to the target

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -269,10 +269,13 @@ impl CosmicMapped {
         &self,
         relative_pos: Point<f64, Logical>,
         surface_type: WindowSurfaceType,
+        seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Logical>)> {
         match &self.element {
             CosmicMappedInternal::Stack(stack) => stack.focus_under(relative_pos, surface_type),
-            CosmicMappedInternal::Window(window) => window.focus_under(relative_pos, surface_type),
+            CosmicMappedInternal::Window(window) => {
+                window.focus_under(relative_pos, surface_type, Some(seat))
+            }
             _ => unreachable!(),
         }
     }

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -253,6 +253,14 @@ impl CosmicMapped {
             .any(|(w, _)| w.has_surface(surface, surface_type))
     }
 
+    pub fn surface_offset(&self, surface: &WlSurface) -> Option<Point<i32, Logical>> {
+        self.windows().find_map(|(window, window_offset)| {
+            window
+                .surface_offset(surface)
+                .map(|offset| window_offset + offset)
+        })
+    }
+
     /// Give the pointer target under a relative offset into this element.
     ///
     /// Returns Target + Offset relative to the target

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -45,7 +45,10 @@ use smithay::{
         IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size, user_data::UserDataMap,
     },
     wayland::{
-        compositor::{SurfaceData, TraversalAction, with_states, with_surface_tree_downward},
+        compositor::{
+            SubsurfaceCachedState, SurfaceData, TraversalAction, with_states,
+            with_surface_tree_downward,
+        },
         seat::WaylandFocus,
         shell::xdg::{
             SurfaceCachedState, ToplevelCachedState, ToplevelSurface, XdgToplevelSurfaceData,
@@ -650,6 +653,68 @@ impl CosmicSurface {
         } else {
             false
         }
+    }
+
+    pub fn surface_offset(&self, surface: &WlSurface) -> Option<Point<i32, Logical>> {
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => {
+                Self::surface_tree_offset(toplevel.wl_surface(), surface)
+            }
+            WindowSurface::X11(surface_x11) => {
+                if surface_x11.wl_surface().as_ref() == Some(surface) {
+                    Some(Point::default())
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn surface_tree_offset(
+        root: &WlSurface,
+        surface: &WlSurface,
+    ) -> Option<Point<i32, Logical>> {
+        if root == surface {
+            return Some(Point::default());
+        }
+
+        let found = AtomicBool::new(false);
+        let mut found_offset = Point::<i32, Logical>::default();
+
+        with_surface_tree_downward(
+            root,
+            Point::<i32, Logical>::default(),
+            |s, states, parent_offset| {
+                let mut offset = *parent_offset;
+                if s != root {
+                    offset += states
+                        .cached_state
+                        .get::<SubsurfaceCachedState>()
+                        .current()
+                        .location;
+                }
+                TraversalAction::DoChildren(offset)
+            },
+            |s, _, offset| {
+                if s == surface {
+                    found_offset = *offset;
+                    found.store(true, Ordering::SeqCst);
+                }
+            },
+            |_, _, _| !found.load(Ordering::SeqCst),
+        );
+
+        if found.load(Ordering::SeqCst) {
+            return Some(found_offset);
+        }
+
+        for (popup, popup_offset) in PopupManager::popups_for_surface(root) {
+            if let Some(offset) = Self::surface_tree_offset(popup.wl_surface(), surface) {
+                return Some(popup_offset + offset);
+            }
+        }
+
+        None
     }
 
     pub fn focus_under(

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -345,7 +345,7 @@ impl CosmicSurface {
                     state.is_some_and(|state| state.states.contains(ToplevelState::Resizing))
                 }))
             }
-            WindowSurface::X11(surface) => surface.pending_geometry().map(|_| true),
+            WindowSurface::X11(surface) => surface.pending_configure().map(|_| true),
         }
     }
 
@@ -591,7 +591,7 @@ impl CosmicSurface {
                     }
                 })
             }
-            WindowSurface::X11(surface) => surface.pending_geometry().is_none(),
+            WindowSurface::X11(surface) => surface.pending_configure().is_none(),
         }
     }
 

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -45,7 +45,10 @@ use smithay::{
         IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size, user_data::UserDataMap,
     },
     wayland::{
-        compositor::{SurfaceData, TraversalAction, with_states, with_surface_tree_downward},
+        compositor::{
+            SubsurfaceCachedState, SurfaceData, TraversalAction, with_states,
+            with_surface_tree_downward,
+        },
         seat::WaylandFocus,
         shell::xdg::{
             SurfaceCachedState, ToplevelCachedState, ToplevelSurface, XdgToplevelSurfaceData,
@@ -651,6 +654,68 @@ impl CosmicSurface {
         } else {
             false
         }
+    }
+
+    pub fn surface_offset(&self, surface: &WlSurface) -> Option<Point<i32, Logical>> {
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(toplevel) => {
+                Self::surface_tree_offset(toplevel.wl_surface(), surface)
+            }
+            WindowSurface::X11(surface_x11) => {
+                if surface_x11.wl_surface().as_ref() == Some(surface) {
+                    Some(Point::default())
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn surface_tree_offset(
+        root: &WlSurface,
+        surface: &WlSurface,
+    ) -> Option<Point<i32, Logical>> {
+        if root == surface {
+            return Some(Point::default());
+        }
+
+        let found = AtomicBool::new(false);
+        let mut found_offset = Point::<i32, Logical>::default();
+
+        with_surface_tree_downward(
+            root,
+            Point::<i32, Logical>::default(),
+            |s, states, parent_offset| {
+                let mut offset = *parent_offset;
+                if s != root {
+                    offset += states
+                        .cached_state
+                        .get::<SubsurfaceCachedState>()
+                        .current()
+                        .location;
+                }
+                TraversalAction::DoChildren(offset)
+            },
+            |s, _, offset| {
+                if s == surface {
+                    found_offset = *offset;
+                    found.store(true, Ordering::SeqCst);
+                }
+            },
+            |_, _, _| !found.load(Ordering::SeqCst),
+        );
+
+        if found.load(Ordering::SeqCst) {
+            return Some(found_offset);
+        }
+
+        for (popup, popup_offset) in PopupManager::popups_for_surface(root) {
+            if let Some(offset) = Self::surface_tree_offset(popup.wl_surface(), surface) {
+                return Some(popup_offset + offset);
+            }
+        }
+
+        None
     }
 
     pub fn focus_under(

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -57,7 +57,7 @@ use smithay::{
         Buffer, IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size, Transform,
         user_data::UserDataMap,
     },
-    wayland::seat::WaylandFocus,
+    wayland::{pointer_constraints::with_pointer_constraint, seat::WaylandFocus},
 };
 use std::{
     borrow::Cow,
@@ -274,12 +274,25 @@ impl CosmicWindow {
         &self,
         mut relative_pos: Point<f64, Logical>,
         surface_type: WindowSurfaceType,
+        seat: Option<&Seat<State>>,
     ) -> Option<(PointerFocusTarget, Point<f64, Logical>)> {
+        let has_constraint = if let Some(seat) = seat
+            && let Some(pointer) = seat.get_pointer()
+            && let Some(surface) = self.wl_surface()
+            && with_pointer_constraint(&surface, &pointer, |constraint| {
+                constraint.is_some_and(|c| c.is_active())
+            }) {
+            true
+        } else {
+            false
+        };
+
         self.0.with_program(|p| {
             let mut offset = Point::from((0., 0.));
             let mut window_ui = None;
             let has_ssd = p.has_ssd(false);
-            if (has_ssd || p.has_tiled_state())
+
+            if (!has_constraint && (has_ssd || p.has_tiled_state()))
                 && surface_type.contains(WindowSurfaceType::TOPLEVEL)
             {
                 let geo = p.window.geometry();
@@ -877,7 +890,8 @@ impl SpaceElement for CosmicWindow {
         })
     }
     fn is_in_input_region(&self, point: &Point<f64, Logical>) -> bool {
-        self.focus_under(*point, WindowSurfaceType::ALL).is_some()
+        self.focus_under(*point, WindowSurfaceType::ALL, None)
+            .is_some()
     }
     fn set_activate(&self, activated: bool) {
         if self

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     shell::{CosmicSurface, MinimizedWindow, Shell, Trigger, element::CosmicMapped},
-    state::Common,
+    state::{Common, State},
     utils::prelude::*,
     wayland::handlers::{xdg_shell::PopupGrabData, xwayland_keyboard_grab::XWaylandGrabSeatData},
 };
@@ -12,6 +12,7 @@ use smithay::{
     reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface},
     utils::{IsAlive, Point, SERIAL_COUNTER, Serial},
     wayland::{
+        pointer_constraints::with_pointer_constraint,
         seat::WaylandFocus,
         selection::{data_device::set_data_device_focus, primary_selection::set_primary_focus},
         shell::wlr_layer::{KeyboardInteractivity, Layer},
@@ -347,6 +348,20 @@ fn update_focus_state(
 ) {
     // update keyboard focus
     if let Some(keyboard) = seat.get_keyboard() {
+        // remove constraint when target changed
+        let old_focus = keyboard.current_focus();
+        if let Some(old_target) = old_focus
+            && target != Some(&old_target)
+            && let Some(surface) = old_target.wl_surface()
+            && let Some(pointer) = seat.get_pointer()
+        {
+            with_pointer_constraint(&surface, &pointer, |constraint| {
+                if let Some(constraint) = constraint {
+                    constraint.deactivate();
+                }
+            });
+        }
+
         if should_update_cursor
             && state.common.config.cosmic_conf.cursor_follows_focus
             && target.is_some()

--- a/src/shell/focus/order.rs
+++ b/src/shell/focus/order.rs
@@ -220,12 +220,12 @@ fn render_input_order_internal<R: 'static>(
             .rev()
             .filter(|or| {
                 (*or)
-                    .geometry()
+                    .last_configure()
                     .as_global()
                     .intersection(output.geometry())
                     .is_some()
             })
-            .map(|or| (or, or.geometry().loc.as_global()))
+            .map(|or| (or, or.last_configure().loc.as_global()))
         {
             callback(Stage::OverrideRedirect { surface, location })?;
         }

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -281,6 +281,18 @@ impl KeyboardFocusTarget {
             false
         }
     }
+
+    pub fn has_surface(&self, shell: &Shell, surface: &WlSurface) -> bool {
+        if let Some(fe) = shell.focused_element(self) {
+            fe.has_surface(surface, WindowSurfaceType::ALL)
+        } else if let KeyboardFocusTarget::Fullscreen(s) = self {
+            s.has_surface(surface, WindowSurfaceType::ALL)
+        } else if let Some(root) = WaylandFocus::wl_surface(self) {
+            CosmicSurface::surface_tree_offset(&root, surface).is_some()
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -953,6 +953,7 @@ impl Drop for MoveGrab {
                     if let Some((target, offset)) = mapped.focus_under(
                         current_location - position.as_logical().to_f64(),
                         WindowSurfaceType::ALL,
+                        &seat,
                     ) {
                         pointer.motion(
                             state,

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -731,7 +731,11 @@ impl FloatingLayout {
         self.space.element_geometry(elem).map(RectExt::as_local)
     }
 
-    pub fn popup_element_under(&self, location: Point<f64, Local>) -> Option<KeyboardFocusTarget> {
+    pub fn popup_element_under(
+        &self,
+        location: Point<f64, Local>,
+        seat: &Seat<State>,
+    ) -> Option<KeyboardFocusTarget> {
         self.space
             .elements()
             .rev()
@@ -752,6 +756,7 @@ impl FloatingLayout {
                 if e.focus_under(
                     point.as_logical(),
                     WindowSurfaceType::POPUP | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 )
                 .is_some()
                 {
@@ -765,6 +770,7 @@ impl FloatingLayout {
     pub fn toplevel_element_under(
         &self,
         location: Point<f64, Local>,
+        seat: &Seat<State>,
     ) -> Option<KeyboardFocusTarget> {
         self.space
             .elements()
@@ -786,6 +792,7 @@ impl FloatingLayout {
                 if e.focus_under(
                     point.as_logical(),
                     WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 )
                 .is_some()
                 {
@@ -799,6 +806,7 @@ impl FloatingLayout {
     pub fn popup_surface_under(
         &self,
         location: Point<f64, Local>,
+        seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Local>)> {
         self.space
             .elements()
@@ -820,6 +828,7 @@ impl FloatingLayout {
                 e.focus_under(
                     point.as_logical(),
                     WindowSurfaceType::POPUP | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 )
                 .map(|(surface, surface_offset)| {
                     (surface, render_location + surface_offset.as_local())
@@ -830,6 +839,7 @@ impl FloatingLayout {
     pub fn toplevel_surface_under(
         &self,
         location: Point<f64, Local>,
+        seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Local>)> {
         self.space
             .elements()
@@ -851,6 +861,7 @@ impl FloatingLayout {
                 e.focus_under(
                     point.as_logical(),
                     WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 )
                 .map(|(surface, surface_offset)| {
                     (surface, render_location + surface_offset.as_local())

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -3145,6 +3145,7 @@ impl TilingLayout {
     pub fn popup_element_under(
         &self,
         location_f64: Point<f64, Local>,
+        seat: &Seat<State>,
     ) -> Option<KeyboardFocusTarget> {
         let location = location_f64.to_i32_round();
 
@@ -3157,6 +3158,7 @@ impl TilingLayout {
                 .focus_under(
                     (location_f64 - geo.loc.to_f64()).as_logical() + mapped.geometry().loc.to_f64(),
                     WindowSurfaceType::POPUP | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 )
                 .is_some()
             {
@@ -3170,6 +3172,7 @@ impl TilingLayout {
     pub fn toplevel_element_under(
         &self,
         location_f64: Point<f64, Local>,
+        seat: &Seat<State>,
     ) -> Option<KeyboardFocusTarget> {
         let location = location_f64.to_i32_round();
 
@@ -3182,6 +3185,7 @@ impl TilingLayout {
                 .focus_under(
                     (location_f64 - geo.loc.to_f64()).as_logical() + mapped.geometry().loc.to_f64(),
                     WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 )
                 .is_some()
             {
@@ -3196,6 +3200,7 @@ impl TilingLayout {
         &self,
         location_f64: Point<f64, Local>,
         overview: OverviewMode,
+        seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Local>)> {
         let location = location_f64.to_i32_round();
 
@@ -3210,6 +3215,7 @@ impl TilingLayout {
                 if let Some((target, surface_offset)) = mapped.focus_under(
                     (location_f64 - geo.loc.to_f64()).as_logical() + mapped.geometry().loc.to_f64(),
                     WindowSurfaceType::POPUP | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 ) {
                     return Some((
                         target,
@@ -3227,6 +3233,7 @@ impl TilingLayout {
         &self,
         location_f64: Point<f64, Local>,
         overview: OverviewMode,
+        seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Local>)> {
         let tree = &self.queue.trees.back().unwrap().0;
         let root = tree.root_node_id()?;
@@ -3243,6 +3250,7 @@ impl TilingLayout {
                 if let Some((target, surface_offset)) = mapped.focus_under(
                     (location_f64 - geo.loc.to_f64()).as_logical() + mapped.geometry().loc.to_f64(),
                     WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
+                    seat,
                 ) {
                     return Some((
                         target,
@@ -3293,6 +3301,7 @@ impl TilingLayout {
                         .focus_under(
                             test_point,
                             WindowSurfaceType::TOPLEVEL | WindowSurfaceType::SUBSURFACE,
+                            seat,
                         )
                         .map(|(surface, surface_offset)| {
                             (

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -737,22 +737,23 @@ impl WorkspaceSet {
         surface: &WlSurface,
     ) -> Option<(Rectangle<i32, Local>, Point<i32, Logical>)> {
         let mut root = surface.clone();
-        loop {
-            while let Some(parent) = get_parent(&root) {
+
+        while let Some(parent) = get_parent(&root) {
+            root = parent;
+        }
+
+        while smithay::wayland::compositor::get_role(&root) == Some(XDG_POPUP_ROLE) {
+            let parent = with_states(&root, |states| {
+                states
+                    .data_map
+                    .get::<XdgPopupSurfaceData>()
+                    .and_then(|m| m.lock().unwrap().parent.as_ref().cloned())
+            });
+            if let Some(parent) = parent {
                 root = parent;
+            } else {
+                break;
             }
-            if smithay::wayland::compositor::get_role(&root) == Some(XDG_POPUP_ROLE)
-                && let Some(parent) = with_states(&root, |states| {
-                    states
-                        .data_map
-                        .get::<XdgPopupSurfaceData>()
-                        .and_then(|m| m.lock().unwrap().parent.as_ref().cloned())
-                })
-            {
-                root = parent;
-                continue;
-            }
-            break;
         }
 
         self.sticky_layer

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -3714,7 +3714,11 @@ impl Shell {
             if old_mapped.is_maximized(false) {
                 new_mapped.set_maximized(false);
             }
-            start_data.set_focus(new_mapped.focus_under((0., 0.).into(), WindowSurfaceType::ALL));
+            start_data.set_focus(new_mapped.focus_under(
+                (0., 0.).into(),
+                WindowSurfaceType::ALL,
+                seat,
+            ));
             new_mapped
         } else {
             old_mapped.clone()
@@ -4185,7 +4189,7 @@ impl Shell {
 
         let element_offset = (new_loc - geometry.loc).as_logical();
         let focus = mapped
-            .focus_under(element_offset.to_f64(), WindowSurfaceType::ALL)
+            .focus_under(element_offset.to_f64(), WindowSurfaceType::ALL, seat)
             .map(|(target, surface_offset)| (target, (surface_offset + element_offset.to_f64())));
         start_data.set_location(new_loc.as_logical().to_f64());
         start_data.set_focus(focus.clone());

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -50,10 +50,13 @@ use smithay::{
     },
     utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
     wayland::{
-        compositor::{SurfaceAttributes, with_states},
+        compositor::{SurfaceAttributes, get_parent, with_states},
         seat::WaylandFocus,
         session_lock::LockSurface,
-        shell::wlr_layer::{KeyboardInteractivity, Layer, LayerSurfaceCachedState},
+        shell::{
+            wlr_layer::{KeyboardInteractivity, Layer, LayerSurfaceCachedState},
+            xdg::{XDG_POPUP_ROLE, XdgPopupSurfaceData},
+        },
         xdg_activation::XdgActivationState,
         xwayland_keyboard_grab::XWaylandKeyboardGrab,
     },
@@ -727,6 +730,81 @@ impl WorkspaceSet {
         self.workspaces = doesnt;
         self.post_remove_workspace(workspace_state, &previous_active_handle);
         prefers
+    }
+
+    pub fn surface_geometry_offset_from_toplevel(
+        &self,
+        surface: &WlSurface,
+    ) -> Option<(Rectangle<i32, Local>, Point<i32, Logical>)> {
+        let mut root = surface.clone();
+        loop {
+            while let Some(parent) = get_parent(&root) {
+                root = parent;
+            }
+            if smithay::wayland::compositor::get_role(&root) == Some(XDG_POPUP_ROLE)
+                && let Some(parent) = with_states(&root, |states| {
+                    states
+                        .data_map
+                        .get::<XdgPopupSurfaceData>()
+                        .and_then(|m| m.lock().unwrap().parent.as_ref().cloned())
+                })
+            {
+                root = parent;
+                continue;
+            }
+            break;
+        }
+
+        self.sticky_layer
+            .mapped()
+            .find(|w| {
+                w.windows()
+                    .any(|(w, _)| w.wl_surface().as_deref() == Some(&root))
+            })
+            .and_then(|w| {
+                w.surface_offset(surface).and_then(|offset| {
+                    self.sticky_layer
+                        .element_geometry(w)
+                        .map(|geom| (geom, offset))
+                })
+            })
+            .or_else(|| {
+                self.workspaces.iter().find_map(|workspace| {
+                    workspace
+                        .get_fullscreen()
+                        .and_then(|fullscreen| {
+                            (fullscreen.wl_surface().as_deref() == Some(&root))
+                                .then(|| {
+                                    fullscreen.surface_offset(surface).and_then(|offset| {
+                                        workspace.fullscreen_geometry().map(|geom| (geom, offset))
+                                    })
+                                })
+                                .flatten()
+                        })
+                        .or_else(|| {
+                            workspace.mapped().find_map(|w| {
+                                w.windows()
+                                    .any(|(w, _)| w.wl_surface().as_deref() == Some(&root))
+                                    .then(|| {
+                                        w.surface_offset(surface).and_then(|offset| {
+                                            workspace.element_geometry(w).map(|geom| (geom, offset))
+                                        })
+                                    })
+                                    .flatten()
+                            })
+                        })
+                })
+            })
+            .or_else(|| {
+                layer_map_for_output(&self.output).layers().find_map(|l| {
+                    (l.wl_surface() == &root)
+                        .then(|| {
+                            CosmicSurface::surface_tree_offset(l.wl_surface(), surface)
+                                .map(|offset| (l.geometry().as_local(), offset))
+                        })
+                        .flatten()
+                })
+            })
     }
 }
 

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -17,8 +17,11 @@ use smithay::{
         pointer::{CursorImageAttributes, CursorImageStatus},
     },
     output::Output,
-    reexports::{input::Device as InputDevice, wayland_server::DisplayHandle},
-    utils::{Buffer, IsAlive, Monotonic, Point, Rectangle, Serial, Time, Transform},
+    reexports::{
+        input::Device as InputDevice,
+        wayland_server::{DisplayHandle, protocol::wl_surface::WlSurface},
+    },
+    utils::{Buffer, IsAlive, Logical, Monotonic, Point, Rectangle, Serial, Time, Transform},
     wayland::compositor::with_states,
 };
 use tracing::warn;
@@ -179,6 +182,9 @@ struct ActiveOutput(pub Mutex<Output>);
 struct FocusedOutput(pub Mutex<Option<Output>>);
 
 #[derive(Default)]
+pub struct PointerConstraintHint(pub Mutex<Option<(WlSurface, Point<f64, Logical>)>>);
+
+#[derive(Default)]
 pub struct LastModifierChange(pub Mutex<Option<Serial>>);
 
 pub fn create_seat(
@@ -201,6 +207,7 @@ pub fn create_seat(
     userdata.insert_if_missing_threadsafe(CursorState::default);
     userdata.insert_if_missing_threadsafe(|| ActiveOutput(Mutex::new(output.clone())));
     userdata.insert_if_missing_threadsafe(|| FocusedOutput(Mutex::new(None)));
+    userdata.insert_if_missing_threadsafe(PointerConstraintHint::default);
     userdata.insert_if_missing_threadsafe(|| Mutex::new(CursorImageStatus::default_named()));
 
     // A lot of clients bind keyboard and pointer unconditionally once on launch..
@@ -252,6 +259,8 @@ pub trait SeatExt {
     fn supressed_buttons(&self) -> &SupressedButtons;
     fn modifiers_shortcut_queue(&self) -> &ModifiersShortcutQueue;
     fn last_modifier_change(&self) -> Option<Serial>;
+    fn pointer_constraint_hint(&self) -> Option<(WlSurface, Point<f64, Logical>)>;
+    fn set_pointer_constraint_hint(&self, hint: Option<(WlSurface, Point<f64, Logical>)>);
 
     fn cursor_geometry(
         &self,
@@ -335,6 +344,23 @@ impl SeatExt for Seat<State> {
             .0
             .lock()
             .unwrap()
+    }
+
+    fn pointer_constraint_hint(&self) -> Option<(WlSurface, Point<f64, Logical>)> {
+        let lock = self.user_data().get::<PointerConstraintHint>().unwrap();
+        let mut hint = lock.0.lock().unwrap();
+        // Check if alive
+        if let Some((ref surface, _)) = *hint
+            && !surface.alive()
+        {
+            *hint = None;
+        }
+        hint.clone()
+    }
+
+    fn set_pointer_constraint_hint(&self, hint: Option<(WlSurface, Point<f64, Logical>)>) {
+        let lock = self.user_data().get::<PointerConstraintHint>().unwrap();
+        *lock.0.lock().unwrap() = hint;
     }
 
     fn cursor_geometry(

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -791,8 +791,8 @@ impl Workspace {
         }
 
         self.floating_layer
-            .popup_element_under(location)
-            .or_else(|| self.tiling_layer.popup_element_under(location))
+            .popup_element_under(location, seat)
+            .or_else(|| self.tiling_layer.popup_element_under(location, seat))
             .or_else(|| {
                 if last_focused.is_none_or(|t| !matches!(t, FocusTarget::Fullscreen(_)))
                     && let Some(fullscreen) = self.fullscreen.as_ref()
@@ -841,8 +841,8 @@ impl Workspace {
         }
 
         self.floating_layer
-            .toplevel_element_under(location)
-            .or_else(|| self.tiling_layer.toplevel_element_under(location))
+            .toplevel_element_under(location, seat)
+            .or_else(|| self.tiling_layer.toplevel_element_under(location, seat))
             .or_else(|| {
                 if last_focused.is_none_or(|t| !matches!(t, FocusTarget::Fullscreen(_)))
                     && let Some(fullscreen) = self.fullscreen.as_ref()
@@ -895,8 +895,11 @@ impl Workspace {
             .as_ref()
             .filter(|f| last_focused.is_some_and(|t| t == &f.surface))
             .and_then(check_fullscreen)
-            .or_else(|| self.floating_layer.popup_surface_under(location))
-            .or_else(|| self.tiling_layer.popup_surface_under(location, overview))
+            .or_else(|| self.floating_layer.popup_surface_under(location, seat))
+            .or_else(|| {
+                self.tiling_layer
+                    .popup_surface_under(location, overview, seat)
+            })
             .or_else(|| {
                 self.fullscreen
                     .as_ref()
@@ -941,8 +944,11 @@ impl Workspace {
             .as_ref()
             .filter(|f| last_focused.is_some_and(|t| t == &f.surface))
             .and_then(check_fullscreen)
-            .or_else(|| self.floating_layer.toplevel_surface_under(location))
-            .or_else(|| self.tiling_layer.toplevel_surface_under(location, overview))
+            .or_else(|| self.floating_layer.toplevel_surface_under(location, seat))
+            .or_else(|| {
+                self.tiling_layer
+                    .toplevel_surface_under(location, overview, seat)
+            })
             .or_else(|| {
                 self.fullscreen
                     .as_ref()

--- a/src/wayland/handlers/pointer_constraints.rs
+++ b/src/wayland/handlers/pointer_constraints.rs
@@ -1,35 +1,123 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::state::State;
+use crate::{shell::CosmicSurface, state::State, utils::prelude::*};
 use smithay::{
     input::pointer::PointerHandle,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::{Logical, Point},
-    wayland::{
-        pointer_constraints::{PointerConstraintsHandler, with_pointer_constraint},
-        seat::WaylandFocus,
-    },
+    wayland::{pointer_constraints::PointerConstraintsHandler, seat::WaylandFocus},
 };
+
+pub use smithay::wayland::pointer_constraints::{PointerConstraintRef, with_pointer_constraint};
 
 impl PointerConstraintsHandler for State {
     fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
-        // XXX region
-        if pointer
-            .current_focus()
-            .is_some_and(|x| x.wl_surface().as_deref() == Some(surface))
-        {
+        let seat = self
+            .common
+            .shell
+            .read()
+            .seats
+            .iter()
+            .find(|s| s.get_pointer().as_ref() == Some(pointer))
+            .cloned();
+
+        let (is_under, is_focused, surface_location) = if let Some(seat) = seat {
+            seat.set_pointer_constraint_hint(None);
+            let current_output = seat.active_output();
+            let position = seat.get_pointer().unwrap().current_location().as_global();
+            let shell = self.common.shell.read();
+            let under = State::surface_under(position, &current_output, &shell);
+            let mut surface_location = None;
+
+            let is_under = if let Some((target, target_loc)) = under
+                && let Some(under_surface) = target.wl_surface()
+            {
+                if *under_surface == *surface {
+                    surface_location = Some(target_loc);
+                    true
+                } else {
+                    CosmicSurface::surface_tree_offset(surface, &under_surface).is_some_and(
+                        |offset| {
+                            surface_location = Some(target_loc - offset.to_f64().as_global());
+                            true
+                        },
+                    )
+                }
+            } else {
+                false
+            };
+
+            let is_focused = seat
+                .get_keyboard()
+                .and_then(|k| k.current_focus())
+                .is_some_and(|f| f.has_surface(&shell, surface));
+
+            (is_under, is_focused, surface_location)
+        } else {
+            (false, false, None)
+        };
+
+        if is_focused && is_under {
             with_pointer_constraint(surface, pointer, |constraint| {
-                constraint.unwrap().activate();
+                if let Some(constraint) = constraint {
+                    if let Some(region) = constraint.region() {
+                        if let Some(surface_location) = surface_location
+                            && let position = pointer.current_location()
+                            && let point = (position - surface_location.as_logical()).to_i32_round()
+                            && region.contains(point)
+                        {
+                            constraint.activate();
+                        }
+                    } else {
+                        constraint.activate();
+                    }
+                }
             });
+        }
+    }
+
+    fn remove_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
+        if with_pointer_constraint(surface, pointer, |constraint| constraint.is_none()) {
+            let seat = self
+                .common
+                .shell
+                .read()
+                .seats
+                .iter()
+                .find(|s| s.get_pointer().as_ref() == Some(pointer))
+                .cloned();
+
+            if let Some(seat) = seat
+                && let Some((hint_surface, hint_location)) = seat.pointer_constraint_hint()
+                && hint_surface == *surface
+            {
+                self.apply_cursor_hint(surface, pointer, hint_location);
+                seat.set_pointer_constraint_hint(None);
+            }
         }
     }
 
     fn cursor_position_hint(
         &mut self,
-        _surface: &WlSurface,
-        _pointer: &PointerHandle<Self>,
-        _location: Point<f64, Logical>,
+        surface: &WlSurface,
+        pointer: &PointerHandle<Self>,
+        location: Point<f64, Logical>,
     ) {
-        // TODO
+        if with_pointer_constraint(surface, pointer, |constraint| {
+            constraint.is_some_and(|c| c.is_active())
+        }) {
+            let seat = self
+                .common
+                .shell
+                .read()
+                .seats
+                .iter()
+                .find(|s| s.get_pointer().as_ref() == Some(pointer))
+                .cloned();
+
+            if let Some(seat) = seat {
+                seat.set_pointer_constraint_hint(Some((surface.clone(), location)));
+            }
+        }
     }
 }


### PR DESCRIPTION
Needs https://github.com/Smithay/smithay/pull/2027
Inspired by: https://github.com/pop-os/cosmic-comp/pull/1861

This PR primarily implement the specification required for zwp_locked_pointer_v1, adds force unlock when focus change, and improves the user experience when the cursor is at the edge of the window.

I did the following:
- Constraints are enabled when all conditions are met, like PointerTargetFocus, KeyboardTargetFocus, Constraint Region
- Cursor Position Hint is applied when the constraint is removed
- Support sliding confinement: original approach made the mouse easily stick to the edge of the window, I changed it to check the possibility of the x or y axis, which greatly improves the user experience.
- Save cursor position hint in the seat to support Multiseats
- Support client_scale for xwayland

This protocol feature is a very important to games, especially first-person and third-person games, many games control mouse behavior through pointer-constraints, some professional software also requires this feature, but I don't have any of them to test it.

If there are still issues with camera control with xwayland, then it's probably not a problem with this protocol.

I still recommend using `PROTON_ENABLE_WAYLAND=1` whenever possible.

the games I have already tested:
- Persona 5 Royal
- Gray Zone Warfare
- ARC Raiders
- Crimson Desert
- Minecraft
- Ready or Not
- Broken Arrow
- Slay the Spire 2
- Clair Obscur: Expedition 33
- R.E.P.O
- FINAL FANTASY XIV
- HELLDIVERS 2

Many thanks to the System76 team for their hard work. cosmic-comp has already demonstrated impressive performance and stability.

With this implementation, no longer need to rely on gamescope to correct mouse behavior, which avoids unnecessary latency and performance overhead. the cursor is now correctly positioned according to the cursor hints provided by games, and pointer constraints are properly released when focus changes. Correct cursor behavior in games is essential for a smooth gaming experience, and this improvement helps make cosmic-comp a competitive gaming compositor alongside KWin from KDE.

I know this PR is a bit too large, so please let me know if there's anything I need to add.

:beers:  
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

