### PR TITLE
fix: prevent gradual slowdown and rising CPU usage in long-running sessions

### DIFF
--- a/src/wayland/protocols/toplevel_management.rs
+++ b/src/wayland/protocols/toplevel_management.rs
@@ -237,11 +237,10 @@ where
                     window_from_handle::<<D as ToplevelInfoHandler>::Window>(toplevel).unwrap();
                 if let Some(toplevel_state) = window.user_data().get::<ToplevelState>() {
                     let mut toplevel_state = toplevel_state.lock().unwrap();
-                    if width == 0 && height == 0 {
-                        toplevel_state
-                            .rectangles
-                            .retain(|(s, _)| s.id() != surface.id());
-                    } else {
+                    toplevel_state
+                        .rectangles
+                        .retain(|(s, _)| s.id() != surface.id());
+                    if width != 0 || height != 0 {
                         toplevel_state.rectangles.push((
                             surface.downgrade(),
                             Rectangle::new((x, y).into(), (width, height).into()),


### PR DESCRIPTION
**The problem**

A new comment on the already-closed issue https://github.com/pop-os/cosmic-comp/issues/2062#issuecomment-4720637087 noted that the original leak is still occurring. Yet it's a totally different leak.

So, from the user's perspective, the problem is that `cosmic-comp` slowly consumes more and more CPU over the course of the session, and as a consequence, the UI starts to feel laggy after some time.  Restarting the compositor fixes it (no reboot is needed), but it slowly builds up again.

**Root cause**

In the original message, we can find clues that everything starts with `Common::refresh`, and that "more and more CPU the longer session lasts" suggests that some collection is growing larger and taking longer to process. 

After some diagnostic time, I've found that in the `SetRectangle` request handler inside `zcosmic_toplevel_manager_v1`, we store a rectangle per surface, and in the set branch, it only pushes, never removing the previous rectangle for the same surface. 

So long-lasting apps push new rectangles on almost every relayout (including workspace changes, min, max, etc), so `ToplevelStateInner::rectangles` grows without any limit.

The only cleanup happens in `ToplevelInfoState::refresh` - it drops rectangles of the surfaces that are already dead.
But long-lasting surfaces are not dead, so we iterate over a growing vector of rectangles and call `surface.upgrade()` on every element on every refresh.

I measured locally and got **~23000** rectangles after **~2-3h** of work, with a small number of windows (**up to 5** at different times) open (it should be exactly 1 per window).

**Fix**
Make `set_rectangle` idempotent per surface: drop any existing rectangle for that surface before pushing the new one (the same thing the unset branch already does).

I checked with temporary debug counters that rectangles now exactly equal the number of windows and reset when windows are closed, instead of only growing.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

