### PR TITLE
backend/kms: Use udmabuf for multi-gpu buffer sharing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ xdg-user = "0.2.1"
 xkbcommon = "0.9"
 zbus = "5.14.0"
 profiling = { version = "1.0" }
-rustix = { version = "1.1.4", features = ["process"] }
+rustix = { version = "1.1.4", features = ["process", "param"] }
 rand = "0.10"
 # CLI arguments
 clap_lex = "1.0"

--- a/src/backend/kms/render/gles.rs
+++ b/src/backend/kms/render/gles.rs
@@ -3,13 +3,13 @@
 use smithay::backend::{
     SwapBuffersError,
     allocator::{
-        Allocator,
+        Allocator, Format, Fourcc, Modifier,
         dmabuf::{AnyError, Dmabuf, DmabufAllocator},
         gbm::GbmAllocator,
     },
     drm::{CreateDrmNodeError, DrmNode},
     renderer::{
-        RendererSuper,
+        Bind, RendererSuper,
         gles::{GlesError, GlesRenderer},
         glow::GlowRenderer,
         multigpu::{ApiDevice, Error as MultiError, GraphicsApi},
@@ -23,7 +23,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use crate::backend::render::element::FromGlesError;
+use crate::backend::{kms::render::udmabuf::UdmabufAllocator, render::element::FromGlesError};
 
 /// Errors raised by the [`GbmGlesBackend`]
 #[derive(Debug, thiserror::Error)]
@@ -124,11 +124,26 @@ impl<A: AsFd + Clone + 'static> GraphicsApi for GbmGlowBackend<A> {
             })
             .flat_map(|(node, (allocator, renderer))| {
                 let renderer = renderer.replace(None)?;
+                let can_render_to_linear = Bind::<Dmabuf>::supported_formats(&renderer)
+                    .is_some_and(|formats| {
+                        formats.contains(&Format {
+                            code: Fourcc::Abgr8888,
+                            modifier: Modifier::Linear,
+                        })
+                    });
+
+                let allocator =
+                    if can_render_to_linear && let Ok(allocator) = UdmabufAllocator::new() {
+                        Box::new(DmabufAllocator(allocator))
+                            as Box<dyn Allocator<Buffer = Dmabuf, Error = AnyError>>
+                    } else {
+                        Box::new(DmabufAllocator(allocator.clone()))
+                    };
 
                 Some(GbmGlowDevice {
                     node: *node,
                     renderer,
-                    allocator: Box::new(DmabufAllocator(allocator.clone())),
+                    allocator,
                 })
             })
             .collect::<Vec<GbmGlowDevice>>();

--- a/src/backend/kms/render/mod.rs
+++ b/src/backend/kms/render/mod.rs
@@ -1,2 +1,3 @@
 pub mod gles;
 pub mod pixman;
+pub mod udmabuf;

--- a/src/backend/kms/render/udmabuf.rs
+++ b/src/backend/kms/render/udmabuf.rs
@@ -1,0 +1,135 @@
+use std::{
+    io,
+    os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd},
+    sync::LazyLock,
+};
+
+use rustix::{
+    fs::{MemfdFlags, Mode, OFlags, SealFlags, fcntl_add_seals, ftruncate, memfd_create},
+    ioctl::{Ioctl, Opcode, ioctl, opcode},
+    param::page_size,
+};
+use smithay::{
+    backend::allocator::{
+        Allocator, Fourcc, Modifier,
+        dmabuf::{Dmabuf, DmabufFlags},
+        format::get_bpp,
+    },
+    utils::Size,
+};
+
+static PAGE_SIZE: LazyLock<usize> = LazyLock::new(page_size);
+
+pub struct UdmabufAllocator {
+    dev: OwnedFd,
+}
+
+pub const STRIDE_ALIGN: usize = 256;
+
+impl UdmabufAllocator {
+    pub fn new() -> io::Result<UdmabufAllocator> {
+        let fd = rustix::fs::open(
+            "/dev/udmabuf",
+            OFlags::RDONLY | OFlags::CLOEXEC,
+            Mode::empty(),
+        )?;
+        Ok(UdmabufAllocator { dev: fd })
+    }
+}
+
+impl Allocator for UdmabufAllocator {
+    type Buffer = Dmabuf;
+    type Error = io::Error;
+
+    fn create_buffer(
+        &mut self,
+        width: u32,
+        height: u32,
+        fourcc: Fourcc,
+        modifiers: &[Modifier],
+    ) -> Result<Self::Buffer, Self::Error> {
+        let width = width as usize;
+        let height = height as usize;
+        if width >= u16::MAX as usize || height >= u16::MAX as usize {
+            return Err(io::ErrorKind::Unsupported.into());
+        }
+        if !modifiers.contains(&Modifier::Linear) {
+            return Err(io::ErrorKind::Unsupported.into());
+        }
+        let stride = (width * get_bpp(fourcc).ok_or(io::ErrorKind::Unsupported)?)
+            .next_multiple_of(STRIDE_ALIGN);
+        let page_mask = !(*PAGE_SIZE - 1);
+        let size = (height * stride + (*PAGE_SIZE - 1)) & page_mask;
+
+        let mem_fd = memfd_create("udmabuf", MemfdFlags::ALLOW_SEALING | MemfdFlags::CLOEXEC)?;
+        ftruncate(&mem_fd, size as u64)?;
+        fcntl_add_seals(&mem_fd, SealFlags::SHRINK)?;
+
+        let dma_fd = udmabuf_from_memfd(&self.dev, mem_fd.as_fd(), 0, size as u64)?;
+        let mut dmabuf = Dmabuf::builder(
+            Size::new(width as i32, height as i32),
+            fourcc,
+            Modifier::Linear,
+            DmabufFlags::empty(),
+        );
+        dmabuf.add_plane(dma_fd, 0, 0, stride as u32);
+        dmabuf
+            .build()
+            .ok_or_else(|| io::ErrorKind::Unsupported.into())
+    }
+}
+
+fn udmabuf_from_memfd(
+    fd: impl AsFd,
+    mem_fd: impl AsRawFd,
+    offset: u64,
+    size: u64,
+) -> io::Result<OwnedFd> {
+    #[repr(C)]
+    #[derive(Debug)]
+    struct udmabuf_create {
+        memfd: u32,
+        flags: u32,
+        offset: u64,
+        size: u64,
+    }
+    const UDMABUF_FLAGS_CLOEXEC: u32 = 0x01;
+
+    unsafe impl Ioctl for udmabuf_create {
+        type Output = RawFd;
+
+        const IS_MUTATING: bool = false;
+
+        fn opcode(&self) -> Opcode {
+            opcode::read_write::<udmabuf_create>(b'u', 0x42)
+        }
+
+        fn as_ptr(&mut self) -> *mut rustix::ffi::c_void {
+            self as *mut Self as *mut _
+        }
+
+        unsafe fn output_from_ptr(
+            out: rustix::ioctl::IoctlOutput,
+            _extract_output: *mut rustix::ffi::c_void,
+        ) -> rustix::io::Result<Self::Output> {
+            if out < 0 {
+                Err(rustix::io::Errno::from_raw_os_error(!out))
+            } else {
+                Ok(out)
+            }
+        }
+    }
+
+    let args = udmabuf_create {
+        memfd: mem_fd.as_raw_fd() as u32,
+        flags: UDMABUF_FLAGS_CLOEXEC,
+        offset,
+        size,
+    };
+
+    unsafe {
+        ioctl(fd, args)
+            .map(|fd| OwnedFd::from_raw_fd(fd))
+            .map_err(|err| io::Error::from_raw_os_error(err.raw_os_error()))
+    }
+}


### PR DESCRIPTION
Draft because I am not sure we want this and due to very limited testing.

But I think this is useful for debugging and maybe also generally at some point, so I'll throw it into a PR for visibility and later use.

Uses a udmabuf to share contents between gpus, forcing the buffer to be linear (unfortunately), but avoids any weird migrations by immediately allocating in RAM. Needs a very recent nvidia driver to render correctly (595) and some Intel cards also have some rendering issues, but also works (without crashing) with llvmpipe and pixman! Not scanout-able, but otherwise just a plain better version of dumb buffers.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

