### PR TITLE
Revert "fix: follow the focus after alt+tab to another output"

### DIFF
--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -111,8 +111,10 @@ impl ToplevelManagementHandler for State {
             std::mem::drop(shell);
 
             // move pointer to window if it’s on a different monitor/output
-            let switching_output = seat.active_output() != *output;
-            if switching_output && let Some(new_pos) = new_pos {
+            if seat.active_output() != *output
+                && self.common.config.cosmic_conf.cursor_follows_focus
+                && let Some(new_pos) = new_pos
+            {
                 seat.set_active_output(output);
                 if let Some(ptr) = seat.get_pointer() {
                     let serial = SERIAL_COUNTER.next_serial();


### PR DESCRIPTION
This reverts commit 56f84fba2dc0ff7de191e48e56f29d92ba50e668.

While a better solution is being discussed let's revert this change.
This wasn't the correct fix anyways. The right fix is to ignore cursors position when keyboard commands are being fired.

This does the same as https://github.com/pop-os/cosmic-comp/pull/2457 but reverts the original commit for a better history.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

