### PR TITLE
Forward axis relative direction to Wayland clients

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1002,6 +1002,10 @@ impl State {
                         if let Some(horizontal_amount) = event.amount(Axis::Horizontal) {
                             if horizontal_amount != 0.0 {
                                 frame = frame
+                                    .relative_direction(
+                                        Axis::Horizontal,
+                                        event.relative_direction(Axis::Horizontal),
+                                    )
                                     .value(Axis::Horizontal, scroll_factor * horizontal_amount);
                                 if let Some(discrete) = event.amount_v120(Axis::Horizontal) {
                                     frame = frame.v120(
@@ -1015,8 +1019,12 @@ impl State {
                         }
                         if let Some(vertical_amount) = event.amount(Axis::Vertical) {
                             if vertical_amount != 0.0 {
-                                frame =
-                                    frame.value(Axis::Vertical, scroll_factor * vertical_amount);
+                                frame = frame
+                                    .relative_direction(
+                                        Axis::Vertical,
+                                        event.relative_direction(Axis::Vertical),
+                                    )
+                                    .value(Axis::Vertical, scroll_factor * vertical_amount);
                                 if let Some(discrete) = event.amount_v120(Axis::Vertical) {
                                     frame = frame.v120(
                                         Axis::Vertical,


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

Fixes #2468

Forward libinput `relative_direction` on pointer axis frames before `.value()`.

Magnifier zoom already handled inversion locally; client-forwarding path did not pass the Wayland hint. Qt apps rely on `QWheelEvent::inverted()` for touchpad swipe direction.

## Testing

Built `cosmic-comp` locally from this branch, installed to `/usr/bin/cosmic-comp`, restarted session.

- **OS:** Fedora 44, COSMIC Wayland (`XDG_SESSION_TYPE=wayland`)
- **Input:** touchpad, natural scrolling enabled
- **App:** Telegram Desktop (official binary, native Wayland)

Two-finger horizontal swipes in Telegram chat (back / reply) were reversed before the patch; correct after.