### PR TITLE
fix(magnifier): smooth mouse wheel zoom and respect natural scroll direction

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -37,11 +37,12 @@ use cosmic_settings_config::shortcuts;
 use cosmic_settings_config::shortcuts::action::{Direction, ResizeDirection};
 use smithay::{
     backend::input::{
-        AbsolutePositionEvent, Axis, AxisSource, Device, DeviceCapability, GestureBeginEvent,
-        GestureEndEvent, GesturePinchUpdateEvent as _, GestureSwipeUpdateEvent as _, InputBackend,
-        InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent, ProximityState, Switch,
-        SwitchState, SwitchToggleEvent, TabletToolButtonEvent, TabletToolEvent,
-        TabletToolProximityEvent, TabletToolTipEvent, TabletToolTipState, TouchEvent,
+        AbsolutePositionEvent, Axis, AxisRelativeDirection, AxisSource, Device, DeviceCapability,
+        GestureBeginEvent, GestureEndEvent, GesturePinchUpdateEvent as _,
+        GestureSwipeUpdateEvent as _, InputBackend, InputEvent, KeyState, KeyboardKeyEvent,
+        PointerAxisEvent, ProximityState, Switch, SwitchState, SwitchToggleEvent,
+        TabletToolButtonEvent, TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent,
+        TabletToolTipState, TouchEvent,
     },
     desktop::{PopupKeyboardGrab, WindowSurfaceType, utils::under_from_surface_tree},
     input::{
@@ -914,12 +915,18 @@ impl State {
                             .or_else(|| event.amount(Axis::Vertical))
                             .map(|val| val * scroll_factor)
                         {
+                            if event.relative_direction(Axis::Vertical)
+                                == AxisRelativeDirection::Inverted
+                            {
+                                percentage *= -1.;
+                            }
+
                             if event.source() == AxisSource::Wheel {
                                 percentage *= 5.;
                             }
 
                             let change = -(percentage / 100.);
-                            self.update_zoom(&seat, change, event.source() == AxisSource::Wheel);
+                            self.update_zoom(&seat, change, false);
                         }
                     } else {
                         let mut frame = AxisFrame::new(event.time_msec()).source(event.source());

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -926,7 +926,7 @@ impl State {
                             }
 
                             let change = -(percentage / 100.);
-                            self.update_zoom(&seat, change, false);
+                            self.update_zoom(&seat, change, event.source() == AxisSource::Wheel);
                         }
                     } else {
                         let mut frame = AxisFrame::new(event.time_msec()).source(event.source());

--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -9,7 +9,7 @@ use cosmic::{
 };
 use cosmic_comp_config::ZoomMovement;
 use cosmic_config::ConfigSet;
-use keyframe::{ease, functions::EaseInOutCubic};
+use keyframe::{ease, functions::Linear};
 use smithay::{
     backend::renderer::{ImportMem, Renderer, element::AsRenderElements},
     desktop::space::SpaceElement,
@@ -135,7 +135,7 @@ impl OutputZoomState {
             let percentage =
                 duration_since.as_millis() as f32 / ANIMATION_DURATION.as_millis() as f32;
             ease(
-                EaseInOutCubic,
+                Linear,
                 EasePoint(*old_point),
                 EasePoint(self.focal_point),
                 percentage,
@@ -159,7 +159,7 @@ impl OutputZoomState {
             let percentage = Instant::now().duration_since(*start).as_millis() as f32
                 / ANIMATION_DURATION.as_millis() as f32;
 
-            ease(EaseInOutCubic, *old_level, self.level, percentage)
+            ease(Linear, *old_level, self.level, percentage)
         } else {
             self.level
         }


### PR DESCRIPTION
Closes #2380 .

- Disable animation for mouse wheel zoom to eliminate the timing race.
- Invert zoom direction when natural scrolling is enabled.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

