### PR TITLE
feat: add config option for xdg activation behavior

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -99,6 +99,7 @@ pub struct CosmicCompConfig {
     pub edge_snap_threshold: u32,
     pub accessibility_zoom: ZoomConfig,
     pub appearance_settings: AppearanceConfig,
+    pub activation_policy: ActivationPolicy,
 }
 
 impl Default for CosmicCompConfig {
@@ -135,6 +136,7 @@ impl Default for CosmicCompConfig {
             edge_snap_threshold: 0,
             accessibility_zoom: ZoomConfig::default(),
             appearance_settings: AppearanceConfig::default(),
+            activation_policy: ActivationPolicy::default(),
         }
     }
 }
@@ -222,6 +224,14 @@ pub enum EavesdroppingKeyboardMode {
     Modifiers,
     Combinations,
     All,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ActivationPolicy {
+    #[default]
+    Focus,
+    FocusIfActiveWorkspace,
+    Urgent,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialEq, Eq)]

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -101,6 +101,7 @@ pub struct CosmicCompConfig {
     pub appearance_settings: AppearanceConfig,
     /// Hide the cursor after this many seconds of pointer inactivity (None disables)
     pub cursor_hide_timeout: Option<u32>,
+    pub activation_policy: ActivationPolicy,
 }
 
 impl Default for CosmicCompConfig {
@@ -138,6 +139,7 @@ impl Default for CosmicCompConfig {
             accessibility_zoom: ZoomConfig::default(),
             appearance_settings: AppearanceConfig::default(),
             cursor_hide_timeout: None,
+            activation_policy: ActivationPolicy::default(),
         }
     }
 }
@@ -225,6 +227,14 @@ pub enum EavesdroppingKeyboardMode {
     Modifiers,
     Combinations,
     All,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ActivationPolicy {
+    #[default]
+    Focus,
+    FocusIfActiveWorkspace,
+    Urgent,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialEq, Eq)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,8 +45,8 @@ mod types;
 use cosmic::config::CosmicTk;
 pub use cosmic_comp_config::EdidProduct;
 use cosmic_comp_config::{
-    AppearanceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior, XkbConfig, XwaylandDescaling,
-    XwaylandEavesdropping, ZoomConfig,
+    ActivationPolicy, AppearanceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior, XkbConfig,
+    XwaylandDescaling, XwaylandEavesdropping, ZoomConfig,
     input::{DeviceState as InputDeviceState, InputConfig, TouchpadOverride},
     output::comp::{
         OutputConfig, OutputInfo, OutputState, OutputsConfig, TransformDef, load_outputs,
@@ -945,6 +945,12 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                     for output in state.common.shell.read().outputs() {
                         state.backend.schedule_render(output);
                     }
+                }
+            }
+            "activation_policy" => {
+                let new = get_config::<ActivationPolicy>(&config, "activation_policy");
+                if new != state.common.config.cosmic_conf.activation_policy {
+                    state.common.config.cosmic_conf.activation_policy = new;
                 }
             }
             _ => {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,8 +45,8 @@ mod types;
 use cosmic::config::CosmicTk;
 pub use cosmic_comp_config::EdidProduct;
 use cosmic_comp_config::{
-    AppearanceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior, XkbConfig, XwaylandDescaling,
-    XwaylandEavesdropping, ZoomConfig,
+    ActivationPolicy, AppearanceConfig, CosmicCompConfig, KeyboardConfig, TileBehavior, XkbConfig,
+    XwaylandDescaling, XwaylandEavesdropping, ZoomConfig,
     input::{DeviceState as InputDeviceState, InputConfig, TouchpadOverride},
     output::comp::{
         OutputConfig, OutputInfo, OutputState, OutputsConfig, TransformDef, load_outputs,
@@ -964,6 +964,12 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                             state.backend.schedule_render(&output);
                         }
                     }
+                }
+            }
+            "activation_policy" => {
+                let new = get_config::<ActivationPolicy>(&config, "activation_policy");
+                if new != state.common.config.cosmic_conf.activation_policy {
+                    state.common.config.cosmic_conf.activation_policy = new;
                 }
             }
             _ => {}

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -5,6 +5,7 @@ use crate::{
     state::State,
     wayland::protocols::workspace::{State as WState, WorkspaceHandle},
 };
+use cosmic_comp_config::ActivationPolicy;
 use smithay::{
     input::Seat,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
@@ -115,10 +116,45 @@ impl XdgActivationHandler for State {
                 }
             }
             ActivationContext::Workspace(_) => {
-                self.activate_surface(
-                    &surface,
-                    Some((ActivationKey::Wayland(surface.clone()), *context)),
-                );
+                match self.common.config.cosmic_conf.activation_policy {
+                    ActivationPolicy::Focus => {
+                        self.activate_surface(
+                            &surface,
+                            Some((ActivationKey::Wayland(surface.clone()), *context)),
+                        );
+                    }
+                    ActivationPolicy::FocusIfActiveWorkspace => {
+                        let shell = self.common.shell.write();
+
+                        let Some((target_workspace, _)) = shell.workspace_for_surface(&surface)
+                        else {
+                            // surface not found, maybe log warning?
+                            return;
+                        };
+
+                        let seat = shell.seats.last_active().clone();
+                        let current_output = seat.active_output();
+                        let current_workspace = shell.active_space(&current_output).unwrap().handle;
+
+                        if target_workspace == current_workspace {
+                            std::mem::drop(shell);
+                            self.activate_surface(
+                                &surface,
+                                Some((ActivationKey::Wayland(surface.clone()), *context)),
+                            );
+                        } else {
+                            let mut workspace_guard = self.common.workspace_state.update();
+                            workspace_guard.add_workspace_state(&target_workspace, WState::Urgent);
+                        }
+                    }
+                    ActivationPolicy::Urgent => {
+                        let shell = self.common.shell.write();
+                        if let Some((workspace, _output)) = shell.workspace_for_surface(&surface) {
+                            let mut workspace_guard = self.common.workspace_state.update();
+                            workspace_guard.add_workspace_state(&workspace, WState::Urgent);
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -5,6 +5,7 @@ use crate::{
     state::State,
     wayland::protocols::workspace::{State as WState, WorkspaceHandle},
 };
+use cosmic_comp_config::ActivationPolicy;
 use smithay::{
     delegate_xdg_activation,
     input::Seat,
@@ -116,10 +117,45 @@ impl XdgActivationHandler for State {
                 }
             }
             ActivationContext::Workspace(_) => {
-                self.activate_surface(
-                    &surface,
-                    Some((ActivationKey::Wayland(surface.clone()), *context)),
-                );
+                match self.common.config.cosmic_conf.activation_policy {
+                    ActivationPolicy::Focus => {
+                        self.activate_surface(
+                            &surface,
+                            Some((ActivationKey::Wayland(surface.clone()), *context)),
+                        );
+                    }
+                    ActivationPolicy::FocusIfActiveWorkspace => {
+                        let shell = self.common.shell.write();
+
+                        let Some((target_workspace, _)) = shell.workspace_for_surface(&surface)
+                        else {
+                            // surface not found, maybe log warning?
+                            return;
+                        };
+
+                        let seat = shell.seats.last_active().clone();
+                        let current_output = seat.active_output();
+                        let current_workspace = shell.active_space(&current_output).unwrap().handle;
+
+                        if target_workspace == current_workspace {
+                            std::mem::drop(shell);
+                            self.activate_surface(
+                                &surface,
+                                Some((ActivationKey::Wayland(surface.clone()), *context)),
+                            );
+                        } else {
+                            let mut workspace_guard = self.common.workspace_state.update();
+                            workspace_guard.add_workspace_state(&target_workspace, WState::Urgent);
+                        }
+                    }
+                    ActivationPolicy::Urgent => {
+                        let shell = self.common.shell.write();
+                        if let Some((workspace, _output)) = shell.workspace_for_surface(&surface) {
+                            let mut workspace_guard = self.common.workspace_state.update();
+                            workspace_guard.add_workspace_state(&workspace, WState::Urgent);
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, when a surface requests activation, cosmic-comp switches focus to it (in most cases/if a valid activation token exists). Even when the surface is on another workspace. This behavior can be quite unexpected and has caused me to enter a password into an IRC Chat window more than once.
I could not find a config option to make the focus switching less aggressive so I implemented this patch. I have daily driven cosmic-comp with this patch applied in the Urgent configuration for about 2 weeks now and did not notice any problems.  The FocusIfActiveWorkspace option was only tested once but seems to work.

This patch adds 3 ActivationPolicy options:
- `Focus`, the current behavior
- `FocusIfActiveWorkspace`, activates the surface if it is on the current workspace, else marks its workspace as urgent
- `Urgent`, does not change focus, just marks the target workspace as urgent

To test, create `~/.config/cosmic/com.system76.CosmicComp/v1/activation_policy` and put `Focus`, `FocusIfActiveWorkspace` or `Urgent` into it.

This might help to fix issue https://github.com/pop-os/cosmic-comp/issues/2363

I used an LLM to get an overview of the code base and find relevant parts of the code, but did not use it to write the code.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [?] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

