### PR TITLE
fix: fullscreen x11 games opening as floating/tiled windows

### DIFF
--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -809,12 +809,14 @@ impl XwmHandler for State {
             );
         }
         if !shell.pending_windows.iter().any(|w| w.surface == window) {
+            let fullscreen = window.is_fullscreen().then(|| seat.active_output());
+            let maximized = window.is_maximized();
             let surface = CosmicSurface::from(window);
             shell.pending_windows.push(PendingWindow {
                 surface,
                 seat,
-                fullscreen: None,
-                maximized: false,
+                fullscreen,
+                maximized,
                 sticky: false,
             })
         }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -916,7 +916,11 @@ impl XwmHandler for State {
         // We only allow floating X11 windows to resize themselves. Nothing else
         let shell = self.common.shell.read();
 
-        // TODO: Fullscreen
+        if window.is_fullscreen() {
+            let _ = window.configure(None);
+            return;
+        }
+
         if let Some(mapped) = shell
             .element_for_surface(&window)
             .filter(|mapped| !mapped.is_minimized())


### PR DESCRIPTION
Looks like since https://github.com/Smithay/smithay/pull/1987 smithay sends the `is_fullscreen` in the request. So instead of setting it to None and waiting for a request for fullscreen, we set it on the pending window from the start.

- https://github.com/pop-os/cosmic-comp/pull/2395/commits/200074e580cbefadf20d5ee9d492846ab0d8e498 fixes games showing up as floating/tiled windows instead of fullscreen.
<img width="2256" height="1504" alt="Screenshot_2026-05-20_19-22-28" src="https://github.com/user-attachments/assets/d2544178-910f-4c83-90a0-4b1cf152b5b7" />

- https://github.com/pop-os/cosmic-comp/pull/2395/commits/451b8319d633e50d729c60a6719a4dd57d751574 fixes Steam Big Picture mode not taking the whole screen and being shown as a small window over a black background.
<img width="2256" height="1504" alt="Screenshot_2026-05-20_19-21-18" src="https://github.com/user-attachments/assets/7ff2d59e-a7b6-464e-802c-5e4ec9b8129c" />

Fixes https://github.com/pop-os/cosmic-comp/issues/2297
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

