### PR TITLE
fix: prevent compositor crash when monitor is awaking from suspending

### DIFF
--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -295,6 +295,7 @@ impl FloatingLayout {
         for mapped in self
             .space
             .elements()
+            .filter(|w| w.alive())
             .cloned()
             .collect::<Vec<_>>()
             .into_iter()
@@ -309,7 +310,10 @@ impl FloatingLayout {
                     None,
                 );
             } else {
-                let geometry = self.space.element_geometry(&mapped).unwrap().to_f64();
+                let Some(geometry) = self.space.element_geometry(&mapped) else {
+                    continue;
+                };
+                let geometry = geometry.to_f64();
                 let new_loc = (
                     ((geometry.loc.x - old_output_geometry.loc.x).max(0.)
                         / old_output_geometry.size.w


### PR DESCRIPTION
**The problem**
Compositor can crash and drop the session back to the greeter when an output is reconfigured/resumed (for example, a monitor waking from DPMS / being re-added). Captured panic:

```
thread 'main' panicked: called `Option::unwrap()` on a `None` value: src/shell/layout/floating/mod.rs:312
    FloatingLayout::set_output
    Workspace::set_output → WorkspaceSet::set_output → Workspaces::add_output
    LockedBackend::apply_config_for_outputs → Config::read_outputs → refresh_output_config
```

**Root cause**
When an output disappears, its workspaces are parked: either entirely in `backup_set` (if the monitor was the only one) or as inactive workspaces in another monitor’s set. 

Parked workspaces are not processed by the regular `refresh()` at all (`Workspaces::refresh` only iterates over `self.sets`, and only the active workspace is cleaned up inside a set), so windows closed during this time are not cleaned up by anyone and accumulate in the space as dead.

When the output returns, `add_output` for each workspace calls `set_output` **before** `workspace.refresh()` - so `FloatingLayout::set_output` always sees an uncleared space. 

It takes a snapshot of all windows (including those already dead) and, in a loop, moves them to the returned monitor. Transferring the very first live window (`map_internal`) internally calls `space.refresh()`, and that function removes dead windows from the space right in the middle of the loop. 

When the loop reaches a dead window from the snapshot, it is no longer in the space, so `element_geometry()` returns `None`, and `unwrap()` panics - the compositor crashes entirely.

**Fix**
Filter the snapshot to live windows so dead ones are never processed.
I also added a branch `let Some(geometry) = self.space.element_geometry(&mapped) else { continue };`, which is kind of very defensive. Obviously, windows can't die during the loop, but IMO, I prefer to preserve it to prevent potential issues caused by unintentional/side-effect changes to `Space::refresh` / `map_internal`.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.