### PR TITLE
Fix "git commit unknown" in the version string 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ vendor:
 	mkdir -p .cargo
 	cargo vendor | head -n -1 > .cargo/config
 	echo 'directory = "vendor"' >> .cargo/config
+	[ -n "$(SOURCE_GIT_HASH)" ] && printf '\n[env]\nGIT_HASH = "%s"\n' "$(SOURCE_GIT_HASH)" >> .cargo/config || true
 	tar pcf vendor.tar vendor
 	rm -rf vendor
 

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,6 @@
 use std::process::Command;
 
 fn main() {
-    if let Ok(hash) = std::env::var("SOURCE_GIT_HASH") {
-        println!("cargo:rustc-env=GIT_HASH={}", hash);
-        return;
-    }
     if let Ok(output) = Command::new("git").args(["rev-parse", "HEAD"]).output() {
         let git_hash = String::from_utf8(output.stdout).unwrap();
         println!("cargo:rustc-env=GIT_HASH={}", git_hash);


### PR DESCRIPTION
This reverts the change from https://github.com/pop-os/cosmic-comp/pull/2313 and fixes the issue properly. 
The previous fix didn't work because the `SOURCE_GIT_HASH` env var is available during [debuild -S](https://github.com/pop-os/pop/blob/3abdf176e05922009b39dcd0e2fa47b4b66eee7e/scripts/pop-ci/src/main.rs#L770) but that's where we're vendoring and creating the source (`-S`), it's not available during `sbuild`. 

Adding `GIT_HASH` to .cargo/config during vendoring is the proper fix.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

