### PR TITLE
Respect cursor_follows_focus when activating a window on another output

### DIFF
--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -110,11 +110,14 @@ impl ToplevelManagementHandler for State {
 
             std::mem::drop(shell);
 
-            // move pointer to window if it’s on a different monitor/output
+            // move pointer to window if it’s on a different monitor/output,
+            // but only when the user opted into cursor_follows_focus.
             let switching_output = seat.active_output() != *output;
             if switching_output && let Some(new_pos) = new_pos {
                 seat.set_active_output(output);
-                if let Some(ptr) = seat.get_pointer() {
+                if self.common.config.cosmic_conf.cursor_follows_focus
+                    && let Some(ptr) = seat.get_pointer()
+                {
                     let serial = SERIAL_COUNTER.next_serial();
                     ptr.motion(
                         self,


### PR DESCRIPTION
## Problem

When clicking an app in the dock/panel while its window is on a **different output**, the pointer is warped to the center of that window — even when **Cursor follows focus** is disabled in Settings. This is surprising and disruptive on multi-monitor setups (you click on monitor A, the window focuses on monitor B, and your cursor is yanked to B).

This is the root cause behind several reports:
- #930 (moving focus between monitors centers the cursor)
- pop-os/cosmic-settings#1269
- pop-os/cosmic-epoch#3121

## Cause

In `src/wayland/handlers/toplevel_management.rs`, the `activate` handler warps the pointer whenever `switching_output` is true, without checking the `cursor_follows_focus` config. Every other focus path in the compositor (`shell::focus::update_focus_state` at `focus/mod.rs`, and `input::actions`) already gates the warp on `cursor_follows_focus`; this path was missed.

## Fix

Gate the pointer warp on `self.common.config.cosmic_conf.cursor_follows_focus`. Keyboard focus and `set_active_output` are unchanged — only the pointer warp becomes conditional, consistent with the rest of the codebase.

When `cursor_follows_focus` is **enabled**, behavior is unchanged (cursor still follows to the window on the other output). When **disabled**, the cursor stays where it is.

## Testing

- Two monitors, `cursor_follows_focus` disabled: click an app in the dock whose window is on the other monitor → cursor no longer jumps. ✅
- `cursor_follows_focus` enabled: cursor still follows to the activated window. ✅
