### PR TITLE
fix: map_window_request should update pending state

### DIFF
--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -807,9 +807,17 @@ impl XwmHandler for State {
                 *context,
             );
         }
-        if !shell.pending_windows.iter().any(|w| w.surface == window) {
-            let fullscreen = window.is_fullscreen().then(|| seat.active_output());
-            let maximized = window.is_maximized();
+        let fullscreen = window.is_fullscreen().then(|| seat.active_output());
+        let maximized = window.is_maximized();
+        if let Some(pending) = shell
+            .pending_windows
+            .iter_mut()
+            .find(|w| w.surface == window)
+        {
+            pending.seat = seat;
+            pending.fullscreen = fullscreen;
+            pending.maximized = maximized;
+        } else {
             let surface = CosmicSurface::from(window);
             shell.pending_windows.push(PendingWindow {
                 surface,


### PR DESCRIPTION
map_window_request wouldn't update the pending state of the window which resulted in some games unmapping the window, setting it to fullscreen then remapping it and the window not ending up fullscreen(in my case it was Granblue Fantasy Relink) as the pending state wasn't updated.

There is a sister PR needed for that game to fully work: https://github.com/Smithay/smithay/pull/2089 for a separate issue.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

