### PR TITLE
Update `smithay` to the latest version, for X11 focus leave fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1540,7 +1540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2710,7 +2710,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2823,7 +2823,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "770919970f7d2f74fea948900d35e2ef64f44129e8ae4015f59de1f0aca7c2a5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3433,7 +3433,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4629,7 +4629,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4924,7 +4924,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=211c19d#211c19d712dc5f1b78eb879f1c195715801e37ff"
+source = "git+https://github.com/smithay/smithay.git?rev=c0ac123#c0ac12315c1621540a586202da91146248215b41"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -5254,7 +5254,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6273,7 +6273,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,4 +143,4 @@ cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch
 cosmic-client-toolkit = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "211c19d" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "c0ac123" }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1406,3 +1406,5 @@ impl Common {
         }
     }
 }
+
+smithay::delegate_dispatch2!(State);

--- a/src/wayland/handlers/alpha_modifier.rs
+++ b/src/wayland/handlers/alpha_modifier.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_alpha_modifier;
-
-delegate_alpha_modifier!(State);

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -7,7 +7,6 @@ use smithay::{
         element::{Kind, surface::KindEvaluation},
         utils::{on_commit_buffer_handler, with_renderer_surface_state},
     },
-    delegate_compositor,
     desktop::{LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output},
     reexports::wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
     utils::{Clock, Logical, Monotonic, SERIAL_COUNTER, Size, Time},
@@ -434,5 +433,3 @@ impl State {
         false
     }
 }
-
-delegate_compositor!(State);

--- a/src/wayland/handlers/data_control/ext.rs
+++ b/src/wayland/handlers/data_control/ext.rs
@@ -1,13 +1,8 @@
 use crate::state::State;
-use smithay::{
-    delegate_ext_data_control,
-    wayland::selection::ext_data_control::{DataControlHandler, DataControlState},
-};
+use smithay::wayland::selection::ext_data_control::{DataControlHandler, DataControlState};
 
 impl DataControlHandler for State {
     fn data_control_state(&mut self) -> &mut DataControlState {
         &mut self.common.ext_data_control_state
     }
 }
-
-delegate_ext_data_control!(State);

--- a/src/wayland/handlers/data_control/wlr.rs
+++ b/src/wayland/handlers/data_control/wlr.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_data_control,
-    wayland::selection::wlr_data_control::{DataControlHandler, DataControlState},
-};
+use smithay::wayland::selection::wlr_data_control::{DataControlHandler, DataControlState};
 
 impl DataControlHandler for State {
     fn data_control_state(&mut self) -> &mut DataControlState {
         &mut self.common.wlr_data_control_state
     }
 }
-
-delegate_data_control!(State);

--- a/src/wayland/handlers/data_device.rs
+++ b/src/wayland/handlers/data_device.rs
@@ -2,7 +2,6 @@
 
 use crate::{state::State, utils::prelude::SeatExt};
 use smithay::{
-    delegate_data_device,
     input::{
         Seat,
         dnd::{DnDGrab, DndGrabHandler, DndTarget, GrabType},
@@ -135,5 +134,3 @@ impl DataDeviceHandler for State {
         &mut self.common.data_device_state
     }
 }
-
-delegate_data_device!(State);

--- a/src/wayland/handlers/decoration.rs
+++ b/src/wayland/handlers/decoration.rs
@@ -1,7 +1,6 @@
 use std::{cell::RefCell, sync::Mutex};
 
 use smithay::{
-    delegate_kde_decoration, delegate_xdg_decoration,
     desktop::Window,
     reexports::{
         wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1::Mode as XdgMode,
@@ -186,6 +185,3 @@ impl KdeDecorationHandler for State {
         });
     }
 }
-
-delegate_xdg_decoration!(State);
-delegate_kde_decoration!(State);

--- a/src/wayland/handlers/dmabuf.rs
+++ b/src/wayland/handlers/dmabuf.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use smithay::{
     backend::{allocator::dmabuf::Dmabuf, renderer::element::Kind},
-    delegate_dmabuf,
     desktop::WindowSurfaceType,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::{
@@ -89,5 +88,3 @@ impl DmabufHandler for State {
         }))
     }
 }
-
-delegate_dmabuf!(State);

--- a/src/wayland/handlers/drm_lease.rs
+++ b/src/wayland/handlers/drm_lease.rs
@@ -3,7 +3,6 @@
 use crate::state::State;
 use smithay::{
     backend::drm::DrmNode,
-    delegate_drm_lease,
     wayland::drm_lease::{
         DrmLease, DrmLeaseBuilder, DrmLeaseHandler, DrmLeaseRequest, DrmLeaseState, LeaseRejected,
     },
@@ -134,5 +133,3 @@ impl DrmLeaseHandler for State {
         }
     }
 }
-
-delegate_drm_lease!(State);

--- a/src/wayland/handlers/drm_syncobj.rs
+++ b/src/wayland/handlers/drm_syncobj.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::{BackendData, State};
-use smithay::{
-    delegate_drm_syncobj,
-    wayland::drm_syncobj::{DrmSyncobjHandler, DrmSyncobjState},
-};
+use smithay::wayland::drm_syncobj::{DrmSyncobjHandler, DrmSyncobjState};
 
 impl DrmSyncobjHandler for State {
     fn drm_syncobj_state(&mut self) -> Option<&mut DrmSyncobjState> {
@@ -15,5 +12,3 @@ impl DrmSyncobjHandler for State {
         kms.syncobj_state.as_mut()
     }
 }
-
-delegate_drm_syncobj!(State);

--- a/src/wayland/handlers/fixes.rs
+++ b/src/wayland/handlers/fixes.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_fixes;
-
-delegate_fixes!(State);

--- a/src/wayland/handlers/foreign_toplevel_list.rs
+++ b/src/wayland/handlers/foreign_toplevel_list.rs
@@ -10,5 +10,3 @@ impl ForeignToplevelListHandler for State {
         &mut self.toplevel_info_state_mut().foreign_toplevel_list
     }
 }
-
-smithay::delegate_foreign_toplevel_list!(State);

--- a/src/wayland/handlers/fractional_scale.rs
+++ b/src/wayland/handlers/fractional_scale.rs
@@ -1,6 +1,5 @@
 use crate::{state::State, utils::prelude::SeatExt};
 use smithay::{
-    delegate_fractional_scale,
     desktop::utils::surface_primary_scanout_output,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::{
@@ -55,5 +54,3 @@ impl FractionalScaleHandler for State {
         });
     }
 }
-
-delegate_fractional_scale!(State);

--- a/src/wayland/handlers/idle_inhibit.rs
+++ b/src/wayland/handlers/idle_inhibit.rs
@@ -1,5 +1,5 @@
 use smithay::{
-    delegate_idle_inhibit, reexports::wayland_server::protocol::wl_surface::WlSurface,
+    reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::idle_inhibit::IdleInhibitHandler,
 };
 
@@ -16,4 +16,3 @@ impl IdleInhibitHandler for State {
         self.common.refresh_idle_inhibit();
     }
 }
-delegate_idle_inhibit!(State);

--- a/src/wayland/handlers/idle_notify.rs
+++ b/src/wayland/handlers/idle_notify.rs
@@ -1,4 +1,4 @@
-use smithay::{delegate_idle_notify, wayland::idle_notify::IdleNotifierHandler};
+use smithay::wayland::idle_notify::IdleNotifierHandler;
 
 use crate::state::State;
 
@@ -9,4 +9,3 @@ impl IdleNotifierHandler for State {
         &mut self.common.idle_notifier_state
     }
 }
-delegate_idle_notify!(State);

--- a/src/wayland/handlers/image_capture_source.rs
+++ b/src/wayland/handlers/image_capture_source.rs
@@ -52,8 +52,4 @@ impl ToplevelCaptureSourceHandler for State {
     }
 }
 
-smithay::delegate_image_capture_source!(State);
-smithay::delegate_output_capture_source!(State);
-smithay::delegate_toplevel_capture_source!(State);
-
 delegate_cosmic_image_capture_source!(State);

--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -449,5 +449,3 @@ fn constraints_for_renderer(
 
     constraints
 }
-
-smithay::delegate_image_copy_capture!(State);

--- a/src/wayland/handlers/input_method.rs
+++ b/src/wayland/handlers/input_method.rs
@@ -2,7 +2,6 @@
 
 use crate::state::State;
 use smithay::{
-    delegate_input_method_manager,
     desktop::{PopupKind, PopupManager, space::SpaceElement},
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::Rectangle,
@@ -41,5 +40,3 @@ impl InputMethodHandler for State {
         self.common.shell.read().unconstrain_popup(&popup.into());
     }
 }
-
-delegate_input_method_manager!(State);

--- a/src/wayland/handlers/keyboard_shortcuts_inhibit.rs
+++ b/src/wayland/handlers/keyboard_shortcuts_inhibit.rs
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_keyboard_shortcuts_inhibit,
-    wayland::keyboard_shortcuts_inhibit::{
-        KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
-    },
+use smithay::wayland::keyboard_shortcuts_inhibit::{
+    KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
 };
 
 impl KeyboardShortcutsInhibitHandler for State {
@@ -18,5 +15,3 @@ impl KeyboardShortcutsInhibitHandler for State {
         inhibitor.activate();
     }
 }
-
-delegate_keyboard_shortcuts_inhibit!(State);

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -2,7 +2,6 @@
 
 use crate::{shell::PendingLayer, utils::prelude::*};
 use smithay::{
-    delegate_layer_shell,
     desktop::{LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output},
     output::Output,
     reexports::wayland_server::protocol::wl_output::WlOutput,
@@ -82,5 +81,3 @@ impl WlrLayerShellHandler for State {
         }
     }
 }
-
-delegate_layer_shell!(State);

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 pub mod a11y;
-pub mod alpha_modifier;
 pub mod buffer;
 pub mod compositor;
 pub mod corner_radius;
@@ -12,7 +11,6 @@ pub mod dmabuf;
 pub mod drm;
 pub mod drm_lease;
 pub mod drm_syncobj;
-pub mod fixes;
 pub mod foreign_toplevel_list;
 pub mod fractional_scale;
 pub mod idle_inhibit;
@@ -27,22 +25,15 @@ pub mod output_configuration;
 pub mod output_power;
 pub mod overlap_notify;
 pub mod pointer_constraints;
-pub mod pointer_gestures;
-pub mod presentation;
 pub mod primary_selection;
-pub mod relative_pointer;
 pub mod seat;
 pub mod security_context;
 pub mod selection;
 pub mod session_lock;
 pub mod shm;
-pub mod single_pixel_buffer;
 pub mod tablet_manager;
-pub mod text_input;
 pub mod toplevel_info;
 pub mod toplevel_management;
-pub mod viewporter;
-pub mod virtual_keyboard;
 pub mod workspace;
 pub mod xdg_activation;
 pub mod xdg_foreign;

--- a/src/wayland/handlers/output.rs
+++ b/src/wayland/handlers/output.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{delegate_output, wayland::output::OutputHandler};
+use smithay::wayland::output::OutputHandler;
 
 impl OutputHandler for State {}
-
-delegate_output!(State);

--- a/src/wayland/handlers/pointer_constraints.rs
+++ b/src/wayland/handlers/pointer_constraints.rs
@@ -2,7 +2,6 @@
 
 use crate::state::State;
 use smithay::{
-    delegate_pointer_constraints,
     input::pointer::PointerHandle,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::{Logical, Point},
@@ -34,4 +33,3 @@ impl PointerConstraintsHandler for State {
         // TODO
     }
 }
-delegate_pointer_constraints!(State);

--- a/src/wayland/handlers/pointer_gestures.rs
+++ b/src/wayland/handlers/pointer_gestures.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_pointer_gestures;
-
-delegate_pointer_gestures!(State);

--- a/src/wayland/handlers/presentation.rs
+++ b/src/wayland/handlers/presentation.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_presentation;
-
-delegate_presentation!(State);

--- a/src/wayland/handlers/primary_selection.rs
+++ b/src/wayland/handlers/primary_selection.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_primary_selection,
-    wayland::selection::primary_selection::{PrimarySelectionHandler, PrimarySelectionState},
+use smithay::wayland::selection::primary_selection::{
+    PrimarySelectionHandler, PrimarySelectionState,
 };
 
 impl PrimarySelectionHandler for State {
@@ -11,5 +10,3 @@ impl PrimarySelectionHandler for State {
         &mut self.common.primary_selection_state
     }
 }
-
-delegate_primary_selection!(State);

--- a/src/wayland/handlers/relative_pointer.rs
+++ b/src/wayland/handlers/relative_pointer.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_relative_pointer;
-
-delegate_relative_pointer!(State);

--- a/src/wayland/handlers/seat.rs
+++ b/src/wayland/handlers/seat.rs
@@ -6,10 +6,7 @@ use crate::{
     state::State,
     utils::prelude::SeatExt,
 };
-use smithay::{
-    delegate_cursor_shape, delegate_seat,
-    input::{SeatHandler, SeatState, keyboard::LedState, pointer::CursorImageStatus},
-};
+use smithay::input::{SeatHandler, SeatState, keyboard::LedState, pointer::CursorImageStatus};
 
 impl SeatHandler for State {
     type KeyboardFocus = KeyboardFocusTarget;
@@ -37,6 +34,3 @@ impl SeatHandler for State {
         devices.update_led_state(led_state);
     }
 }
-
-delegate_seat!(State);
-delegate_cursor_shape!(State);

--- a/src/wayland/handlers/security_context.rs
+++ b/src/wayland/handlers/security_context.rs
@@ -1,7 +1,6 @@
 use crate::state::{ClientState, State};
 use smithay::{
     backend::drm::DrmNode,
-    delegate_security_context,
     wayland::security_context::{
         SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
     },
@@ -54,4 +53,3 @@ impl SecurityContextHandler for State {
             .expect("Failed to init the wayland socket source.");
     }
 }
-delegate_security_context!(State);

--- a/src/wayland/handlers/session_lock.rs
+++ b/src/wayland/handlers/session_lock.rs
@@ -2,7 +2,6 @@
 
 use crate::{shell::SessionLock, state::State, utils::prelude::*};
 use smithay::{
-    delegate_session_lock,
     output::Output,
     reexports::wayland_server::{Resource, protocol::wl_output::WlOutput},
     utils::Size,
@@ -68,5 +67,3 @@ impl SessionLockHandler for State {
         }
     }
 }
-
-delegate_session_lock!(State);

--- a/src/wayland/handlers/shm.rs
+++ b/src/wayland/handlers/shm.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_shm,
-    wayland::shm::{ShmHandler, ShmState},
-};
+use smithay::wayland::shm::{ShmHandler, ShmState};
 
 impl ShmHandler for State {
     fn shm_state(&self) -> &ShmState {
         &self.common.shm_state
     }
 }
-
-delegate_shm!(State);

--- a/src/wayland/handlers/single_pixel_buffer.rs
+++ b/src/wayland/handlers/single_pixel_buffer.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_single_pixel_buffer;
-
-delegate_single_pixel_buffer!(State);

--- a/src/wayland/handlers/tablet_manager.rs
+++ b/src/wayland/handlers/tablet_manager.rs
@@ -2,8 +2,8 @@
 
 use crate::state::State;
 use smithay::{
-    backend::input::TabletToolDescriptor, delegate_tablet_manager,
-    input::pointer::CursorImageStatus, wayland::tablet_manager::TabletSeatHandler,
+    backend::input::TabletToolDescriptor, input::pointer::CursorImageStatus,
+    wayland::tablet_manager::TabletSeatHandler,
 };
 
 impl TabletSeatHandler for State {
@@ -11,5 +11,3 @@ impl TabletSeatHandler for State {
         // TODO display cursor for each tablet tool
     }
 }
-
-delegate_tablet_manager!(State);

--- a/src/wayland/handlers/text_input.rs
+++ b/src/wayland/handlers/text_input.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_text_input_manager;
-
-delegate_text_input_manager!(State);

--- a/src/wayland/handlers/viewporter.rs
+++ b/src/wayland/handlers/viewporter.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_viewporter;
-
-delegate_viewporter!(State);

--- a/src/wayland/handlers/virtual_keyboard.rs
+++ b/src/wayland/handlers/virtual_keyboard.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-only
-
-use crate::state::State;
-use smithay::delegate_virtual_keyboard_manager;
-
-delegate_virtual_keyboard_manager!(State);

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -6,7 +6,6 @@ use crate::{
     wayland::protocols::workspace::{State as WState, WorkspaceHandle},
 };
 use smithay::{
-    delegate_xdg_activation,
     input::Seat,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::xdg_activation::{
@@ -246,5 +245,3 @@ impl State {
         };
     }
 }
-
-delegate_xdg_activation!(State);

--- a/src/wayland/handlers/xdg_foreign.rs
+++ b/src/wayland/handlers/xdg_foreign.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_xdg_foreign,
-    wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState},
-};
+use smithay::wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState};
 
 impl XdgForeignHandler for State {
     fn xdg_foreign_state(&mut self) -> &mut XdgForeignState {
         &mut self.common.xdg_foreign_state
     }
 }
-
-delegate_xdg_foreign!(State);

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use smithay::desktop::layer_map_for_output;
 use smithay::{
-    delegate_xdg_shell,
     desktop::{
         PopupGrab, PopupKeyboardGrab, PopupKind, PopupPointerGrab, PopupUngrabStrategy,
         WindowSurfaceType, find_popup_root_surface,
@@ -391,5 +390,3 @@ impl XdgShellHandler for State {
         }
     }
 }
-
-delegate_xdg_shell!(State);

--- a/src/wayland/handlers/xwayland_keyboard_grab.rs
+++ b/src/wayland/handlers/xwayland_keyboard_grab.rs
@@ -2,7 +2,6 @@
 
 use crate::{shell::focus::target::KeyboardFocusTarget, state::State};
 use smithay::{
-    delegate_xwayland_keyboard_grab,
     input::Seat,
     reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface},
     wayland::xwayland_keyboard_grab::{XWaylandKeyboardGrab, XWaylandKeyboardGrabHandler},
@@ -49,5 +48,3 @@ impl XWaylandGrabSeat for Seat<State> {
             .is_some_and(|(s, g)| g.grab().is_alive() && s == surface)
     }
 }
-
-delegate_xwayland_keyboard_grab!(State);

--- a/src/wayland/handlers/xwayland_shell.rs
+++ b/src/wayland/handlers/xwayland_shell.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::State;
-use smithay::{
-    delegate_xwayland_shell,
-    wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState},
-};
+use smithay::wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState};
 
 impl XWaylandShellHandler for State {
     fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState {
         &mut self.common.xwayland_shell_state
     }
 }
-
-delegate_xwayland_shell!(State);

--- a/src/wayland/protocols/overlap_notify.rs
+++ b/src/wayland/protocols/overlap_notify.rs
@@ -16,7 +16,10 @@ use smithay::{
     desktop::{LayerSurface, layer_map_for_output},
     output::Output,
     reexports::{
-        wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        wayland_protocols::ext::foreign_toplevel_list::v1::server::{
+            ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+            ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        },
         wayland_protocols_wlr::layer_shell::v1::server::{
             zwlr_layer_shell_v1::Layer as WlrLayer, zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
         },
@@ -24,7 +27,9 @@ use smithay::{
     },
     utils::{Logical, Rectangle},
     wayland::{
-        foreign_toplevel_list::ForeignToplevelListHandler,
+        foreign_toplevel_list::{
+            ForeignToplevelHandle, ForeignToplevelListGlobalData, ForeignToplevelListHandler,
+        },
         shell::wlr_layer::{ExclusiveZone, Layer},
     },
 };
@@ -81,6 +86,8 @@ impl OverlapNotifyState {
             + GlobalDispatch<ZcosmicToplevelInfoV1, ToplevelInfoGlobalData>
             + Dispatch<ZcosmicToplevelInfoV1, ()>
             + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
+            + GlobalDispatch<ExtForeignToplevelListV1, ForeignToplevelListGlobalData>
+            + Dispatch<ExtForeignToplevelHandleV1, ForeignToplevelHandle>
             + ForeignToplevelListHandler
             + ToplevelInfoHandler<Window = W>
             + 'static,

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -5,7 +5,10 @@ use std::{collections::HashSet, sync::Mutex};
 use smithay::{
     output::Output,
     reexports::{
-        wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        wayland_protocols::ext::foreign_toplevel_list::v1::server::{
+            ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+            ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        },
         wayland_server::{
             Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
             backend::{ClientId, GlobalId},
@@ -14,7 +17,8 @@ use smithay::{
     },
     utils::{IsAlive, Logical, Rectangle, user_data::UserDataMap},
     wayland::foreign_toplevel_list::{
-        ForeignToplevelHandle, ForeignToplevelListHandler, ForeignToplevelListState,
+        ForeignToplevelHandle, ForeignToplevelListGlobalData, ForeignToplevelListHandler,
+        ForeignToplevelListState,
     },
 };
 
@@ -302,6 +306,8 @@ where
     D: GlobalDispatch<ZcosmicToplevelInfoV1, ToplevelInfoGlobalData>
         + Dispatch<ZcosmicToplevelInfoV1, ()>
         + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
+        + GlobalDispatch<ExtForeignToplevelListV1, ForeignToplevelListGlobalData>
+        + Dispatch<ExtForeignToplevelHandleV1, ForeignToplevelHandle>
         + ForeignToplevelListHandler
         + ToplevelInfoHandler<Window = W>
         + 'static,


### PR DESCRIPTION
**Note**
The main intention of this PR is to apply fixes for the upcoming cosmic-comp update and unblock [sustainable Unity Editor usage](https://github.com/Smithay/smithay/pull/2029).

**What PR does and what doesn't**
There are several fixes and additions since the last update made in this PR: https://github.com/pop-os/cosmic-comp/pull/2318

Some of them are pretty straightforward fixes, not requiring any migration, and some are EWMH support additions:
https://github.com/Smithay/smithay/compare/211c19...c0ac123

- The only breaking change that requires migration is the subject of that PR:  https://github.com/Smithay/smithay/pull/2008
- Other enhancements, such as wiring EWMH additions, are subject to separate PRs.

This PR addresses exactly the migration from multiple delegate macros to a single `delegate_dispatch2`.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

