### PR TITLE
Multiple windows with focus border around them in floating workspaces

### DIFF
--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1688,13 +1688,17 @@ impl Workspace {
                 self.floating_layer
                     .render::<R>(
                         renderer,
-                        focused.as_ref().and_then(|target| {
-                            if let FocusTarget::Window(mapped) = target {
-                                Some(mapped)
-                            } else {
-                                None
-                            }
-                        }),
+                        render_focus
+                            .then(|| {
+                                focused.as_ref().and_then(|target| {
+                                    if let FocusTarget::Window(mapped) = target {
+                                        Some(mapped)
+                                    } else {
+                                        None
+                                    }
+                                })
+                            })
+                            .flatten(),
                         resize_indicator.clone(),
                         indicator_thickness,
                         alpha,


### PR DESCRIPTION
Fixes multiple windows with the focus border around them.

Steps to reproduce:
1- on a multi monitor setup, set all workspaces to floating
2- open a window on all of them
3- all windows will have the focus border around them

This does not happen for tiling workspaces.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

