### PR TITLE
fix: handle missing element geometry in floating layout set_output

### DIFF
--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -308,8 +308,8 @@ impl FloatingLayout {
                     Some(geometry.size.as_logical()),
                     None,
                 );
-            } else {
-                let geometry = self.space.element_geometry(&mapped).unwrap().to_f64();
+            } else if let Some(geometry) = self.space.element_geometry(&mapped) {
+                let geometry = geometry.to_f64();
                 let new_loc = (
                     ((geometry.loc.x - old_output_geometry.loc.x).max(0.)
                         / old_output_geometry.size.w


### PR DESCRIPTION
Replace .unwrap() with if let Some to avoid panic when a mapped window has no geometry during output reconfiguration. This can occur during KVM switches, monitor hotplug, or suspend/resume where the window's geometry may not yet be available.

Fixes #2286 where cosmic-comp crashes with:
called Option::unwrap() on a None value
at src/shell/layout/floating/mod.rs:312
