### PR TITLE
fix: unminimized window at wrong size after animation ends

### DIFF
--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1346,7 +1346,7 @@ impl FloatingLayout {
             mapped.set_bounds(geometry.size.as_logical());
             let prev = self.space.element_geometry(&mapped).map(RectExt::as_local);
 
-            let window_geometry = if mapped.is_maximized(false) {
+            let window_geometry = if mapped.is_maximized(true) {
                 geometry
             } else {
                 prev.map(|mut rect| {


### PR DESCRIPTION
**Fixes**: pop-os/cosmic-epoch#2743

**Problem**
<img width="1920" height="1200" alt="Screenshot_2026-06-19_20-25-03" src="https://github.com/user-attachments/assets/e94d20c1-68cc-45c0-9b81-e3440f537207" />
After the unminimizing animation window receives the wrong size.

**Root cause**
`FloatingLayout::recalculate` reconfigures every floating window. When selecting the window geometry, it checks `mapped.is_maximized(false)`, which reflects the **committed** maximized state. Right after unminimization, the client hasn't acked the maximize yet, so the committed state is still **not maximized**. As a result, `recalculate` recomputes the geometry from the old, unmaximized size. 

The `configure` it sends still has the pending-maximized flag set, so the client receives **an unmaximized size with the maximized state** and renders it small, thinking it's maximized.

**Fix**
Use the geometry from the **pending** maximized state (`is_maximized(true)`) instead of the committed one - intended state, not the client has acked yet.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

