### PR TITLE
feat: separate logind feature from systemd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,8 @@ optional = true
 [features]
 debug = ["egui", "egui_plot", "smithay-egui", "anyhow/backtrace"]
 default = ["systemd"]
-systemd = ["libsystemd", "logind-zbus"]
+logind = ["logind-zbus"]
+systemd = ["libsystemd", "logind"]
 profile-with-tracy = ["profiling/profile-with-tracy", "tracy-client/default"]
 profile-with-tracy-gpu = ["profile-with-tracy", "smithay/tracy_gpu_profiling"]
 

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -14,7 +14,7 @@ use tracing::{error, warn};
 
 pub mod a11y_keyboard_monitor;
 use a11y_keyboard_monitor::A11yKeyboardMonitorState;
-#[cfg(feature = "systemd")]
+#[cfg(feature = "logind")]
 pub mod logind;
 mod name_owners;
 mod power;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1600,7 +1600,7 @@ impl State {
             }
             InputEvent::Special(_) => {}
             InputEvent::SwitchToggle { event } => {
-                #[cfg(feature = "systemd")]
+                #[cfg(feature = "logind")]
                 if event.switch() == Some(Switch::Lid) && self.common.inhibit_lid_fd.is_some() {
                     let backend = self.backend.lock();
                     let output = backend

--- a/src/state.rs
+++ b/src/state.rs
@@ -116,7 +116,7 @@ use smithay::{
 };
 use tracing::warn;
 
-#[cfg(feature = "systemd")]
+#[cfg(feature = "logind")]
 use std::os::fd::OwnedFd;
 
 use std::{
@@ -292,7 +292,7 @@ pub struct Common {
     pub xwayland_shell_state: XWaylandShellState,
     pub pointer_focus_state: Option<PointerFocusState>,
 
-    #[cfg(feature = "systemd")]
+    #[cfg(feature = "logind")]
     pub inhibit_lid_fd: Option<OwnedFd>,
 
     pub with_xwayland: bool,
@@ -791,7 +791,7 @@ impl State {
                 pointer_focus_state: None,
                 dbus_state,
 
-                #[cfg(feature = "systemd")]
+                #[cfg(feature = "logind")]
                 inhibit_lid_fd: None,
 
                 with_xwayland,
@@ -816,7 +816,7 @@ impl State {
     }
 
     fn update_inhibitor_locks(&mut self) {
-        #[cfg(feature = "systemd")]
+        #[cfg(feature = "logind")]
         {
             use smithay::backend::session::Session;
             use tracing::{debug, error, warn};


### PR DESCRIPTION
Move logind-zbus to a dedicated 'logind' feature that is independent of the 'systemd' feature. This allows non-systemd users (e.g., OpenRC with elogind) to access lid switch inhibition and lid status detection without requiring the full systemd stack.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

