### PR TITLE
shell/focus: Order sticky windows before fullscreen windows

### DIFF
--- a/src/shell/focus/order.rs
+++ b/src/shell/focus/order.rs
@@ -231,9 +231,7 @@ fn render_input_order_internal<R: 'static>(
         }
 
         // sticky window popups
-        if !has_focused_fullscreen {
-            callback(Stage::StickyPopups(&set.sticky_layer))?;
-        }
+        callback(Stage::StickyPopups(&set.sticky_layer))?;
     }
 
     if element_filter != ElementFilter::LayerShellOnly {
@@ -313,11 +311,11 @@ fn render_input_order_internal<R: 'static>(
         for (layer, location) in layer_surfaces(output, Layer::Top, element_filter) {
             callback(Stage::LayerSurface { layer, location })?;
         }
+    }
 
-        // sticky windows
-        if element_filter != ElementFilter::LayerShellOnly {
-            callback(Stage::Sticky(&set.sticky_layer))?;
-        }
+    // sticky windows
+    if element_filter != ElementFilter::LayerShellOnly {
+        callback(Stage::Sticky(&set.sticky_layer))?;
     }
 
     if element_filter != ElementFilter::LayerShellOnly {


### PR DESCRIPTION
This appears to be everything necessary to make sticky window appear on top of fullscreen apps. Of course depending on whether a game might lock or confine the cursor, one may or may not be able to interact with the sticky window. But I'd argue that is expected.

See https://github.com/pop-os/cosmic-comp/issues/534 and mattermost discussions.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

