### PR TITLE
input: support libinput custom acceleration curves

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ features = ["svg"]
 optional = true
 
 [features]
+custom-accel = ["cosmic-comp-config/custom-accel"]
 debug = ["egui", "egui_plot", "smithay-egui", "anyhow/backtrace"]
 default = ["systemd"]
 systemd = ["libsystemd", "logind-zbus"]

--- a/cosmic-comp-config/Cargo.toml
+++ b/cosmic-comp-config/Cargo.toml
@@ -17,5 +17,6 @@ tracing = { version = "0.1.44", features = [
 
 [features]
 default = []
+custom-accel = ["input/libinput_1_30"]
 output = ["ron", "tracing"]
 randr = ["cosmic-randr-shell", "output"]

--- a/cosmic-comp-config/src/input.rs
+++ b/cosmic-comp-config/src/input.rs
@@ -38,6 +38,24 @@ pub struct AccelConfig {
     #[serde(with = "AccelProfileDef")]
     pub profile: Option<AccelProfile>,
     pub speed: f64,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub custom_points: Option<CustomAccelPoints>,
+}
+
+// Custom acceleration curve points for the `Custom` libinput accel profile.
+// `step` is the input-velocity step in device units / ms.
+// `motion` (and optional `scroll`) are the multipliers at i*step.
+// `anchors` is editor-only state (cosmic-settings curve handles, expressed as
+// (mm/s, multiplier) pairs). cosmic-comp ignores it; only `motion` is fed to
+// libinput. cosmic-settings owns and round-trips it.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct CustomAccelPoints {
+    pub step: f64,
+    pub motion: Vec<f64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scroll: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub anchors: Option<Vec<(f64, f64)>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
@@ -115,17 +133,24 @@ mod AccelProfileDef {
     enum AccelProfile {
         Flat,
         Adaptive,
+        Custom,
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<AccelProfileOrig>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let o = Option::deserialize(deserializer)?;
-        Ok(o.map(|x| match x {
-            AccelProfile::Flat => AccelProfileOrig::Flat,
-            AccelProfile::Adaptive => AccelProfileOrig::Adaptive,
-        }))
+        let Some(x) = Option::deserialize(deserializer)? else {
+            return Ok(None);
+        };
+        Ok(match x {
+            AccelProfile::Flat => Some(AccelProfileOrig::Flat),
+            AccelProfile::Adaptive => Some(AccelProfileOrig::Adaptive),
+            #[cfg(feature = "custom-accel")]
+            AccelProfile::Custom => Some(AccelProfileOrig::Custom),
+            #[cfg(not(feature = "custom-accel"))]
+            AccelProfile::Custom => None,
+        })
     }
 
     pub fn serialize<S>(arg: &Option<AccelProfileOrig>, ser: S) -> Result<S::Ok, S::Error>
@@ -135,6 +160,8 @@ mod AccelProfileDef {
         let arg = match arg {
             Some(AccelProfileOrig::Flat) => Some(AccelProfile::Flat),
             Some(AccelProfileOrig::Adaptive) => Some(AccelProfile::Adaptive),
+            #[cfg(feature = "custom-accel")]
+            Some(AccelProfileOrig::Custom) => Some(AccelProfile::Custom),
             Some(_) | None => None,
         };
         Option::serialize(&arg, ser)

--- a/src/config/input_config.rs
+++ b/src/config/input_config.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "custom-accel")]
+use smithay::reexports::input::{AccelConfig as LibinputAccelConfig, AccelProfile, AccelType};
 use smithay::reexports::input::{
     Device as InputDevice, DeviceConfigError, DragLockState, ScrollMethod, SendEventsMode,
 };
@@ -20,6 +22,7 @@ pub fn for_device(device: &InputDevice) -> InputConfig {
             Some(AccelConfig {
                 profile: device.config_accel_profile(),
                 speed: device.config_accel_speed(),
+                custom_points: None,
             })
         } else {
             None
@@ -142,10 +145,33 @@ pub fn update_device(
         );
     }
     if let Some((accel, is_default)) = config!(|x| x.acceleration.as_ref()) {
-        if let Some(profile) = accel.profile
-            && let Err(err) = device.config_accel_set_profile(profile)
-        {
-            config_set_error(device, "acceleration profile", profile, err, is_default);
+        let profile_result = match (accel.profile, accel.custom_points.as_ref()) {
+            #[cfg(feature = "custom-accel")]
+            (Some(AccelProfile::Custom), Some(pts)) => {
+                match LibinputAccelConfig::new(AccelProfile::Custom) {
+                    Some(cfg) => {
+                        let mut err = cfg.set_points(AccelType::Motion, pts.step, &pts.motion);
+                        if err.is_ok()
+                            && let Some(scroll) = pts.scroll.as_ref()
+                        {
+                            err = cfg.set_points(AccelType::Scroll, pts.step, scroll);
+                        }
+                        err.and_then(|()| device.config_accel_apply(cfg))
+                    }
+                    None => Err(DeviceConfigError::Unsupported),
+                }
+            }
+            (Some(profile), _) => device.config_accel_set_profile(profile),
+            (None, _) => Ok(()),
+        };
+        if let Err(err) = profile_result {
+            config_set_error(
+                device,
+                "acceleration profile",
+                accel.profile,
+                err,
+                is_default,
+            );
         }
         if let Err(err) = device.config_accel_set_speed(accel.speed) {
             config_set_error(device, "acceleration speed", accel.speed, err, is_default);


### PR DESCRIPTION
AI-generated: This code was co-authored with Claude.

I got a 5K monitor and Magic Trackpad and no matter what I do, I don't get the feeling I want for moving the cursor.

Libinput 1.30 added a `Custom` accel profile that takes piecewise-linear multiplier tables instead of the single scalar that `Flat` and `Adaptive` use. Wire it through cosmic-comp's config so users can supply their own curves (e.g. from cosmic-settings).

Ultimately I'm aiming for this, which I got going on my desktop.

<img width="75%" height="1994" alt="image" src="https://github.com/user-attachments/assets/301f5ce7-a66f-4628-b660-3c724ce739aa" />


Gated behind a new flag `custom-accel` so it's possible to compile with libinput < 1.30. With the feature off the input crate stays at its default `libinput_1_21` floor, the `Custom` variant on libinput's `AccelProfile` isn't compiled in, and configs that specify the `Custom` profile deserialize to `None` (libinput falls back to its default). With the feature on the `input` crate is built with `libinput_1_30`, the apply path becomes available, and a runtime libinput >= 1.30 is required.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
