### PR TITLE
kms/timings: fix idle GPU busy-loop from render_start collapsing to zero

### DIFF
--- a/src/backend/kms/surface/timings.rs
+++ b/src/backend/kms/surface/timings.rs
@@ -316,9 +316,15 @@ impl Timings {
             since_last.as_secs() * 1_000_000_000 + u64::from(since_last.subsec_nanos());
         let to_next_ns = (since_last_ns / refresh_interval_ns + 1) * refresh_interval_ns;
 
-        // If VRR is enabled and we are already a full frame or more behind schedule (i.e. this is
-        // a genuine missed-vblank recovery, not just the normal one-interval-ahead computation),
-        // assume that we can present immediately.
+        // If VRR is enabled and more than two full intervals have passed since last presentation,
+        // assume that we can present immediately. This is deliberately more conservative than
+        // "more than one interval" (the original condition): at higher refresh rates the original
+        // threshold was met on essentially every steady-state frame, not just on a genuine
+        // late/missed vblank, which kept re-triggering Timer::immediate() and starving the GPU of
+        // idle time between frames. This does trade off some presentation latency for content that
+        // legitimately becomes ready between one and two intervals after the last presentation;
+        // a more precise fix would need to distinguish that case (e.g. via damage tracking) rather
+        // than widening this threshold.
         if self.vrr && to_next_ns > 2 * refresh_interval_ns {
             Duration::ZERO
         } else {
@@ -382,27 +388,21 @@ impl Timings {
             return Duration::ZERO;
         }
 
-        // When the deadline (estimated_presentation_time - margin) has already passed, don't
-        // collapse to Duration::ZERO: that causes an immediate re-render right after the previous
-        // vblank instead of one scheduled just before the next vblank, keeping the GPU busy for
-        // (almost) the whole refresh interval instead of letting it idle. Floor to a small delay
-        // so rendering still happens close to, but not exactly at, the previous presentation.
-        const MIN_RENDER_TIME: Duration = Duration::from_millis(1);
+        let margin = self.avg_submittime(SAMPLE_TIME_WINDOW).unwrap_or(baseline) + BASE_SAFETY_MARGIN;
 
-        let Some(avg_submittime) = self.avg_submittime(SAMPLE_TIME_WINDOW) else {
-            let margin = baseline + BASE_SAFETY_MARGIN;
-            return if estimated_presentation_time > margin {
-                estimated_presentation_time - margin
-            } else {
-                MIN_RENDER_TIME
-            };
-        };
-
-        let margin = avg_submittime + BASE_SAFETY_MARGIN;
-        if estimated_presentation_time > margin {
-            estimated_presentation_time - margin
-        } else {
-            MIN_RENDER_TIME
+        // estimated_presentation_time <= margin doesn't mean the next vblank is physically
+        // unreachable, only that too little of the submission margin would remain before it if we
+        // rendered for it. Rather than collapsing to Duration::ZERO (or an arbitrary short delay)
+        // and forcing an immediate re-render right after the previous vblank, schedule against the
+        // next presentation target that still has the full submission margin ahead of it. This is
+        // not a latency optimization: on some inputs it defers the render further than a short
+        // fixed floor would, in exchange for the GPU getting to idle for most of the interval
+        // instead of spinning on repeated immediate renders.
+        let refresh_interval = Duration::from_nanos(refresh_interval.get());
+        let mut target = estimated_presentation_time;
+        while target <= margin {
+            target += refresh_interval;
         }
+        target - margin
     }
 }

--- a/src/backend/kms/surface/timings.rs
+++ b/src/backend/kms/surface/timings.rs
@@ -316,9 +316,10 @@ impl Timings {
             since_last.as_secs() * 1_000_000_000 + u64::from(since_last.subsec_nanos());
         let to_next_ns = (since_last_ns / refresh_interval_ns + 1) * refresh_interval_ns;
 
-        // If VRR is enabled and more than one frame passed since last presentation, assume that we
-        // can present immediately.
-        if self.vrr && to_next_ns > refresh_interval_ns {
+        // If VRR is enabled and we are already a full frame or more behind schedule (i.e. this is
+        // a genuine missed-vblank recovery, not just the normal one-interval-ahead computation),
+        // assume that we can present immediately.
+        if self.vrr && to_next_ns > 2 * refresh_interval_ns {
             Duration::ZERO
         } else {
             last_presentation_time + Duration::from_nanos(to_next_ns) - now
@@ -381,11 +382,27 @@ impl Timings {
             return Duration::ZERO;
         }
 
+        // When the deadline (estimated_presentation_time - margin) has already passed, don't
+        // collapse to Duration::ZERO: that causes an immediate re-render right after the previous
+        // vblank instead of one scheduled just before the next vblank, keeping the GPU busy for
+        // (almost) the whole refresh interval instead of letting it idle. Floor to a small delay
+        // so rendering still happens close to, but not exactly at, the previous presentation.
+        const MIN_RENDER_TIME: Duration = Duration::from_millis(1);
+
         let Some(avg_submittime) = self.avg_submittime(SAMPLE_TIME_WINDOW) else {
-            return estimated_presentation_time.saturating_sub(baseline + BASE_SAFETY_MARGIN);
+            let margin = baseline + BASE_SAFETY_MARGIN;
+            return if estimated_presentation_time > margin {
+                estimated_presentation_time - margin
+            } else {
+                MIN_RENDER_TIME
+            };
         };
 
         let margin = avg_submittime + BASE_SAFETY_MARGIN;
-        estimated_presentation_time.saturating_sub(margin)
+        if estimated_presentation_time > margin {
+            estimated_presentation_time - margin
+        } else {
+            MIN_RENDER_TIME
+        }
     }
 }


### PR DESCRIPTION
## Summary

Related to the ~20-25% idle `gpu_busy_percent` reported in #2153, reproduced on a non-Nvidia (AMD Phoenix1 iGPU) machine with one VRR output (144Hz eDP) and one non-VRR output (60Hz HDMI) — so the existing Nvidia-specific hack in `Timings::next_render_time()` was not the cause here.

Note: `next_render_time()` has an early `if self.vendor == Some(0x10de) { return Duration::ZERO; }` return for Nvidia, which runs before the `next_render_time()` fix below — so that half of this PR does not affect Nvidia hardware. The `next_presentation_time()` VRR-threshold fix also ends up masked on Nvidia by that same early return once it reaches `next_render_time()`. This PR is unlikely to be a full fix for #2153 on Nvidia; it targets the busy-loop reproduced on the AMD machine described above.

Root-caused via live `gdb`/`perf` instrumentation of a running KMS-backend session (no code changes to the live process, non-stopping `dprintf` breakpoints only). Confirmed with direct memory reads and call-rate probes that `queue_redraw`'s `render_start` was landing on `Duration::ZERO` (-> `Timer::immediate()`) on nearly every frame, via two independent branches in `timings.rs`:

- `Timings::next_presentation_time()`'s VRR-immediate check (`self.vrr && to_next_ns > refresh_interval_ns`) triggers whenever more than one refresh interval has elapsed since the last presentation — which is true on essentially every steady-state frame at higher refresh rates, not just on a genuine missed vblank. Confirmed firing on the 144Hz VRR output.
- `Timings::next_render_time()`'s final `saturating_sub(margin)` silently clamps to zero whenever the computed render deadline has already passed by even a few nanoseconds, instead of scheduling shortly before the *next* vblank. Confirmed firing independently (~60% of calls) on the non-VRR 60Hz output.

Both feed `queue_redraw` (`surface/mod.rs`) arming `Timer::immediate()` instead of a real pre-vblank deadline, so the compositor re-renders immediately after every vblank instead of idling between frames — keeping the GPU busy for nearly the entire refresh interval on an otherwise fully idle desktop.

## Changes

- `next_presentation_time()`: require the VRR-immediate branch to represent more than two full refresh intervals having elapsed since the last presentation, instead of firing on the normal one-interval-ahead computation that was true on essentially every steady-state frame. This trades off some presentation latency for VRR content that legitimately becomes ready between one and two intervals after the last presentation; a more precise fix would need damage tracking to distinguish that case, which is out of scope here.
- `next_render_time()`: instead of collapsing to `Duration::ZERO` (or an arbitrary fixed floor) when the computed deadline has already passed, roll the target forward one refresh interval at a time until it again has the full submission margin ahead of it, and schedule against that. This is not a latency optimization — on some inputs it defers the render further than a short fixed delay would — but it avoids repeatedly re-triggering immediate-render behavior right after the previous vblank, letting the GPU idle over more of the interval instead.

## Test plan

- [x] `cargo check --lib` passes
- [x] Reproduced the original ~1200+ `queue_redraw`/`Timer::immediate()` calls-per-second behavior live via gdb `dprintf` probes on both outputs before the fix
- [x] Built and installed on the actual reporting machine in place of the stock package binary, logged back into a real KMS session running it live: idle `gpu_busy_percent` dropped from ~20-25% to a steady 6-8%, confirmed via `/sys/class/drm/card*/device/gpu_busy_percent`

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
