### PR TITLE
fix(kms): defer process::exit() until surface threads are joined

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,19 +216,17 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
                 // Kiosk child exited with status
                 Ok(Some(exit_status)) => {
                     info!("Command exited with status {:?}", exit_status);
-                    match exit_status.code() {
-                        // Exiting with the same status as the kiosk child
-                        Some(code) => process::exit(code),
-                        // The kiosk child exited with signal, exiting with error
-                        None => process::exit(1),
-                    }
+                    let code = exit_status.code().unwrap_or(1);
+                    state.common.kiosk_exit_code = Some(code);
+                    state.common.should_stop = true;
                 }
                 // Command still running
                 Ok(None) => {}
                 // Kiosk child disappeared, exiting with error
                 Err(err) => {
                     warn!(?err, "Failed to wait for command");
-                    process::exit(1);
+                    state.common.kiosk_exit_code = Some(1);
+                    state.common.should_stop = true;
                 }
             }
         }
@@ -239,9 +237,16 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
         let _ = child.kill();
     }
 
-    // drop eventloop & state before logger
+    let kiosk_exit_code = state.common.kiosk_exit_code;
+
+    // drop eventloop & state before logger — this joins surface threads
+    // before any Mesa atexit handlers can run
     std::mem::drop(event_loop);
     std::mem::drop(state);
+
+    if let Some(code) = kiosk_exit_code {
+        process::exit(code);
+    }
 
     Ok(())
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -241,6 +241,7 @@ pub struct Common {
     pub clock: Clock<Monotonic>,
     pub startup_done: Arc<AtomicBool>,
     pub should_stop: bool,
+    pub kiosk_exit_code: Option<i32>,
 
     pub gesture_state: Option<GestureState>,
 
@@ -751,6 +752,7 @@ impl State {
                 clock,
                 startup_done: Arc::new(AtomicBool::new(false)),
                 should_stop: false,
+                kiosk_exit_code: None,
                 gesture_state: None,
 
                 kiosk_child: None,


### PR DESCRIPTION
Before reviewing, please check #2375 for the problem analysis..

  When the kiosk child exits, calling process::exit() directly from the
  calloop callback causes Mesa's util_queue atexit handler to run
  concurrently with the KMS surface thread, which may still be mid-frame
  calling eglCreateSync(). This races on Mesa's internal heap state,
  producing "free(): corrupted unsorted chunks" and SIGABRT.

~Replace the three process::exit() calls with should_stop + a new
  kiosk_exit_code field, so the event loop exits cleanly and state is
  dropped — joining surface threads — before process::exit() is called.~
This is untrue, there is no explicit join in those codepaths.

  The race window is only reliably hit when a GPU-heavy client (Firefox,
  Thunderbird) is driving continuous rendering, explaining why the crash
  never occurred without one present.

  Introduced in 1.0.12 by the Smithay update that added export_sync_point()
  to GlesFrame::finish_internal; in 1.0.11 the surface thread did not call
  eglCreateSync() during frame finish, so the atexit was safe.

  **AI Usage:
  Claude Code did the root cause analyis especially of all the stacktraces  and all code for this bugfix.**

  Fixes #2375

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  **Disclaimer here: I understand the changes, but I do not understand the complete effect this has on the teardown logic. Teardown logic is inherently complex and an expert needs to review this again. This would be true, even if I had written this code.**
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper 
  - fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.