### PR TITLE
feat: allow naming pinned workspaces

### DIFF
--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -63,5 +63,5 @@ pub struct PinnedWorkspace {
     pub output: OutputMatch,
     pub tiling_enabled: bool,
     pub id: Option<String>,
-    // TODO: name
+    pub name: Option<String>,
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -436,6 +436,11 @@ fn create_workspace_from_pinned(
             | WorkspaceCapabilities::Pin
             | WorkspaceCapabilities::Move,
     );
+
+    if let Some(ref name) = pinned.name {
+        state.set_workspace_name(&workspace_handle, name);
+    }
+
     Workspace::from_pinned(
         pinned,
         workspace_handle,
@@ -616,6 +621,7 @@ impl WorkspaceSet {
             state,
             self.workspaces.len() as u8 + 1,
             &workspace.handle,
+            workspace.name.as_deref(),
             // this method is only used by code paths related to dynamic workspaces, so this should be fine
         );
         self.workspaces.push(workspace);
@@ -677,7 +683,12 @@ impl WorkspaceSet {
 
     fn update_workspace_idxs(&self, state: &mut WorkspaceUpdateGuard<'_, State>) {
         for (i, workspace) in self.workspaces.iter().enumerate() {
-            workspace_set_idx(state, i as u8 + 1, &workspace.handle);
+            workspace_set_idx(
+                state,
+                i as u8 + 1,
+                &workspace.handle,
+                workspace.name.as_deref(),
+            );
         }
     }
 
@@ -4944,8 +4955,9 @@ fn workspace_set_idx(
     state: &mut WorkspaceUpdateGuard<'_, State>,
     idx: u8,
     handle: &WorkspaceHandle,
+    name: Option<&str>,
 ) {
-    state.set_workspace_name(handle, format!("{}", idx));
+    state.set_workspace_name(handle, name.unwrap_or(&format!("{}", idx)));
     state.set_workspace_coordinates(handle, &[idx as u32]);
 }
 

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -111,6 +111,7 @@ pub struct Workspace {
     pub fullscreen: Option<FullscreenSurface>,
     pub pinned: bool,
     pub id: Option<String>,
+    pub name: Option<String>,
 
     pub handle: WorkspaceHandle,
     pub focus_stack: FocusStacks,
@@ -386,6 +387,7 @@ impl Workspace {
             fullscreen: None,
             pinned: false,
             id: None,
+            name: None,
             handle,
             focus_stack: FocusStacks::default(),
             image_copy: ImageCopySessions::default(),
@@ -419,6 +421,7 @@ impl Workspace {
             fullscreen: None,
             pinned: true,
             id: pinned.id.clone(),
+            name: pinned.name.clone(),
             handle,
             focus_stack: FocusStacks::default(),
             image_copy: ImageCopySessions::default(),
@@ -446,6 +449,7 @@ impl Workspace {
                 },
                 tiling_enabled: self.tiling_enabled,
                 id: self.id.clone(),
+                name: self.name.clone(),
             })
         } else {
             None


### PR DESCRIPTION
TL;DR: This patch adds the missing bits to enable naming pinned workspaces via the config file.

I was looking into cosmic-applets-workspaces code the other day and found out that the numbers displayed by the widget are literally the workspaces names. This then raised the question: Is there a way to configure these names somehow so the applet displays something else than a number? On my way to figure out how naming workspaces works, I ended up in cosmic-comp, where workspace names were simply generated from a workspaces index. I also found a `// TODO: name` in cosmic-comp-config and thought: lets do the todo. Below is a screenshot showing 4 named workspaces (I added the numbers and colons to the name).

<img width="460" height="50" alt="named_workspaces" src="https://github.com/user-attachments/assets/e58fe29d-d00f-4201-be39-903ed64827aa" />

I like the result and it might help people who like a more static and topic oriented workspace layout.

To test this, pin a workspace and edit `~/.config/cosmic/com.system76.CosmicComp/v1/pinned_workspaces`. Add something like `name: Some("my workspace name"),` to the config block you want to give a name to.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

