### PR TITLE
xwayland: clean up stale X11 data upon xwayland crash

### DIFF
--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -35,7 +35,8 @@ use smithay::{
     input::{keyboard::ModifiersState, pointer::CursorIcon},
     reexports::{wayland_server::Client, x11rb::protocol::xproto::Window as X11Window},
     utils::{
-        Buffer as BufferCoords, Logical, Point, Rectangle, SERIAL_COUNTER, Serial, Size, Transform,
+        Buffer as BufferCoords, IsAlive, Logical, Point, Rectangle, SERIAL_COUNTER, Serial, Size,
+        Transform,
     },
     wayland::{
         selection::{
@@ -177,10 +178,26 @@ impl State {
                     data.common.update_xwayland_primary_output();
                 }
                 XWaylandEvent::Error => {
+                    data.common
+                        .xwayland_reset_eavesdropping(SERIAL_COUNTER.next_serial());
                     if let Some(mut xwayland_state) = data.common.xwayland_state.take() {
                         xwayland_state.xwm = None;
                     }
                     data.common.xwayland_scale = None;
+
+                    let mut shell = data.common.shell.write();
+                    shell.xwayland_keyboard_grab = None;
+                    shell.override_redirect_windows.retain(|or| or.alive());
+                    shell
+                        .pending_windows
+                        .retain(|pending| pending.surface.alive());
+                    shell
+                        .pending_activations
+                        .retain(|key, _| !matches!(key, crate::shell::ActivationKey::X11(_)));
+                    // The main mapped surfaces will be cleaned up by routine `alive()` checks in `refresh()`,
+                    // but we ensure the shell drops dead X11 surfaces directly here.
+                    std::mem::drop(shell);
+
                     data.notify_ready();
                 }
             }) {

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -180,6 +180,7 @@ impl State {
                     if let Some(mut xwayland_state) = data.common.xwayland_state.take() {
                         xwayland_state.xwm = None;
                     }
+                    data.common.xwayland_scale = None;
                     data.notify_ready();
                 }
             }) {
@@ -721,15 +722,15 @@ impl Common {
             // update cursor
             xwayland.reload_cursor(new_scale);
 
-            if let Some(geometries) = geometries {
-                // update client scale
-                xwayland
-                    .client
-                    .get_data::<XWaylandClientData>()
-                    .unwrap()
-                    .compositor_state
-                    .set_client_scale(new_scale);
+            // update client scale
+            xwayland
+                .client
+                .get_data::<XWaylandClientData>()
+                .unwrap()
+                .compositor_state
+                .set_client_scale(new_scale);
 
+            if let Some(geometries) = geometries {
                 // update wl/xdg_outputs
                 for output in self.shell.read().outputs() {
                     output.change_current_state(None, None, None, None);


### PR DESCRIPTION
We all know that games are often unstable, so it's not surprising that the game itself caused xwayland to crash. Therefore, I try to improve that we can clean up and restart after a problem occurs.

- ensures `client_scale` is always updated during changes or error. this is an important parameter for calculating mouse coordinates.
- clean up stale X11 surfaces and resets eavesdropping on crash.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

