### PR TITLE
fix: panic on pinning in debug build 

### DIFF
--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -431,9 +431,9 @@ impl Workspace {
     }
 
     pub fn to_pinned(&self) -> Option<PinnedWorkspace> {
-        debug_assert!(self.id.is_some());
         let output = self.explicit_output().clone();
         if self.pinned {
+            debug_assert!(self.id.is_some());
             Some(PinnedWorkspace {
                 output: cosmic_comp_config::workspace::OutputMatch {
                     name: output.name,


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.



ids seem to only be created upon pinning a workspace, but to_pinned is called on every workspace as a filter at src/shell/mod.rs:1406 which contains a debug assert that panics. As workspaces in this context only receive an id if they're pinned the assert should probably be in that branch.  

Fixes: #2365 