### PR TITLE
input: allow a few shortcut keys to be repeated by holding down the key

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -132,6 +132,24 @@ impl SupressedKeys {
     }
 }
 
+const REPEATABLE_ACTION_DELAY: Duration = Duration::from_millis(500);
+const REPEATABLE_ACTION_INTERVAL: Duration = Duration::from_millis(120);
+
+fn repeatable_action_interval(action: &shortcuts::Action) -> Option<Duration> {
+    matches!(
+        action,
+        shortcuts::Action::System(
+            shortcuts::action::System::VolumeRaise
+                | shortcuts::action::System::VolumeLower
+                | shortcuts::action::System::BrightnessUp
+                | shortcuts::action::System::BrightnessDown
+                | shortcuts::action::System::KeyboardBrightnessUp
+                | shortcuts::action::System::KeyboardBrightnessDown
+        )
+    )
+    .then_some(REPEATABLE_ACTION_INTERVAL)
+}
+
 impl SupressedButtons {
     fn add(&self, button: u32) {
         self.0.borrow_mut().insert(button);
@@ -1639,6 +1657,42 @@ impl State {
         }
     }
 
+    fn schedule_repeat_action(
+        &self,
+        seat: &Seat<State>,
+        handle: &KeysymHandle<'_>,
+        action: Action,
+        binding: shortcuts::Binding,
+        serial: Serial,
+        time: u32,
+        initial_delay: Duration,
+        interval: Duration,
+    ) {
+        let seat_clone = seat.clone();
+        let start = Instant::now();
+        let token = self
+            .common
+            .event_loop_handle
+            .insert_source(
+                Timer::from_duration(initial_delay),
+                move |current, _, state| {
+                    let elapsed = current.duration_since(start).as_millis() as u32;
+                    state.handle_action(
+                        action.clone(),
+                        &seat_clone,
+                        serial,
+                        time.overflowing_add(elapsed).0,
+                        binding.clone(),
+                        None,
+                    );
+                    TimeoutAction::ToDuration(interval)
+                },
+            )
+            .ok();
+
+        seat.supressed_keys().add(handle, token);
+    }
+
     /// Determine is key event should be intercepted as a key binding, or forwarded to surface
     #[profiling::function]
     pub fn filter_keyboard_input<B: InputBackend, E: KeyboardKeyEvent<B>>(
@@ -1790,32 +1844,16 @@ impl State {
                         }
                     }
                 } else {
-                    let seat_clone = seat.clone();
-                    let action_clone = action.clone();
-                    let key_pattern_clone = key_pattern.clone();
-                    let start = Instant::now();
-                    let time = event.time_msec();
-                    let token = self
-                        .common
-                        .event_loop_handle
-                        .insert_source(
-                            Timer::from_duration(Duration::from_millis(200)),
-                            move |current, _, state| {
-                                let duration = current.duration_since(start).as_millis();
-                                state.handle_action(
-                                    action_clone.clone(),
-                                    &seat_clone,
-                                    serial,
-                                    time.overflowing_add(duration as u32).0,
-                                    key_pattern_clone.clone(),
-                                    None,
-                                );
-                                calloop::timer::TimeoutAction::ToDuration(Duration::from_millis(25))
-                            },
-                        )
-                        .ok();
-
-                    seat.supressed_keys().add(&handle, token);
+                    self.schedule_repeat_action(
+                        seat,
+                        &handle,
+                        action.clone(),
+                        key_pattern.clone(),
+                        serial,
+                        event.time_msec(),
+                        Duration::from_millis(200),
+                        Duration::from_millis(25),
+                    );
                 }
                 return FilterResult::Intercept(Some((action, key_pattern)));
             }
@@ -1968,7 +2006,22 @@ impl State {
                     && cosmic_modifiers_eq_smithay(&binding.modifiers, modifiers)
                 {
                     modifiers_queue.clear();
-                    seat.supressed_keys().add(&handle, None);
+
+                    if let Some(interval) = repeatable_action_interval(action) {
+                        self.schedule_repeat_action(
+                            seat,
+                            &handle,
+                            Action::Shortcut(action.clone()),
+                            binding.clone(),
+                            serial,
+                            event.time_msec(),
+                            REPEATABLE_ACTION_DELAY,
+                            interval,
+                        );
+                    } else {
+                        seat.supressed_keys().add(&handle, None);
+                    }
+
                     return FilterResult::Intercept(Some((
                         Action::Shortcut(action.clone()),
                         binding.clone(),


### PR DESCRIPTION
I did notice an issue testing when holding down volume down then releasing and quickly pressing volume up but the issue seems to be related to libinput which produces a release event despite me holding the up key down.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

