### PR TITLE
wayland: implement pointer-warp-v1

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2393,7 +2393,7 @@ impl State {
             });
 
             if let Some((output, geometry, surface_offset)) = found {
-                let mut pos_in_element = location + surface_offset.to_f64();
+                let pos_in_element = location + surface_offset.to_f64();
                 let window_size = geometry.size.to_f64();
 
                 let is_legal = |p: Point<f64, Logical>| {
@@ -2417,29 +2417,13 @@ impl State {
                 let workspace_origin = output.geometry().loc.to_f64();
                 let origin = geometry.loc.to_f64();
 
-                if !is_legal(pos_in_element) {
-                    let original_global = pointer.current_location();
-
-                    let original_pos_in_element = Point::new(
-                        original_global.x - workspace_origin.x - origin.x,
-                        original_global.y - workspace_origin.y - origin.y,
-                    );
-
-                    let y_only_pos = Point::new(original_pos_in_element.x, pos_in_element.y);
-                    let x_only_pos = Point::new(pos_in_element.x, original_pos_in_element.y);
-
-                    if is_legal(y_only_pos) {
-                        pos_in_element = y_only_pos;
-                    } else if is_legal(x_only_pos) {
-                        pos_in_element = x_only_pos;
-                    } else {
-                        pos_in_element = original_pos_in_element;
-                    }
+                if is_legal(pos_in_element) {
+                    let x = workspace_origin.x + origin.x + pos_in_element.x;
+                    let y = workspace_origin.y + origin.y + pos_in_element.y;
+                    Some((Point::new(x, y), output.clone()))
+                } else {
+                    None
                 }
-
-                let x = workspace_origin.x + origin.x + pos_in_element.x;
-                let y = workspace_origin.y + origin.y + pos_in_element.y;
-                Some((Point::new(x, y), output.clone()))
             } else {
                 None
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -86,6 +86,7 @@ use smithay::{
         output::OutputManagerState,
         pointer_constraints::PointerConstraintsState,
         pointer_gestures::PointerGesturesState,
+        pointer_warp::PointerWarpManager,
         presentation::PresentationState,
         seat::WaylandFocus,
         security_context::{SecurityContext, SecurityContextState},
@@ -671,6 +672,7 @@ impl State {
         XWaylandKeyboardGrabState::new::<Self>(dh);
         let xwayland_shell_state = XWaylandShellState::new::<Self>(dh);
         PointerConstraintsState::new::<Self>(dh);
+        PointerWarpManager::new::<Self>(dh);
         PointerGesturesState::new::<Self>(dh);
         TabletManagerState::new::<Self>(dh);
         SecurityContextState::new::<Self, _>(dh, client_has_no_security_context);

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -25,6 +25,7 @@ pub mod output_configuration;
 pub mod output_power;
 pub mod overlap_notify;
 pub mod pointer_constraints;
+pub mod pointer_warp;
 pub mod primary_selection;
 pub mod seat;
 pub mod security_context;

--- a/src/wayland/handlers/pointer_warp.rs
+++ b/src/wayland/handlers/pointer_warp.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::state::State;
+use smithay::{
+    input::pointer::PointerHandle,
+    reexports::wayland_server::protocol::{wl_pointer::WlPointer, wl_surface::WlSurface},
+    utils::{Logical, Point, Serial},
+    wayland::pointer_warp::PointerWarpHandler,
+};
+
+impl PointerWarpHandler for State {
+    fn warp_pointer(
+        &mut self,
+        surface: WlSurface,
+        pointer: WlPointer,
+        pos: Point<f64, Logical>,
+        serial: Serial,
+    ) {
+        let Some(resource_handle) = PointerHandle::<State>::from_resource(&pointer) else {
+            return;
+        };
+
+        let shell = self.common.shell.read();
+
+        let pointer_handle = shell.seats.iter().find_map(|seat| {
+            if let Some(pointer_handle) = seat.get_pointer()
+                && resource_handle == pointer_handle
+                && pointer_handle.last_enter() == Some(serial)
+                && let Some(keyboard) = seat.get_keyboard()
+                && let Some(keyboard_focus) = keyboard.current_focus()
+                && keyboard_focus.has_surface(&shell, &surface)
+            {
+                return Some(pointer_handle);
+            }
+            None
+        });
+
+        drop(shell);
+
+        if let Some(pointer_handle) = pointer_handle {
+            self.apply_cursor_hint(&surface, &pointer_handle, pos);
+        }
+    }
+}


### PR DESCRIPTION
A few weeks ago, the winewayland driver [merged](https://gitlab.winehq.org/wine/wine/-/merge_requests/10830) support for pointer-warp-v1, and given that we already have pointer-constraint-v1, enabling this protocol is simple.

I also add keyboard focus check to prevent the pointer from being warped just by hovering over the window.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

