### PR TITLE
fix: a11y: magnifier: change ZoomState::update_focal_point to use f64 to avoid rounding errors

### DIFF
--- a/src/shell/zoom.rs
+++ b/src/shell/zoom.rs
@@ -259,10 +259,8 @@ impl ZoomState {
         original_position: Point<f64, Global>,
         movement: ZoomMovement,
     ) {
-        let cursor_position = cursor_position.to_i32_round();
-        let original_position = original_position.to_i32_round();
-        let output_geometry = output.geometry();
-        let mut zoomed_output_geometry = output.zoomed_geometry().unwrap();
+        let output_geometry = output.geometry().to_f64();
+        let mut zoomed_output_geometry = output.zoomed_geometry().unwrap().to_f64();
 
         let output_state = output.user_data().get::<Mutex<OutputZoomState>>().unwrap();
         let mut output_state_ref = output_state.lock().unwrap();
@@ -275,44 +273,40 @@ impl ZoomState {
 
         let cursor_position = cursor_position.to_local(output);
         match movement {
-            ZoomMovement::Continuously => output_state_ref.focal_point = cursor_position.to_f64(),
+            ZoomMovement::Continuously => output_state_ref.focal_point = cursor_position,
             ZoomMovement::OnEdge => {
                 if !zoomed_output_geometry
-                    .overlaps_or_touches(Rectangle::new(original_position, Size::from((16, 16))))
+                    .overlaps_or_touches(Rectangle::new(original_position, Size::from((16., 16.))))
                 {
                     zoomed_output_geometry.loc = cursor_position.to_global(output)
-                        - zoomed_output_geometry.size.downscale(2).to_point();
+                        - zoomed_output_geometry.size.downscale(2.).to_point();
                     let mut focal_point = zoomed_output_geometry
                         .loc
                         .to_local(output)
-                        .upscale(
-                            output_geometry.size.w
-                                / (output_geometry.size.w - zoomed_output_geometry.size.w),
-                        )
+                        .upscale(output_state_ref.level)
                         .to_global(output);
                     focal_point.x = focal_point.x.clamp(
                         output_geometry.loc.x,
-                        output_geometry.loc.x + output_geometry.size.w - 1,
+                        output_geometry.loc.x + output_geometry.size.w - 1.,
                     );
                     focal_point.y = focal_point.y.clamp(
                         output_geometry.loc.y,
-                        output_geometry.loc.y + output_geometry.size.h - 1,
+                        output_geometry.loc.y + output_geometry.size.h - 1.,
                     );
                     output_state_ref.previous_point =
                         Some((output_state_ref.focal_point, Instant::now()));
-                    output_state_ref.focal_point = focal_point.to_local(output).to_f64();
+                    output_state_ref.focal_point = focal_point.to_local(output);
                 } else if !zoomed_output_geometry.contains(cursor_position.to_global(output)) {
                     let mut diff = output_state_ref.focal_point.to_global(output)
                         + (cursor_position.to_global(output) - original_position)
-                            .to_f64()
                             .upscale(output_state_ref.level);
                     diff.x = diff.x.clamp(
-                        output_geometry.loc.x as f64,
-                        ((output_geometry.loc.x + output_geometry.size.w) as f64).next_down(),
+                        output_geometry.loc.x,
+                        (output_geometry.loc.x + output_geometry.size.w).next_down(),
                     );
                     diff.y = diff.y.clamp(
-                        output_geometry.loc.y as f64,
-                        ((output_geometry.loc.y + output_geometry.size.h) as f64).next_down(),
+                        output_geometry.loc.y,
+                        (output_geometry.loc.y + output_geometry.size.h).next_down(),
                     );
                     diff -= output_state_ref.focal_point.to_global(output);
 
@@ -321,28 +315,27 @@ impl ZoomState {
             }
             ZoomMovement::Centered => {
                 zoomed_output_geometry.loc = cursor_position.to_global(output)
-                    - zoomed_output_geometry.size.downscale(2).to_point();
+                    - zoomed_output_geometry.size.downscale(2.).to_point();
 
                 let mut focal_point = zoomed_output_geometry
                     .loc
                     .to_local(output)
                     .upscale(
-                        output_geometry
-                            .size
-                            .w
-                            .checked_div(output_geometry.size.w - zoomed_output_geometry.size.w)
-                            .unwrap_or(1),
+                        (output_geometry.size.w
+                            / (output_geometry.size.w - zoomed_output_geometry.size.w)
+                                .max(f64::EPSILON))
+                        .max(1.),
                     )
                     .to_global(output);
                 focal_point.x = focal_point.x.clamp(
                     output_geometry.loc.x,
-                    output_geometry.loc.x + output_geometry.size.w - 1,
+                    output_geometry.loc.x + output_geometry.size.w - 1.,
                 );
                 focal_point.y = focal_point.y.clamp(
                     output_geometry.loc.y,
-                    output_geometry.loc.y + output_geometry.size.h - 1,
+                    output_geometry.loc.y + output_geometry.size.h - 1.,
                 );
-                output_state_ref.focal_point = focal_point.to_local(output).to_f64();
+                output_state_ref.focal_point = focal_point.to_local(output);
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes #2515  (erratic cursor movement in magnifier when **Zoomed view moves** mode is **To keep pointer centered** -- `ZoomMovement::Centered`).

Please see the issue for full description and screen recording.

By changing the coordinate calculations in `ZoomState::update_focal_point` from `i32` to `f64`, we avoid:
- truncating integer division that results in miscalculation of the focal point;
- potential other edge cases related to the same issue.

Tagging @Drakulix  and @leviport , thanks for your help with my last PR!

## Screen recording of fix

Attached in comment...

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

