### PR TITLE
fix: internal laptop screen stuck on vendor logo with external monitor

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -96,7 +96,6 @@ pub struct Device {
     pub inner: InnerDevice,
     pub drm: GbmDrmOutputManager,
 
-    supports_atomic: bool,
     pub texture_formats: FormatSet,
     event_token: Option<RegistrationToken>,
     pub socket: Option<Socket>,
@@ -711,7 +710,6 @@ impl Device {
         let (drm, notifier) = DrmDevice::new(fd.clone(), false)
             .with_context(|| format!("Failed to initialize drm device for: {}", path.display()))?;
         let dev_node = DrmNode::from_dev_id(dev)?;
-        let supports_atomic = drm.is_atomic();
 
         let gbm = GbmDevice::new(fd)
             .with_context(|| format!("Failed to initialize GBM device for {}", path.display()))?;
@@ -831,7 +829,6 @@ impl Device {
                 active_clients,
             },
 
-            supports_atomic,
             texture_formats,
             event_token: Some(token),
             socket,
@@ -840,8 +837,7 @@ impl Device {
 
     pub fn enumerate_surfaces(&mut self) -> Result<OutputChanges> {
         // enumerate our outputs
-        let config =
-            drm_helpers::display_configuration(self.drm.device_mut(), self.supports_atomic)?;
+        let config = drm_helpers::display_configuration(self.drm.device_mut())?;
 
         let surfaces = self
             .inner

--- a/src/backend/kms/drm_helpers.rs
+++ b/src/backend/kms/drm_helpers.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result, anyhow};
 use libdisplay_info::{edid::DisplayDescriptorTag, info::Info};
 use smithay::{
+    backend::drm::DrmDevice,
     reexports::drm::control::{
         AtomicCommitFlags, Device as ControlDevice, Mode, ModeFlags, PlaneType, ResourceHandle,
         atomic::AtomicModeReq,
@@ -16,8 +17,7 @@ use smithay::{
 use std::{collections::HashMap, ops::Range};
 
 pub fn display_configuration(
-    device: &mut impl ControlDevice,
-    supports_atomic: bool,
+    device: &mut DrmDevice,
 ) -> Result<HashMap<connector::Handle, Option<crtc::Handle>>> {
     let res_handles = device.resource_handles()?;
     let connectors = res_handles.connectors();
@@ -73,7 +73,7 @@ pub fn display_configuration(
     }
 
     // And then cleanup
-    if supports_atomic {
+    if device.is_atomic() {
         let mut req = AtomicModeReq::new();
         let plane_handles = device.plane_handles()?;
 
@@ -105,24 +105,20 @@ pub fn display_configuration(
             let _ = device.set_cursor(*crtc, Option::<&DumbBuffer>::None);
         }
     }
-    disable_crtcs(device, supports_atomic, &cleanup)?;
+    disable_crtcs(device, &cleanup)?;
 
     Ok(map)
 }
 
 /// Disables the given CRTCs and detaches their connectors/planes.
-pub fn disable_crtcs(
-    device: &mut impl ControlDevice,
-    supports_atomic: bool,
-    crtcs: &[crtc::Handle],
-) -> Result<()> {
+pub fn disable_crtcs(device: &mut DrmDevice, crtcs: &[crtc::Handle]) -> Result<()> {
     if crtcs.is_empty() {
         return Ok(());
     }
 
     let res_handles = device.resource_handles()?;
 
-    if supports_atomic {
+    if device.is_atomic() {
         let mut req = AtomicModeReq::new();
 
         for conn in res_handles

--- a/src/backend/kms/drm_helpers.rs
+++ b/src/backend/kms/drm_helpers.rs
@@ -77,24 +77,6 @@ pub fn display_configuration(
         let mut req = AtomicModeReq::new();
         let plane_handles = device.plane_handles()?;
 
-        for conn in connectors
-            .iter()
-            .flat_map(|conn| device.get_connector(*conn, false).ok())
-            .filter(|conn| {
-                if let Some(enc) = conn.current_encoder()
-                    && let Ok(enc) = device.get_encoder(enc)
-                    && let Some(crtc) = enc.crtc()
-                {
-                    return cleanup.contains(&crtc);
-                }
-                false
-            })
-            .map(|info| info.handle())
-        {
-            let crtc_id = get_prop(device, conn, "CRTC_ID")?;
-            req.add_property(conn, crtc_id, property::Value::CRTC(None));
-        }
-
         // We cannot just shortcut and use the legacy api for all cleanups because of this.
         // (Technically a device does not need to be atomic for planes to be used, but nobody does this otherwise.)
         for plane in plane_handles {
@@ -108,7 +90,7 @@ pub fn display_configuration(
                         _ => false,
                     },
                 )?;
-                if cleanup.contains(&crtc) || !is_primary {
+                if !is_primary && !cleanup.contains(&crtc) {
                     let crtc_id = get_prop(device, plane, "CRTC_ID")?;
                     let fb_id = get_prop(device, plane, "FB_ID")?;
                     req.add_property(plane, crtc_id, property::Value::CRTC(None));
@@ -116,27 +98,80 @@ pub fn display_configuration(
                 }
             }
         }
-
-        for crtc in cleanup {
-            let mode_id = get_prop(device, crtc, "MODE_ID")?;
-            let active = get_prop(device, crtc, "ACTIVE")?;
-            req.add_property(crtc, active, property::Value::Boolean(false));
-            req.add_property(crtc, mode_id, property::Value::Unknown(0));
-        }
-
         device.atomic_commit(AtomicCommitFlags::ALLOW_MODESET, req)?;
     } else {
         for crtc in res_handles.crtcs() {
             #[allow(deprecated)]
             let _ = device.set_cursor(*crtc, Option::<&DumbBuffer>::None);
         }
-        for crtc in cleanup {
+    }
+    disable_crtcs(device, supports_atomic, &cleanup)?;
+
+    Ok(map)
+}
+
+/// Disables the given CRTCs and detaches their connectors/planes.
+pub fn disable_crtcs(
+    device: &mut impl ControlDevice,
+    supports_atomic: bool,
+    crtcs: &[crtc::Handle],
+) -> Result<()> {
+    if crtcs.is_empty() {
+        return Ok(());
+    }
+
+    let res_handles = device.resource_handles()?;
+
+    if supports_atomic {
+        let mut req = AtomicModeReq::new();
+
+        for conn in res_handles
+            .connectors()
+            .iter()
+            .flat_map(|conn| device.get_connector(*conn, false).ok())
+            .filter(|conn| {
+                if let Some(enc) = conn.current_encoder()
+                    && let Ok(enc) = device.get_encoder(enc)
+                    && let Some(crtc) = enc.crtc()
+                {
+                    return crtcs.contains(&crtc);
+                }
+                false
+            })
+            .map(|info| info.handle())
+        {
+            let crtc_id = get_prop(device, conn, "CRTC_ID")?;
+            req.add_property(conn, crtc_id, property::Value::CRTC(None));
+        }
+
+        for plane in device.plane_handles()? {
+            let info = device.get_plane(plane)?;
+            if let Some(crtc) = info.crtc()
+                && crtcs.contains(&crtc)
+            {
+                let crtc_id = get_prop(device, plane, "CRTC_ID")?;
+                let fb_id = get_prop(device, plane, "FB_ID")?;
+                req.add_property(plane, crtc_id, property::Value::CRTC(None));
+                req.add_property(plane, fb_id, property::Value::Framebuffer(None));
+            }
+        }
+
+        for crtc in crtcs {
+            let mode_id = get_prop(device, *crtc, "MODE_ID")?;
+            let active = get_prop(device, *crtc, "ACTIVE")?;
+            req.add_property(*crtc, active, property::Value::Boolean(false));
+            req.add_property(*crtc, mode_id, property::Value::Unknown(0));
+        }
+
+        device.atomic_commit(AtomicCommitFlags::ALLOW_MODESET, req)?;
+    } else {
+        for crtc in crtcs {
             // null commit (necessary to trigger removal on the kernel side with the legacy api.)
-            let _ = device.set_crtc(crtc, None, (0, 0), &[], None);
+            let _ = device.set_crtc(*crtc, None, (0, 0), &[], None);
         }
     }
 
-    Ok(map)
+    Ok(())
 }
 
 pub fn interface_name(device: &impl ControlDevice, connector: connector::Handle) -> Result<String> {

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -852,11 +852,26 @@ impl KmsGuard<'_> {
 
             // first drop old surfaces
             if !test_only {
-                for output in outputs.iter().filter(|o| !o.is_enabled()) {
-                    device
-                        .inner
-                        .surfaces
-                        .retain(|_, surface| surface.output != *output);
+                let mut disabled_crtcs = Vec::new();
+                device.inner.surfaces.retain(|crtc, surface| {
+                    if outputs
+                        .iter()
+                        .any(|o| !o.is_enabled() && surface.output == *o)
+                    {
+                        disabled_crtcs.push(*crtc);
+                        false
+                    } else {
+                        true
+                    }
+                });
+
+                let supports_atomic = device.drm.device().is_atomic();
+                if let Err(err) = drm_helpers::disable_crtcs(
+                    device.drm.device_mut(),
+                    supports_atomic,
+                    &disabled_crtcs,
+                ) {
+                    warn!("Failed to disable crtcs for disabled outputs: {err}");
                 }
             }
 

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -865,12 +865,9 @@ impl KmsGuard<'_> {
                     }
                 });
 
-                let supports_atomic = device.drm.device().is_atomic();
-                if let Err(err) = drm_helpers::disable_crtcs(
-                    device.drm.device_mut(),
-                    supports_atomic,
-                    &disabled_crtcs,
-                ) {
+                if let Err(err) =
+                    drm_helpers::disable_crtcs(device.drm.device_mut(), &disabled_crtcs)
+                {
                     warn!("Failed to disable crtcs for disabled outputs: {err}");
                 }
             }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This PR fixes this issue https://github.com/pop-os/cosmic-epoch/issues/2933. In summary, when you disable a laptops screen in the display configuration menu due to having external monitors connected, on boot, the laptop screen will retain the last frame buffer. This effectively means, that the laptop screen, although disabled in the COSMIC settings, is active and holding a frame forever. This is especially bad for OLED screens due to burn in risk. 
The workaround so far was, on every login open the settings and turn the laptop screen on and off. 

LLM disclosure: Claude Opus came up with the initial idea, but I had to refactor it due to unnecessary code duplication and the usual excessive comments. I can reason about the changes. 

What is this MR changing:
- extracted the clean up logic for disabling CRTs that was already present in the `display_configuration` method into a new function `disable_crts` (that's the largest part of the diff really) 
- use the `disable_crts` function in `apply_config_for_outputs` - after finding out which monitors should be powered down, actually power them down (this part missing caused the bug).
- Regarding the change `if !is_primary && !cleanup.contains(&crtc) {`: clean up is done now in the separate function. to keep responsabilities where they should, this no longer cleans up

I tested: 
- the issue is 100% reproducible on main 
- my MR fixes the issue 
- my MR does not break turning on/off screens from the settings menu or starting with a different permutation of display config.

Awesome work btw, I'm daily driving this DE for almost 2 years now and its shaped up so nice :) 