### PR TITLE
Two independent KMS correctness fixes, relevant to hybrid-GPU systems

### DIFF
--- a/src/backend/kms/drm_helpers.rs
+++ b/src/backend/kms/drm_helpers.rs
@@ -75,6 +75,7 @@ pub fn display_configuration(
     // And then cleanup
     if device.is_atomic() {
         let mut req = AtomicModeReq::new();
+        let mut has_changes = false;
         let plane_handles = device.plane_handles()?;
 
         // We cannot just shortcut and use the legacy api for all cleanups because of this.
@@ -95,10 +96,15 @@ pub fn display_configuration(
                     let fb_id = get_prop(device, plane, "FB_ID")?;
                     req.add_property(plane, crtc_id, property::Value::CRTC(None));
                     req.add_property(plane, fb_id, property::Value::Framebuffer(None));
+                    has_changes = true;
                 }
             }
         }
-        device.atomic_commit(AtomicCommitFlags::ALLOW_MODESET, req)?;
+        // Skip an empty commit: a no-op modeset that also fails with EPERM
+        // without DRM master (e.g. a render-only secondary GPU).
+        if has_changes {
+            device.atomic_commit(AtomicCommitFlags::ALLOW_MODESET, req)?;
+        }
     } else {
         for crtc in res_handles.crtcs() {
             #[allow(deprecated)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use smithay::{
 };
 
 use anyhow::{Context, Result};
-use state::{LastRefresh, State};
+use state::{BackendData, LastRefresh, State};
 use std::{
     env,
     ffi::OsString,
@@ -222,19 +222,17 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
                 // Kiosk child exited with status
                 Ok(Some(exit_status)) => {
                     info!("Command exited with status {:?}", exit_status);
-                    match exit_status.code() {
-                        // Exiting with the same status as the kiosk child
-                        Some(code) => process::exit(code),
-                        // The kiosk child exited with signal, exiting with error
-                        None => process::exit(1),
-                    }
+                    // Stop cleanly so surface threads are joined before exit() (signal -> 1).
+                    state.common.kiosk_exit_code = Some(exit_status.code().unwrap_or(1));
+                    state.common.should_stop = true;
                 }
                 // Command still running
                 Ok(None) => {}
                 // Kiosk child disappeared, exiting with error
                 Err(err) => {
                     warn!(?err, "Failed to wait for command");
-                    process::exit(1);
+                    state.common.kiosk_exit_code = Some(1);
+                    state.common.should_stop = true;
                 }
             }
         }
@@ -245,9 +243,31 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
         let _ = child.kill();
     }
 
+    let kiosk_exit_code = state.common.kiosk_exit_code;
+
+    // Join surface threads before exit() so no thread is mid-eglCreateSync when
+    // Mesa's atexit handlers run and corrupt the heap (issue #2375). Safe here
+    // because the event loop has stopped; an unconditional join in Surface::Drop
+    // would instead deadlock against apply_config_for_outputs.
+    if let BackendData::Kms(kms) = &mut state.backend {
+        // Release master first so the surface drop path skips its blocking commit.
+        for device in kms.drm_devices.values_mut() {
+            device.drm.pause();
+        }
+        for device in kms.drm_devices.values_mut() {
+            for (_, surface) in device.inner.surfaces.drain() {
+                surface.drop_and_join();
+            }
+        }
+    }
+
     // drop eventloop & state before logger
     std::mem::drop(event_loop);
     std::mem::drop(state);
+
+    if let Some(code) = kiosk_exit_code {
+        process::exit(code);
+    }
 
     Ok(())
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -244,6 +244,7 @@ pub struct Common {
     pub clock: Clock<Monotonic>,
     pub startup_done: Arc<AtomicBool>,
     pub should_stop: bool,
+    pub kiosk_exit_code: Option<i32>,
 
     pub gesture_state: Option<GestureState>,
 
@@ -754,6 +755,7 @@ impl State {
                 clock,
                 startup_done: Arc::new(AtomicBool::new(false)),
                 should_stop: false,
+                kiosk_exit_code: None,
                 gesture_state: None,
 
                 kiosk_child: None,


### PR DESCRIPTION
**Update 2026-07-20:** I rebased to current master, the commits are a lot cleaner now, because master also contained two of my fixes, surviving are:

Fix commit 1: Exit via `libc::_exit()` on the kiosk-child exit path, so Mesa's atexit handlers cannot run while KMS surface threads are still inside EGL calls,  removes a reliable SIGABRT on greeter to session handoff and at logout.

Fix commit 2: Treat EPERM/EACCES from the DRM cleanup `atomic_commit()` as a skip rather than a hard error, so device enumeration continues on hybrid-GPU systems where the compositor does not hold DRM master on a secondary node.


## Old PR description:
This PR fixes on SIGABRT on teardown and skips DRM cleanup, when it is not needed or master is missing. Both are separated by commit. By testing a lot, I found that fix number 2 (the skipping of extra cleanup commits) triggers the AMD panel refresh freeze bug mentined in #2375 a lot less often. (Freezes go from happening after seconds to hours, but they still occur after going to 1.0.12).
Both commits should be reviewed independently. If required I can also split the PR.

**All fixes were done using Claude Code, as was the analysis. I also want to point out that I do understand the fixes, but I do not understand their complete fallout. I am still sending the PR, because it makes my system so much more stable without the explicit amdgpu boot option mentioned in #2375 .**

## Commits

**`fix(kms): exit via _exit() to avoid SIGABRT on compositor shutdown`**
cosmic-comp aborts with SIGABRT when the compositor exits — at the
greeter→session handoff and at logout. Those paths call `process::exit()`,
which runs Mesa's `util_queue` atexit handler while the KMS render threads
are still in EGL calls; the process aborts (confirmed by coredumps -
all SIGABRT inside `exit()`). This is an exit-path bug; it does not affect a
running session.
Exit with `libc::_exit()`, which skips atexit handlers, after `pause()`-ing
the DRM devices to release master. Rust destructors still run via explicit
`drop()`; only libc atexit handlers are skipped. `_exit()` also can't hang on
a stuck render thread, which a join-based fix would. The kiosk exit code is
carried out of the event loop in `Common::kiosk_exit_code` so the `_exit()`
happens once, after the loop returns.
*Trade-off:* `_exit()` skips atexit/stdio-flush. cosmic-comp registers no
atexit handlers of its own, and logging goes through journald (eager), so
nothing meaningful is lost; render-thread GPU resources are reclaimed by the
kernel, as in 1.0.11.
This is most probably the most controversial. I tried around a lot here by explicitly joining, but nothing worked.

**`fix(kms): skip DRM cleanup commit when not needed or master is missing`**
`display_configuration()` runs on every udev `CHANGED` event. It issued a
no-op `atomic_commit(ALLOW_MODESET)` even with an empty cleanup set, and
treated `EPERM`/`EACCES` (no DRM master - routine on a hybrid GPU) as fatal,
aborting `device_changed()`. Guard the cleanup block on a non-empty set, and
treat `PermissionDenied` as a skip so the rest of `device_changed()` runs.
*(Info after rebase: the atomic_commit stuff has been fixed on master already)*

## Scope
Commit 1 is confirmed by coredumps. Commit 2 is a correctness fix evident
from the code path.

Neither addresses the display freezes seen on this hardware. Those are a
separate AMD DMCUB/DCN3.1 firmware hang (`flip_done timed out` after a
hotplug-driven modeset), unrelated to this PR and mitigated at the kernel
level by disabling panel self-refresh (`amdgpu.dcdebugmask`).

## Testing

Commit 1: across repeated greeter-login and logout-login cycles, the
exit-path SIGABRT no longer occurs, whereas they always occured before.

Commit 2: external-display hotplug exercised over ~10 connect/disconnect
cycles on a DisplayPort MST dock, driving `device_changed()` /
`display_configuration()` repeatedly - no crash, no regression. Not run as a
controlled before/after against an unpatched build.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [ ] I understand these changes in full and will be able to respond to review comments.
  - I cannot in good faith put an X here. The commits are simple to understand on their own, but I do not understand their full fallout. I can respond to review comments and provide coredumps.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
