### PR TITLE
fix xwayland windows with CSD shrinking on any event

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -238,7 +238,8 @@ impl CosmicSurface {
                 toplevel.with_pending_state(|state| state.size = Some(geo.size.as_logical()))
             }
             WindowSurface::X11(surface) => {
-                let _ = surface.configure_with_sync(geo.as_logical(), None);
+                let _ =
+                    surface.configure_with_sync(geo.as_logical() + surface.frame_extents(), None);
             }
         }
     }

--- a/src/shell/layout/floating/grabs/resize.rs
+++ b/src/shell/layout/floating/grabs/resize.rs
@@ -543,7 +543,7 @@ impl ResizeSurfaceGrab {
                             );
                         }
                         WindowSurface::X11(surface) => {
-                            let mut geometry = surface.geometry();
+                            let mut geometry = surface.last_configure();
                             geometry.loc += (location - new_location).as_logical();
                             let _ = surface.configure(geometry);
                         }


### PR DESCRIPTION
This fixes the resizing issue in xwayland windows with CSD. We add the `frame_extents` to the size and pass it to xwayland and remove it from the size we receive from xwayland.

Also use `last_configure`, instead of `geometry` in resize. This was missed in https://github.com/pop-os/cosmic-comp/pull/2357/changes/9c3f50410a0e17aa7b9ed4276dc8b114263b37ab.~~

Fixes #2440

~~Draft until I can confirm it fixes the issue, ~~I'm having trouble reproducing the issue~~, and there are other call sites that seem to need to be updated too.~~
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

