### PR TITLE
Fix login screen not showing up

### DIFF
--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -42,6 +42,14 @@ impl DBusState {
             a11y_keyboard_monitor: RefCell::new(None),
         }));
         evlh.insert_source(source, |_, _, _| {}).unwrap();
+
+        if let Err(err) = futures_executor::block_on(state.session_conn()) {
+            tracing::error!("Failed to connect to session bus: {}", err);
+        }
+        if let Err(err) = futures_executor::block_on(state.system_conn()) {
+            tracing::error!("Failed to connect to system bus: {}", err);
+        }
+
         let state_clone = state.clone();
         state.spawn(async move {
             if let Err(err) = init_session(&state_clone).await {


### PR DESCRIPTION
This avoids a race that causes a deadlock on laptops connected to an external monitor.

This is a hack, the latest changes in cosmic-comp makes creating these connections lazy. But this makes it sync and creates it so no-one can call block_on on an inflight init.
___

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

