### PR TITLE
feat(input): add compositor-side kinetic scrolling

### DIFF
--- a/cosmic-comp-config/src/input.rs
+++ b/cosmic-comp-config/src/input.rs
@@ -47,6 +47,8 @@ pub struct ScrollConfig {
     pub natural_scroll: Option<bool>,
     pub scroll_button: Option<u32>,
     pub scroll_factor: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub kinetic: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/src/config/input_config.rs
+++ b/src/config/input_config.rs
@@ -65,6 +65,7 @@ pub fn for_device(device: &InputDevice) -> InputConfig {
                     None
                 },
                 scroll_factor: None,
+                kinetic: None,
             })
         } else {
             None

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -622,6 +622,14 @@ impl Config {
         .map_or(1.0, |x| x.0)
     }
 
+    pub fn kinetic_scroll_enabled(&self, device: &InputDevice) -> bool {
+        let (device_config, default_config) = self.get_device_config(device);
+        input_config::get_config(device_config.as_ref(), default_config, |x| {
+            x.scroll_config.as_ref()?.kinetic
+        })
+        .is_some_and(|x| x.0)
+    }
+
     pub fn map_to_output(&self, device: &InputDevice) -> Option<String> {
         let (device_config, default_config) = self.get_device_config(device);
         Some(

--- a/src/input/kinetic.rs
+++ b/src/input/kinetic.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Compositor-side kinetic (inertial) scrolling for two-finger touchpad scroll.
+//
+// Buffered finger-source axis deltas feed a closed-form exponential fling on
+// lift; synthetic `wl_pointer.axis` events with `AxisSource::Continuous` are
+// emitted until velocity decays below `STOP_VELOCITY`. The fling deliberately
+// suppresses the `wl_pointer.axis_stop` that libinput would normally emit at
+// finger-lift — toolkits (GTK/Qt/Firefox/Chromium) treat that stop event as
+// "user input ended, apply your own kinetic." Sending it AND our synthetic
+// inertia would compound the two and overshoot.
+
+use crate::state::State;
+use calloop::timer::{TimeoutAction, Timer};
+use smithay::{
+    backend::input::{Axis, AxisSource},
+    input::{Seat, pointer::AxisFrame},
+    utils::{Logical, Point},
+};
+use std::{cell::RefCell, collections::VecDeque, time::Duration};
+use tracing::trace;
+
+/// Maximum age of samples retained for velocity calculation. Kept slightly
+/// larger than [`VELOCITY_WINDOW`] so a momentary pause near lift doesn't
+/// starve the velocity estimator.
+const SAMPLE_WINDOW: Duration = Duration::from_millis(150);
+/// Only samples from the most recent VELOCITY_WINDOW contribute to fling
+/// velocity. Biases the estimate toward what the finger was doing *just*
+/// before release rather than averaging across the whole gesture.
+const VELOCITY_WINDOW: Duration = Duration::from_millis(80);
+/// Minimum raw lift velocity (logical units/sec) required to start a fling.
+const MIN_FLING_VELOCITY: f64 = 50.0;
+/// Velocity (logical units/sec) at which the fling terminates.
+const STOP_VELOCITY: f64 = 15.0;
+/// Per-millisecond friction; matches `DECELERATION_TOUCHPAD` in
+/// `input/gestures/mod.rs`.
+const FRICTION_PER_MS: f64 = 0.997;
+/// Cap on initial fling velocity so an extreme flick doesn't whip-scroll the
+/// entire page in one frame.
+const MAX_FLING_VELOCITY: f64 = 4000.0;
+/// 120 v120 units == one wheel detent == ~15 logical pixels (Wayland
+/// convention). Synthesising v120 alongside Continuous-source frames helps
+/// clients that gate kinetic-style handling on the presence of high-res
+/// wheel steps (Chromium in particular).
+const V120_PER_LOGICAL: f64 = 8.0;
+/// Tick interval for the fling timer (~125 Hz).
+const TICK: Duration = Duration::from_millis(8);
+
+#[derive(Clone, Copy, Debug)]
+struct Sample {
+    delta: Point<f64, Logical>,
+    time: Duration,
+}
+
+#[derive(Default)]
+pub struct KineticScroller(RefCell<Inner>);
+
+#[derive(Default)]
+struct Inner {
+    samples: VecDeque<Sample>,
+    velocity: Point<f64, Logical>,
+    active: bool,
+    last_tick: Option<Duration>,
+    /// Accumulated fractional v120 not yet emitted. Carries the rounding
+    /// remainder across ticks so the integer stream stays smooth even as
+    /// the fling decays toward zero.
+    v120_residual: (f64, f64),
+}
+
+impl Inner {
+    fn clear_fling(&mut self) {
+        self.active = false;
+        self.velocity = Point::default();
+        self.last_tick = None;
+        self.v120_residual = (0.0, 0.0);
+    }
+}
+
+impl KineticScroller {
+    /// Buffer a finger delta. If a fling was running, cancel it and return
+    /// `true` (caller emits a Continuous `axis_stop` for the synthetic stream).
+    pub fn push(&self, delta: Point<f64, Logical>, t: Duration) -> bool {
+        let mut inner = self.0.borrow_mut();
+        let was_active = inner.active;
+        if was_active {
+            inner.clear_fling();
+        }
+
+        if let Some(last) = inner.samples.back()
+            && t < last.time
+        {
+            trace!(
+                "ignoring kinetic sample with timestamp {t:?} earlier than last {:?}",
+                last.time
+            );
+            return was_active;
+        }
+
+        inner.samples.push_back(Sample { delta, time: t });
+        Self::trim(&mut inner.samples, t);
+        was_active
+    }
+
+    /// Compute velocity from buffered samples and, if above
+    /// `MIN_FLING_VELOCITY`, start the fling. Returns the initial velocity
+    /// when a fling actually starts.
+    pub fn start_fling(&self) -> Option<Point<f64, Logical>> {
+        let mut inner = self.0.borrow_mut();
+        let Some(last) = inner.samples.back().copied() else {
+            inner.samples.clear();
+            return None;
+        };
+
+        let cutoff = last.time.saturating_sub(VELOCITY_WINDOW);
+        let (count, total, first_time) = inner.samples.iter().filter(|s| s.time >= cutoff).fold(
+            (0usize, Point::<f64, Logical>::default(), None::<Duration>),
+            |(n, acc, first), s| (n + 1, acc + s.delta, Some(first.unwrap_or(s.time))),
+        );
+        inner.samples.clear();
+
+        if count < 2 {
+            return None;
+        }
+        let first_time = first_time.unwrap();
+        let span = last.time.saturating_sub(first_time).as_secs_f64();
+        if span <= 0.0 {
+            return None;
+        }
+
+        let raw = Point::<f64, Logical>::from((total.x / span, total.y / span));
+        if raw.x.abs() < MIN_FLING_VELOCITY && raw.y.abs() < MIN_FLING_VELOCITY {
+            return None;
+        }
+
+        let velocity = Point::<f64, Logical>::from((
+            raw.x.clamp(-MAX_FLING_VELOCITY, MAX_FLING_VELOCITY),
+            raw.y.clamp(-MAX_FLING_VELOCITY, MAX_FLING_VELOCITY),
+        ));
+
+        inner.clear_fling();
+        inner.velocity = velocity;
+        inner.active = true;
+        Some(velocity)
+    }
+
+    /// Advance the fling. Returns the delta to emit, or `None` when the fling
+    /// has decayed below `STOP_VELOCITY` (also clears `active`).
+    pub fn tick(&self, now: Duration) -> Option<Point<f64, Logical>> {
+        let mut inner = self.0.borrow_mut();
+        if !inner.active {
+            return None;
+        }
+
+        let last = inner.last_tick.unwrap_or(now);
+        let dt_ms = now.saturating_sub(last).as_secs_f64() * 1000.0;
+        inner.last_tick = Some(now);
+
+        let delta = if dt_ms > 0.0 {
+            let factor = FRICTION_PER_MS.powf(dt_ms);
+            let scale = (factor - 1.0) / FRICTION_PER_MS.ln() / 1000.0;
+            let v = inner.velocity;
+            let out = Point::from((v.x * scale, v.y * scale));
+            inner.velocity = Point::from((v.x * factor, v.y * factor));
+            out
+        } else {
+            Point::default()
+        };
+
+        if inner.velocity.x.abs() < STOP_VELOCITY && inner.velocity.y.abs() < STOP_VELOCITY {
+            inner.clear_fling();
+            return None;
+        }
+        Some(delta)
+    }
+
+    /// Compute integer v120 step counts for the given pixel delta, carrying
+    /// the rounding remainder forward so consecutive frames don't oscillate
+    /// between 0 and 1 at low velocity.
+    fn next_v120(&self, delta: Point<f64, Logical>) -> (i32, i32) {
+        let mut inner = self.0.borrow_mut();
+        let tx = delta.x * V120_PER_LOGICAL + inner.v120_residual.0;
+        let ty = delta.y * V120_PER_LOGICAL + inner.v120_residual.1;
+        let ex = tx.round() as i32;
+        let ey = ty.round() as i32;
+        inner.v120_residual = (tx - ex as f64, ty - ey as f64);
+        (ex, ey)
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.0.borrow().active
+    }
+
+    pub fn cancel(&self) -> bool {
+        let mut inner = self.0.borrow_mut();
+        let was_active = inner.active;
+        inner.clear_fling();
+        inner.samples.clear();
+        was_active
+    }
+
+    fn trim(samples: &mut VecDeque<Sample>, latest: Duration) {
+        while let Some(front) = samples.front() {
+            if latest <= front.time + SAMPLE_WINDOW {
+                break;
+            }
+            samples.pop_front();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plumbing: protocol I/O glued to a seat's `KineticScroller`. Called from
+// `src/input/mod.rs` and `src/shell/focus/mod.rs`.
+
+/// Emit a `Continuous` source axis_stop frame to the seat's pointer.
+fn emit_stop(state: &mut State, seat: &Seat<State>, time_msec: u32) {
+    let frame = AxisFrame::new(time_msec)
+        .source(AxisSource::Continuous)
+        .stop(Axis::Horizontal)
+        .stop(Axis::Vertical);
+    let ptr = seat.get_pointer().unwrap();
+    ptr.axis(state, frame);
+    ptr.frame(state);
+}
+
+/// Cancel any running fling on this seat. Emits a Continuous `axis_stop`
+/// if there was an active fling so kinetic-aware clients know the synthetic
+/// stream ended.
+pub fn cancel_with_stop(state: &mut State, seat: &Seat<State>, time_msec: u32) {
+    if let Some(scroller) = seat.user_data().get::<KineticScroller>()
+        && scroller.cancel()
+    {
+        emit_stop(state, seat, time_msec);
+    }
+}
+
+/// Buffer a finger delta. If a fling was previously running, this cancels it
+/// and emits a Continuous `axis_stop` before the caller's Finger frame so
+/// clients see a clean source transition.
+pub fn push_delta(
+    state: &mut State,
+    seat: &Seat<State>,
+    delta: Point<f64, Logical>,
+    t: Duration,
+    time_msec: u32,
+) {
+    if let Some(scroller) = seat.user_data().get::<KineticScroller>()
+        && scroller.push(delta, t)
+    {
+        emit_stop(state, seat, time_msec);
+    }
+}
+
+/// Try to start a fling from the buffered samples. Returns true if one was
+/// started — caller should skip its own `axis_stop` emission, the fling will
+/// deliver it when it decays.
+pub fn try_start_fling(state: &mut State, seat: &Seat<State>) -> bool {
+    let started = seat
+        .user_data()
+        .get::<KineticScroller>()
+        .and_then(|s| s.start_fling())
+        .is_some();
+    if started {
+        schedule_tick(state, seat);
+    }
+    started
+}
+
+fn schedule_tick(state: &mut State, seat: &Seat<State>) {
+    let seat = seat.clone();
+    let _ = state.common.event_loop_handle.insert_source(
+        Timer::from_duration(TICK),
+        move |_, _, state| {
+            tick_handler(state, &seat);
+            TimeoutAction::Drop
+        },
+    );
+}
+
+fn tick_handler(state: &mut State, seat: &Seat<State>) {
+    let now_time = state.common.clock.now();
+    let time_msec = now_time.as_millis();
+    let now: Duration = now_time.into();
+
+    // Capture active state *before* `tick` so we can distinguish a natural
+    // decay end (active was true, tick returned None → emit stop) from a
+    // stale timer firing after an external cancellation (active already
+    // false → cancel already emitted the stop, sending another here would
+    // land after the next gesture's Finger frames and confuse clients like
+    // Firefox that treat it as a flush signal).
+    let was_active = seat
+        .user_data()
+        .get::<KineticScroller>()
+        .is_some_and(|s| s.is_active());
+
+    let result = seat
+        .user_data()
+        .get::<KineticScroller>()
+        .and_then(|s| s.tick(now));
+
+    match result {
+        Some(delta) => {
+            let scroller = seat.user_data().get::<KineticScroller>().unwrap();
+            let (v120_x, v120_y) = scroller.next_v120(delta);
+
+            let mut frame = AxisFrame::new(time_msec).source(AxisSource::Continuous);
+            if delta.x != 0.0 {
+                frame = frame.value(Axis::Horizontal, delta.x);
+                if v120_x != 0 {
+                    frame = frame.v120(Axis::Horizontal, v120_x);
+                }
+            }
+            if delta.y != 0.0 {
+                frame = frame.value(Axis::Vertical, delta.y);
+                if v120_y != 0 {
+                    frame = frame.v120(Axis::Vertical, v120_y);
+                }
+            }
+            let ptr = seat.get_pointer().unwrap();
+            ptr.axis(state, frame);
+            ptr.frame(state);
+            schedule_tick(state, seat);
+        }
+        None => {
+            if was_active {
+                emit_stop(state, seat, time_msec);
+            }
+        }
+    }
+}

--- a/src/input/kinetic.rs
+++ b/src/input/kinetic.rs
@@ -18,7 +18,7 @@ use smithay::{
     utils::{Logical, Point},
 };
 use std::{cell::RefCell, collections::VecDeque, time::Duration};
-use tracing::trace;
+use tracing::{trace, warn};
 
 /// Maximum age of samples retained for velocity calculation. Kept slightly
 /// larger than [`VELOCITY_WINDOW`] so a momentary pause near lift doesn't
@@ -151,7 +151,12 @@ impl KineticScroller {
             return None;
         }
 
-        let last = inner.last_tick.unwrap_or(now);
+        // The first tick fires TICK after `start_fling` scheduled it, so
+        // back-date `last_tick` accordingly — otherwise dt_ms == 0 and we emit
+        // an empty Continuous axis frame that wakes clients for no reason.
+        let last = inner
+            .last_tick
+            .unwrap_or_else(|| now.saturating_sub(TICK));
         let dt_ms = now.saturating_sub(last).as_secs_f64() * 1000.0;
         inner.last_tick = Some(now);
 
@@ -267,14 +272,22 @@ pub fn try_start_fling(state: &mut State, seat: &Seat<State>) -> bool {
 }
 
 fn schedule_tick(state: &mut State, seat: &Seat<State>) {
-    let seat = seat.clone();
-    let _ = state.common.event_loop_handle.insert_source(
+    let seat_for_tick = seat.clone();
+    let res = state.common.event_loop_handle.insert_source(
         Timer::from_duration(TICK),
         move |_, _, state| {
-            tick_handler(state, &seat);
+            tick_handler(state, &seat_for_tick);
             TimeoutAction::Drop
         },
     );
+    // If the timer fails to register the fling would otherwise stay `active`
+    // with no further ticks — the synthetic axis_stop would never reach the
+    // client, leaving kinetic-aware toolkits stuck in "still scrolling".
+    if let Err(err) = res {
+        warn!("failed to schedule kinetic-scroll tick: {err}");
+        let time_msec = state.common.clock.now().as_millis();
+        cancel_with_stop(state, seat, time_msec);
+    }
 }
 
 fn tick_handler(state: &mut State, seat: &Seat<State>) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -59,7 +59,7 @@ use smithay::{
     reexports::{
         input::Device as InputDevice, wayland_server::protocol::wl_shm::Format as ShmFormat,
     },
-    utils::{Point, Rectangle, SERIAL_COUNTER, Serial},
+    utils::{Logical, Point, Rectangle, SERIAL_COUNTER, Serial},
     wayland::{
         image_copy_capture::{BufferConstraints, CursorSessionRef},
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
@@ -82,6 +82,7 @@ use std::{
 
 pub mod actions;
 pub mod gestures;
+pub mod kinetic;
 
 /// Used for debouncing focus updates due to pointer motion, if after the focus change is
 /// triggered the event will cancel if the pointer moves to the original target
@@ -213,6 +214,10 @@ impl State {
                     let keycode = event.key_code();
                     let state = event.state();
                     trace!(?keycode, ?state, "key");
+
+                    if state == KeyState::Pressed {
+                        kinetic::cancel_with_stop(self, &seat, Event::time_msec(&event));
+                    }
 
                     let serial = SERIAL_COUNTER.next_serial();
                     let time = Event::time_msec(&event);
@@ -705,6 +710,7 @@ impl State {
 
                 let mut pass_event = !seat.supressed_buttons().remove(button);
                 if event.state() == ButtonState::Pressed {
+                    kinetic::cancel_with_stop(self, &seat, event.time_msec());
                     // change the keyboard focus unless the pointer is grabbed
                     // We test for any matching surface type here but always use the root
                     // (in case of a window the toplevel) surface for the focus.
@@ -882,11 +888,14 @@ impl State {
                 }
             }
             InputEvent::PointerAxis { event, .. } => {
-                let scroll_factor =
+                let (scroll_factor, kinetic_enabled) =
                     if let Some(device) = <dyn Any>::downcast_ref::<InputDevice>(&event.device()) {
-                        self.common.config.scroll_factor(device)
+                        (
+                            self.common.config.scroll_factor(device),
+                            self.common.config.kinetic_scroll_enabled(device),
+                        )
                     } else {
-                        1.0
+                        (1.0, false)
                     };
 
                 let maybe_seat = self
@@ -907,6 +916,7 @@ impl State {
                             .accessibility_zoom
                             .enable_mouse_zoom_shortcuts
                     {
+                        kinetic::cancel_with_stop(self, &seat, event.time_msec());
                         seat.modifiers_shortcut_queue().clear();
                         if let Some(mut percentage) = event
                             .amount_v120(Axis::Vertical)
@@ -922,6 +932,29 @@ impl State {
                             self.update_zoom(&seat, change, event.source() == AxisSource::Wheel);
                         }
                     } else {
+                        // Kinetic-scroll hook: cancel on non-finger sources;
+                        // push samples / start fling on finger sources. Returns
+                        // true if a fling started — caller skips the axis_stop
+                        // emission for this lift; the fling delivers stop later.
+                        if event.source() != AxisSource::Finger {
+                            kinetic::cancel_with_stop(self, &seat, event.time_msec());
+                        } else if kinetic_enabled {
+                            let t = Duration::from_millis(event.time_msec() as u64);
+                            let dx_raw = event.amount(Axis::Horizontal).unwrap_or(0.0);
+                            let dy_raw = event.amount(Axis::Vertical).unwrap_or(0.0);
+                            if dx_raw == 0.0 && dy_raw == 0.0 {
+                                if kinetic::try_start_fling(self, &seat) {
+                                    return;
+                                }
+                            } else {
+                                let delta = Point::<f64, Logical>::from((
+                                    dx_raw * scroll_factor,
+                                    dy_raw * scroll_factor,
+                                ));
+                                kinetic::push_delta(self, &seat, delta, t, event.time_msec());
+                            }
+                        }
+
                         let mut frame = AxisFrame::new(event.time_msec()).source(event.source());
                         if let Some(horizontal_amount) = event.amount(Axis::Horizontal) {
                             if horizontal_amount != 0.0 {
@@ -1206,6 +1239,12 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
+                    if event.fingers() == 2 {
+                        // 2 fingers landing on the touchpad — the user is about
+                        // to scroll; stop any in-flight fling immediately so it
+                        // doesn't fight the new gesture.
+                        kinetic::cancel_with_stop(self, &seat, event.time_msec());
+                    }
                     let serial = SERIAL_COUNTER.next_serial();
                     let pointer = seat.get_pointer().unwrap();
                     pointer.gesture_hold_begin(

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -345,6 +345,14 @@ fn update_focus_state(
     serial: Option<Serial>,
     should_update_cursor: bool,
 ) {
+    // Cancel any in-flight kinetic fling on focus change so it doesn't keep
+    // scrolling the previously-focused surface.
+    let prev_focus = seat.get_keyboard().and_then(|k| k.current_focus());
+    if prev_focus.as_ref() != target {
+        let time_msec = state.common.clock.now().as_millis();
+        crate::input::kinetic::cancel_with_stop(state, seat, time_msec);
+    }
+
     // update keyboard focus
     if let Some(keyboard) = seat.get_keyboard() {
         if should_update_cursor

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -194,6 +194,7 @@ pub fn create_seat(
     userdata.insert_if_missing(Devices::default);
     userdata.insert_if_missing(SupressedKeys::default);
     userdata.insert_if_missing(SupressedButtons::default);
+    userdata.insert_if_missing(crate::input::kinetic::KineticScroller::default);
     userdata.insert_if_missing(ModifiersShortcutQueue::default);
     userdata.insert_if_missing(LastModifierChange::default);
     userdata.insert_if_missing_threadsafe(SeatMoveGrabState::default);


### PR DESCRIPTION
## Summary

Add an opt-in `KineticScroller` that buffers finger-source axis-event
deltas, computes a velocity-weighted lift, and emits a decaying synthetic
axis-event stream until the fling decays below a minimum velocity.

Config: `kinetic: Option<bool>` on `ScrollConfig` (per-device or global
default), defaults to **off**. No cosmic-settings UI yet.

## Why compositor-level, given the prior discussion in #204(https://github.com/pop-os/cosmic-epoch/issues/204)

GNOME (GTK) and KDE (Qt/QtQuick, system-wide as of Plasma 6.4) implement
kinetic at the toolkit. macOS does the same via AppKit. That works
because most apps in those environments share a toolkit. It does not
work for us:

1. **iced/libcosmic has no kinetic today.** COSMIC's own apps are the
   immediate gap. Doing this in the compositor closes it now without
   waiting on upstream iced.
2. **Per-app scroll behaviour is only possible at the compositor.** Each
   toolkit only sees its own surfaces. The compositor is the one place
   where "kinetic on for app X, off for app Y, custom decay for Z" can
   exist at all. That's the longer-term opportunity I'd like to set up
   here — a follow-up PR can add per-app rules + a cosmic-settings page.
3. Apps with no kinetic story at all (Java/Swing, some terminals, older
   toolkits) get the feature for free.

I'm aware this direction is contested. If maintainers would rather see
the effort go into iced upstream instead, I'd rather hear that now than
after the per-app config work.

## Known issues (carried into follow-up PRs)

The compositor-toolkit interaction warned about in (cosmic-epoch #204) is real:

- **Firefox**: scroll appears to "stick" until 2-finger lift. Caused by
  duplicate `axis_stop` frames Gecko emits when it sees finger-source
  events. Workaround written, kept out of this PR for size.
- **Some Java/Swing apps**: same, plus duplicate `hold_start`/`hold_end`
  frames. Workaround written, same reason.

These are precisely why the default is off and why per-app rules are the
intended next step. Kinetic-aware toolkits would land in the off-by-
default list; the user gets one consistent fling for everything else.

I'll open the workaround PRs separately if this approach is accepted.

## Protocol-semantics decision

At finger-lift when a fling is starting, we do **not** emit
`wl_pointer.axis_stop`. Kinetic-aware toolkits interpret `axis_stop` as
"user input ended, apply your own inertia," and would compound theirs
with ours. The synthetic events use `AxisSource::Continuous` so apps
treat them as already-smoothed motion. `axis_value120` is emitted
alongside `value` with fractional-remainder accumulation so the
high-res wheel stream stays smooth as the fling decays.

Cancellation paths: button press, key press, 2-finger touchpad land,
keyboard focus change, and (via `push()`) the first delta of a renewed
finger scroll.

## Files changed

- `src/input/kinetic.rs` (new, ~330 lines): state machine + plumbing
- `src/input/mod.rs` (+47): mod decl + thin hooks in PointerAxis /
  Button / Keyboard / GestureHoldBegin arms
- `src/shell/focus/mod.rs` (+8): cancel on focus change
- `src/shell/seats.rs` (+1): register on seat user_data
- `src/config/mod.rs` (+8): `kinetic_scroll_enabled` accessor
- `src/config/input_config.rs` (+1): default init
- `cosmic-comp-config/src/input.rs` (+2): field

## Testing

Tested on Pop!_OS 24.04 across a mix of libcosmic, GTK, Qt, Electron,
Firefox, and Java apps. libcosmic/iced apps gain inertia. GTK and Qt
apps work but with the compounding caveat noted above on aggressive
flings. Firefox and Java exhibit the documented bugs.

## AI disclosure

Claude Code was used for project exploration, code-generation
assistance, and drafting commit messages. I have read and understood
every line of the diff and am able to defend or revise any of it in
review.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the Developer Certificate of Origin and certify my
      contribution under its conditions.