### PR TITLE
fix: follow the focus after alt+tab to another output

### DIFF
--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -111,10 +111,8 @@ impl ToplevelManagementHandler for State {
             std::mem::drop(shell);
 
             // move pointer to window if it’s on a different monitor/output
-            if seat.active_output() != *output
-                && self.common.config.cosmic_conf.cursor_follows_focus
-                && let Some(new_pos) = new_pos
-            {
+            let switching_output = seat.active_output() != *output;
+            if switching_output && let Some(new_pos) = new_pos {
                 seat.set_active_output(output);
                 if let Some(ptr) = seat.get_pointer() {
                     let serial = SERIAL_COUNTER.next_serial();


### PR DESCRIPTION
If you use alt+tab to switch to a window on another output, the cursor should follow you there regardless of "cursor follows focus" config. Just like it does when you move the focus to a window on another window using super+hjkl. 

Right now, you can use alt+tab to switch focus to a window on another output, but if you use super+jk to change workspace, the workspace on your old output will change not where your focus is.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

