### PR TITLE
fix: keep windows visible until overview commits a buffer

### DIFF
--- a/src/utils/quirks.rs
+++ b/src/utils/quirks.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use smithay::{desktop::layer_map_for_output, output::Output};
+use smithay::{
+    backend::renderer::utils::with_renderer_surface_state, desktop::layer_map_for_output,
+    output::Output,
+};
 
 /// Layer shell namespace used by `cosmic-workspaces`
 // TODO: Avoid special case, or add protocol to expose required behavior
@@ -10,5 +13,14 @@ pub const WORKSPACE_OVERVIEW_NAMESPACE: &str = "cosmic-workspace-overview";
 pub fn workspace_overview_is_open(output: &Output) -> bool {
     layer_map_for_output(output)
         .layers()
-        .any(|s| s.namespace() == WORKSPACE_OVERVIEW_NAMESPACE)
+        .filter(|s| s.namespace() == WORKSPACE_OVERVIEW_NAMESPACE)
+        // Only consider the overview open once it has committed a buffer. The
+        // surface is inserted into the layer map on its initial (bufferless)
+        // commit, so checking for the namespace alone hides all toplevels for a
+        // frame before the overview has anything to draw, briefly flashing the
+        // bare wallpaper.
+        .any(|s| {
+            with_renderer_surface_state(s.wl_surface(), |state| state.buffer().is_some())
+                .unwrap_or(false)
+        })
 }


### PR DESCRIPTION
When transitioning to the workspace overview, the open windows briefly hide, which causes a flicker effect that briefly shows the wallpaper. This fixes that.

before:

https://github.com/user-attachments/assets/94bb69da-b435-4788-9cb4-b404a7d98a09




after:

https://github.com/user-attachments/assets/9f3b9d17-c76c-4e93-86e0-976761509e06





- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

