### PR TITLE
Fix fullscreening a window out of a stack + foreign-toplevel-list ghost entries

### DIFF
--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -532,6 +532,15 @@ impl CosmicMapped {
         }
     }
 
+    /// Whether the wire keyboard focus must be re-asserted even though this
+    /// element is already the keyboard focus target: a stack's active tab can
+    /// change underneath the unchanged target, which smithay can't observe.
+    pub fn needs_reenter(&self, seat: &Seat<State>) -> bool {
+        self.stack_ref().is_some_and(|stack| {
+            surface::KeyboardEnteredSurface::get(seat).as_ref() != Some(&stack.active())
+        })
+    }
+
     pub fn convert_to_stack(
         &mut self,
         (output, overlap): (&Output, Rectangle<i32, Logical>),

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -1,5 +1,6 @@
 use super::{
     CosmicSurface,
+    surface::KeyboardEnteredSurface,
     window::{Focus, RESIZE_BORDER},
 };
 use crate::{
@@ -113,10 +114,8 @@ pub struct CosmicStackInternal {
     group_focused: AtomicBool,
     previous_index: Mutex<Option<(Serial, usize)>>,
     scroll_to_focus: AtomicBool,
-    previous_keyboard: AtomicUsize,
     pointer_entered: AtomicU8,
     touch_serial: AtomicU32,
-    reenter: AtomicBool,
     potential_drag: Mutex<Option<usize>>,
     override_alive: AtomicBool,
     geometry: Mutex<Option<Rectangle<i32, Global>>>,
@@ -171,10 +170,8 @@ impl CosmicStack {
                 group_focused: AtomicBool::new(false),
                 previous_index: Mutex::new(None),
                 scroll_to_focus: AtomicBool::new(false),
-                previous_keyboard: AtomicUsize::new(0),
                 pointer_entered: AtomicU8::new(0),
                 touch_serial: AtomicU32::new(0),
-                reenter: AtomicBool::new(false),
                 potential_drag: Mutex::new(None),
                 override_alive: AtomicBool::new(true),
                 geometry: Mutex::new(None),
@@ -213,11 +210,7 @@ impl CosmicStack {
             window.send_configure();
             if let Some(idx) = idx {
                 p.windows.lock().unwrap().insert(idx, window);
-                let old_idx = p.active.swap(idx, Ordering::SeqCst);
-                if old_idx == idx {
-                    p.reenter.store(true, Ordering::SeqCst);
-                    p.previous_keyboard.store(old_idx, Ordering::SeqCst);
-                }
+                p.active.store(idx, Ordering::SeqCst);
             } else {
                 let mut windows = p.windows.lock().unwrap();
                 windows.push(window);
@@ -244,9 +237,6 @@ impl CosmicStack {
             let Some(idx) = windows.iter().position(|w| w == window) else {
                 return;
             };
-            if idx == p.active.load(Ordering::SeqCst) {
-                p.reenter.store(true, Ordering::SeqCst);
-            }
             let window = windows.remove(idx);
             window.try_force_undecorated(false);
             window.set_tiled(false);
@@ -274,9 +264,6 @@ impl CosmicStack {
             }
             if windows.len() <= idx {
                 return None;
-            }
-            if idx == p.active.load(Ordering::SeqCst) {
-                p.reenter.store(true, Ordering::SeqCst);
             }
             let window = windows.remove(idx);
             window.try_force_undecorated(false);
@@ -316,20 +303,18 @@ impl CosmicStack {
             match direction {
                 FocusDirection::Left => {
                     if !p.group_focused.load(Ordering::SeqCst) {
-                        if let Ok(old) =
-                            p.active
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
-                                    val.checked_sub(1)
-                                })
+                        if p.active
+                            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+                                val.checked_sub(1)
+                            })
+                            .is_ok()
                         {
-                            p.previous_keyboard.store(old, Ordering::SeqCst);
                             p.scroll_to_focus.store(true, Ordering::SeqCst);
                             (true, true)
                         } else {
                             let new = prev_idx.unwrap().1;
                             let old = p.active.swap(new, Ordering::SeqCst);
                             if old != new {
-                                p.previous_keyboard.store(old, Ordering::SeqCst);
                                 p.scroll_to_focus.store(true, Ordering::SeqCst);
                                 (false, true)
                             } else {
@@ -343,20 +328,19 @@ impl CosmicStack {
                 FocusDirection::Right => {
                     if !p.group_focused.load(Ordering::SeqCst) {
                         let max = p.windows.lock().unwrap().len();
-                        if let Ok(old) =
-                            p.active
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
-                                    if val < max - 1 { Some(val + 1) } else { None }
-                                })
+                        if p
+                            .active
+                            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+                                if val < max - 1 { Some(val + 1) } else { None }
+                            })
+                            .is_ok()
                         {
-                            p.previous_keyboard.store(old, Ordering::SeqCst);
                             p.scroll_to_focus.store(true, Ordering::SeqCst);
                             (true, true)
                         } else {
                             let new = prev_idx.unwrap().1;
                             let old = p.active.swap(new, Ordering::SeqCst);
                             if old != new {
-                                p.previous_keyboard.store(old, Ordering::SeqCst);
                                 p.scroll_to_focus.store(true, Ordering::SeqCst);
                                 (false, true)
                             } else {
@@ -400,7 +384,6 @@ impl CosmicStack {
                         let new = prev_idx.unwrap().1;
                         let old = p.active.swap(new, Ordering::SeqCst);
                         if old != new {
-                            p.previous_keyboard.store(old, Ordering::SeqCst);
                             p.scroll_to_focus.store(true, Ordering::SeqCst);
                         }
                         (false, true)
@@ -441,7 +424,6 @@ impl CosmicStack {
             if let Some(val) = next {
                 let old = p.active.swap(val, Ordering::SeqCst);
                 windows.swap(old, val);
-                p.previous_keyboard.store(old, Ordering::SeqCst);
                 p.scroll_to_focus.store(true, Ordering::SeqCst);
                 MoveResult::Handled
             } else {
@@ -495,10 +477,7 @@ impl CosmicStack {
     {
         self.0.with_program(|p| {
             if let Some(val) = p.windows.lock().unwrap().iter().position(|w| w == window) {
-                let old = p.active.swap(val, Ordering::SeqCst);
-                if old != val {
-                    p.previous_keyboard.store(old, Ordering::SeqCst);
-                }
+                p.active.store(val, Ordering::SeqCst);
             }
         });
         self.0
@@ -612,29 +591,21 @@ impl CosmicStack {
         }
     }
 
-    fn keyboard_leave_if_previous(
+    /// Enters the active tab iff it does not already hold the wire keyboard
+    /// focus, per the seat's [`KeyboardEnteredSurface`] record; returns the
+    /// active index.
+    fn keyboard_enter_active(
         &self,
         seat: &Seat<State>,
         data: &mut State,
+        keys: Vec<KeysymHandle<'_>>,
         serial: Serial,
     ) -> usize {
         self.0.with_program(|p| {
             let active = p.active.load(Ordering::SeqCst);
-            let previous = p.previous_keyboard.swap(active, Ordering::SeqCst);
-            if previous != active || p.reenter.swap(false, Ordering::SeqCst) {
-                let windows = p.windows.lock().unwrap();
-                if let Some(previous_surface) = windows.get(previous)
-                    && previous != active
-                {
-                    KeyboardTarget::leave(previous_surface, seat, data, serial);
-                }
-                KeyboardTarget::enter(
-                    &windows[active],
-                    seat,
-                    data,
-                    Vec::new(), /* TODO */
-                    serial,
-                )
+            let active_surface = p.windows.lock().unwrap()[active].clone();
+            if KeyboardEnteredSurface::get(seat).as_ref() != Some(&active_surface) {
+                KeyboardTarget::enter(&active_surface, seat, data, keys, serial);
             }
             active
         })
@@ -1513,24 +1484,22 @@ impl KeyboardTarget<State> for CosmicStack {
         keys: Vec<KeysymHandle<'_>>,
         serial: Serial,
     ) {
-        self.0.with_program(|p| {
-            let active = p.active.load(Ordering::SeqCst);
-            p.previous_keyboard.store(active, Ordering::SeqCst);
-            KeyboardTarget::enter(
-                &p.windows.lock().unwrap()[p.active.load(Ordering::SeqCst)],
-                seat,
-                data,
-                keys,
-                serial,
-            )
-        })
+        self.keyboard_enter_active(seat, data, keys, serial);
     }
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial) {
-        let active = self.keyboard_leave_if_previous(seat, data, serial);
         self.0.force_redraw();
         self.0.with_program(|p| {
             p.group_focused.store(false, Ordering::SeqCst);
-            KeyboardTarget::leave(&p.windows.lock().unwrap()[active], seat, data, serial)
+
+            // Release the focus from whichever of our surfaces actually holds
+            // it; if the entered surface was just extracted, it took the wire
+            // focus with it - nothing to release.
+            let windows = p.windows.lock().unwrap();
+            if let Some(entered) =
+                KeyboardEnteredSurface::get(seat).filter(|s| windows.contains(s))
+            {
+                KeyboardTarget::leave(&entered, seat, data, serial);
+            }
         })
     }
     fn key(
@@ -1542,7 +1511,7 @@ impl KeyboardTarget<State> for CosmicStack {
         serial: Serial,
         time: u32,
     ) {
-        let active = self.keyboard_leave_if_previous(seat, data, serial);
+        let active = self.keyboard_enter_active(seat, data, Vec::new(), serial);
         self.0.with_program(|p| {
             if !p.group_focused.load(Ordering::SeqCst) {
                 KeyboardTarget::key(
@@ -1564,7 +1533,7 @@ impl KeyboardTarget<State> for CosmicStack {
         modifiers: ModifiersState,
         serial: Serial,
     ) {
-        let active = self.keyboard_leave_if_previous(seat, data, serial);
+        let active = self.keyboard_enter_active(seat, data, Vec::new(), serial);
         self.0.with_program(|p| {
             if !p.group_focused.load(Ordering::SeqCst) {
                 KeyboardTarget::modifiers(

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -603,7 +603,11 @@ impl CosmicStack {
     ) -> usize {
         self.0.with_program(|p| {
             let active = p.active.load(Ordering::SeqCst);
-            let active_surface = p.windows.lock().unwrap()[active].clone();
+            // The active index and the window list update separately - the
+            // index may be stale here.
+            let Some(active_surface) = p.windows.lock().unwrap().get(active).cloned() else {
+                return active;
+            };
             if KeyboardEnteredSurface::get(seat).as_ref() != Some(&active_surface) {
                 KeyboardTarget::enter(&active_surface, seat, data, keys, serial);
             }
@@ -1513,16 +1517,10 @@ impl KeyboardTarget<State> for CosmicStack {
     ) {
         let active = self.keyboard_enter_active(seat, data, Vec::new(), serial);
         self.0.with_program(|p| {
-            if !p.group_focused.load(Ordering::SeqCst) {
-                KeyboardTarget::key(
-                    &p.windows.lock().unwrap()[active],
-                    seat,
-                    data,
-                    key,
-                    state,
-                    serial,
-                    time,
-                )
+            if !p.group_focused.load(Ordering::SeqCst)
+                && let Some(window) = p.windows.lock().unwrap().get(active)
+            {
+                KeyboardTarget::key(window, seat, data, key, state, serial, time)
             }
         })
     }
@@ -1535,14 +1533,10 @@ impl KeyboardTarget<State> for CosmicStack {
     ) {
         let active = self.keyboard_enter_active(seat, data, Vec::new(), serial);
         self.0.with_program(|p| {
-            if !p.group_focused.load(Ordering::SeqCst) {
-                KeyboardTarget::modifiers(
-                    &p.windows.lock().unwrap()[active],
-                    seat,
-                    data,
-                    modifiers,
-                    serial,
-                )
+            if !p.group_focused.load(Ordering::SeqCst)
+                && let Some(window) = p.windows.lock().unwrap().get(active)
+            {
+                KeyboardTarget::modifiers(window, seat, data, modifiers, serial)
             }
         })
     }

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -1,5 +1,6 @@
 use super::{
     CosmicSurface,
+    surface::KeyboardEnteredSurface,
     window::{Focus, RESIZE_BORDER},
 };
 use crate::{
@@ -109,10 +110,8 @@ pub struct CosmicStackInternal {
     group_focused: AtomicBool,
     previous_index: Mutex<Option<(Serial, usize)>>,
     scroll_to_focus: AtomicBool,
-    previous_keyboard: AtomicUsize,
     pointer_entered: AtomicU8,
     touch_serial: AtomicU32,
-    reenter: AtomicBool,
     potential_drag: Mutex<Option<usize>>,
     override_alive: AtomicBool,
     geometry: Mutex<Option<Rectangle<i32, Global>>>,
@@ -168,10 +167,8 @@ impl CosmicStack {
                 group_focused: AtomicBool::new(false),
                 previous_index: Mutex::new(None),
                 scroll_to_focus: AtomicBool::new(false),
-                previous_keyboard: AtomicUsize::new(0),
                 pointer_entered: AtomicU8::new(0),
                 touch_serial: AtomicU32::new(0),
-                reenter: AtomicBool::new(false),
                 potential_drag: Mutex::new(None),
                 override_alive: AtomicBool::new(true),
                 geometry: Mutex::new(None),
@@ -210,11 +207,7 @@ impl CosmicStack {
             window.send_configure();
             if let Some(idx) = idx {
                 p.windows.lock().unwrap().insert(idx, window);
-                let old_idx = p.active.swap(idx, Ordering::SeqCst);
-                if old_idx == idx {
-                    p.reenter.store(true, Ordering::SeqCst);
-                    p.previous_keyboard.store(old_idx, Ordering::SeqCst);
-                }
+                p.active.store(idx, Ordering::SeqCst);
             } else {
                 let mut windows = p.windows.lock().unwrap();
                 windows.push(window);
@@ -241,9 +234,6 @@ impl CosmicStack {
             let Some(idx) = windows.iter().position(|w| w == window) else {
                 return;
             };
-            if idx == p.active.load(Ordering::SeqCst) {
-                p.reenter.store(true, Ordering::SeqCst);
-            }
             let window = windows.remove(idx);
             window.try_force_undecorated(false);
             window.set_tiled(false);
@@ -271,9 +261,6 @@ impl CosmicStack {
             }
             if windows.len() <= idx {
                 return None;
-            }
-            if idx == p.active.load(Ordering::SeqCst) {
-                p.reenter.store(true, Ordering::SeqCst);
             }
             let window = windows.remove(idx);
             window.try_force_undecorated(false);
@@ -313,20 +300,18 @@ impl CosmicStack {
             match direction {
                 FocusDirection::Left => {
                     if !p.group_focused.load(Ordering::SeqCst) {
-                        if let Ok(old) =
-                            p.active
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
-                                    val.checked_sub(1)
-                                })
+                        if p.active
+                            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+                                val.checked_sub(1)
+                            })
+                            .is_ok()
                         {
-                            p.previous_keyboard.store(old, Ordering::SeqCst);
                             p.scroll_to_focus.store(true, Ordering::SeqCst);
                             (true, true)
                         } else {
                             let new = prev_idx.unwrap().1;
                             let old = p.active.swap(new, Ordering::SeqCst);
                             if old != new {
-                                p.previous_keyboard.store(old, Ordering::SeqCst);
                                 p.scroll_to_focus.store(true, Ordering::SeqCst);
                                 (false, true)
                             } else {
@@ -340,20 +325,18 @@ impl CosmicStack {
                 FocusDirection::Right => {
                     if !p.group_focused.load(Ordering::SeqCst) {
                         let max = p.windows.lock().unwrap().len();
-                        if let Ok(old) =
-                            p.active
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
-                                    if val < max - 1 { Some(val + 1) } else { None }
-                                })
+                        if p.active
+                            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+                                if val < max - 1 { Some(val + 1) } else { None }
+                            })
+                            .is_ok()
                         {
-                            p.previous_keyboard.store(old, Ordering::SeqCst);
                             p.scroll_to_focus.store(true, Ordering::SeqCst);
                             (true, true)
                         } else {
                             let new = prev_idx.unwrap().1;
                             let old = p.active.swap(new, Ordering::SeqCst);
                             if old != new {
-                                p.previous_keyboard.store(old, Ordering::SeqCst);
                                 p.scroll_to_focus.store(true, Ordering::SeqCst);
                                 (false, true)
                             } else {
@@ -397,7 +380,6 @@ impl CosmicStack {
                         let new = prev_idx.unwrap().1;
                         let old = p.active.swap(new, Ordering::SeqCst);
                         if old != new {
-                            p.previous_keyboard.store(old, Ordering::SeqCst);
                             p.scroll_to_focus.store(true, Ordering::SeqCst);
                         }
                         (false, true)
@@ -438,7 +420,6 @@ impl CosmicStack {
             if let Some(val) = next {
                 let old = p.active.swap(val, Ordering::SeqCst);
                 windows.swap(old, val);
-                p.previous_keyboard.store(old, Ordering::SeqCst);
                 p.scroll_to_focus.store(true, Ordering::SeqCst);
                 MoveResult::Handled
             } else {
@@ -492,10 +473,7 @@ impl CosmicStack {
     {
         self.0.with_program(|p| {
             if let Some(val) = p.windows.lock().unwrap().iter().position(|w| w == window) {
-                let old = p.active.swap(val, Ordering::SeqCst);
-                if old != val {
-                    p.previous_keyboard.store(old, Ordering::SeqCst);
-                }
+                p.active.store(val, Ordering::SeqCst);
             }
         });
         self.0
@@ -609,29 +587,21 @@ impl CosmicStack {
         }
     }
 
-    fn keyboard_leave_if_previous(
+    /// Enters the active tab iff it does not already hold the wire keyboard
+    /// focus, per the seat's [`KeyboardEnteredSurface`] record; returns the
+    /// active index.
+    fn keyboard_enter_active(
         &self,
         seat: &Seat<State>,
         data: &mut State,
+        keys: Vec<KeysymHandle<'_>>,
         serial: Serial,
     ) -> usize {
         self.0.with_program(|p| {
             let active = p.active.load(Ordering::SeqCst);
-            let previous = p.previous_keyboard.swap(active, Ordering::SeqCst);
-            if previous != active || p.reenter.swap(false, Ordering::SeqCst) {
-                let windows = p.windows.lock().unwrap();
-                if let Some(previous_surface) = windows.get(previous)
-                    && previous != active
-                {
-                    KeyboardTarget::leave(previous_surface, seat, data, serial);
-                }
-                KeyboardTarget::enter(
-                    &windows[active],
-                    seat,
-                    data,
-                    Vec::new(), /* TODO */
-                    serial,
-                )
+            let active_surface = p.windows.lock().unwrap()[active].clone();
+            if KeyboardEnteredSurface::get(seat).as_ref() != Some(&active_surface) {
+                KeyboardTarget::enter(&active_surface, seat, data, keys, serial);
             }
             active
         })
@@ -1530,24 +1500,20 @@ impl KeyboardTarget<State> for CosmicStack {
         keys: Vec<KeysymHandle<'_>>,
         serial: Serial,
     ) {
-        self.0.with_program(|p| {
-            let active = p.active.load(Ordering::SeqCst);
-            p.previous_keyboard.store(active, Ordering::SeqCst);
-            KeyboardTarget::enter(
-                &p.windows.lock().unwrap()[p.active.load(Ordering::SeqCst)],
-                seat,
-                data,
-                keys,
-                serial,
-            )
-        })
+        self.keyboard_enter_active(seat, data, keys, serial);
     }
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: Serial) {
-        let active = self.keyboard_leave_if_previous(seat, data, serial);
         self.0.force_redraw();
         self.0.with_program(|p| {
             p.group_focused.store(false, Ordering::SeqCst);
-            KeyboardTarget::leave(&p.windows.lock().unwrap()[active], seat, data, serial)
+
+            // An extracted surface takes the wire focus with it - only
+            // release a holder that is still one of ours.
+            let windows = p.windows.lock().unwrap();
+            if let Some(entered) = KeyboardEnteredSurface::get(seat).filter(|s| windows.contains(s))
+            {
+                KeyboardTarget::leave(&entered, seat, data, serial);
+            }
         })
     }
     fn key(
@@ -1559,7 +1525,7 @@ impl KeyboardTarget<State> for CosmicStack {
         serial: Serial,
         time: InputTime,
     ) {
-        let active = self.keyboard_leave_if_previous(seat, data, serial);
+        let active = self.keyboard_enter_active(seat, data, Vec::new(), serial);
         self.0.with_program(|p| {
             if !p.group_focused.load(Ordering::SeqCst) {
                 KeyboardTarget::key(
@@ -1581,7 +1547,7 @@ impl KeyboardTarget<State> for CosmicStack {
         modifiers: ModifiersState,
         serial: Serial,
     ) {
-        let active = self.keyboard_leave_if_previous(seat, data, serial);
+        let active = self.keyboard_enter_active(seat, data, Vec::new(), serial);
         self.0.with_program(|p| {
             if !p.group_focused.load(Ordering::SeqCst) {
                 KeyboardTarget::modifiers(

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -378,8 +378,16 @@ impl CosmicSurface {
                     });
                     with_states(toplevel.wl_surface(), |data| {
                         if let Some(kde_data) = data.data_map.get::<KdeDecorationData>() {
-                            for obj in kde_data.lock().unwrap().objs.iter() {
-                                obj.mode(KdeMode::Server);
+                            let kde_data = kde_data.lock().unwrap();
+                            // Prefer the recorded xdg preference; fall back to
+                            // the client's kde-decoration request.
+                            let mode = match previous_mode {
+                                Some(DecorationMode::ServerSide) => KdeMode::Server,
+                                Some(_) => KdeMode::Client,
+                                None => kde_data.mode.unwrap_or(KdeMode::Client),
+                            };
+                            for obj in kde_data.objs.iter() {
+                                obj.mode(mode);
                             }
                         }
                     })

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -1008,43 +1008,79 @@ impl SpaceElement for CosmicSurface {
     }
 }
 
+/// Enter/leave pairing bookkeeping for keyboard focus, generic so the
+/// decision table is unit-testable (a [`CosmicSurface`] cannot be constructed
+/// without a live compositor).
+#[derive(Debug)]
+pub struct EnteredTracker<S>(Mutex<Option<S>>);
+
+impl<S> Default for EnteredTracker<S> {
+    fn default() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+/// What an `enter` for a surface must translate to on the wire.
+#[derive(Debug)]
+pub enum EnterAction<S> {
+    /// The surface already holds an unpaired `enter` - don't re-send it.
+    AlreadyHeld,
+    /// Send the `enter`, releasing the stale holder first when one exists.
+    Enter { stale: Option<S> },
+}
+
+impl<S: Clone + PartialEq> EnteredTracker<S> {
+    /// The surface currently holding an unpaired `enter`, if it is still alive.
+    pub fn held(&self, alive: impl Fn(&S) -> bool) -> Option<S> {
+        self.0.lock().unwrap().clone().filter(|s| alive(s))
+    }
+
+    /// Record an `enter` for `next` and decide what to send on the wire.
+    pub fn on_enter(&self, next: &S, alive: impl Fn(&S) -> bool) -> EnterAction<S> {
+        let mut guard = self.0.lock().unwrap();
+        if guard.as_ref() == Some(next) {
+            return EnterAction::AlreadyHeld;
+        }
+        let stale = guard.replace(next.clone()).filter(|s| alive(s));
+        EnterAction::Enter { stale }
+    }
+
+    /// Record a `leave` for `left`; a leave for a non-holder changes nothing.
+    pub fn on_leave(&self, left: &S) {
+        let mut guard = self.0.lock().unwrap();
+        if guard.as_ref() == Some(left) {
+            *guard = None;
+        }
+    }
+}
+
 /// Tracks, per seat, which [`CosmicSurface`] holds the keyboard focus on the
 /// wire (received an `enter` not yet paired with a `leave`). All toplevel
 /// enters/leaves funnel through [`CosmicSurface`]'s [`KeyboardTarget`] impl,
 /// making this the ground truth for focus bookkeeping.
 #[derive(Debug, Default)]
-pub struct KeyboardEnteredSurface(Mutex<Option<CosmicSurface>>);
+pub struct KeyboardEnteredSurface(EnteredTracker<CosmicSurface>);
 
 impl KeyboardEnteredSurface {
     pub fn get(seat: &Seat<State>) -> Option<CosmicSurface> {
         seat.user_data()
             .get_or_insert::<Self, _>(Self::default)
             .0
-            .lock()
-            .unwrap()
-            .clone()
-            .filter(IsAlive::alive)
+            .held(IsAlive::alive)
     }
 
-    fn replace(seat: &Seat<State>, surface: &CosmicSurface) -> Option<CosmicSurface> {
+    fn on_enter(seat: &Seat<State>, surface: &CosmicSurface) -> EnterAction<CosmicSurface> {
         seat.user_data()
             .get_or_insert::<Self, _>(Self::default)
             .0
-            .lock()
-            .unwrap()
-            .replace(surface.clone())
+            .on_enter(surface, IsAlive::alive)
     }
 
-    fn clear_if(seat: &Seat<State>, surface: &CosmicSurface) {
-        let mut guard = seat
-            .user_data()
+    fn on_leave(seat: &Seat<State>, surface: &CosmicSurface) {
+        seat.user_data()
             .get_or_insert::<Self, _>(Self::default)
             .0
-            .lock()
-            .unwrap();
-        if guard.as_ref() == Some(surface) {
-            *guard = None;
-        }
+            .on_leave(surface)
     }
 }
 
@@ -1060,17 +1096,18 @@ impl KeyboardTarget<State> for CosmicSurface {
             keys = vec![];
         }
 
-        let previous = KeyboardEnteredSurface::replace(seat, self);
-        if previous.as_ref() == Some(self) {
+        match KeyboardEnteredSurface::on_enter(seat, self) {
             // A focus-target swap resolved to the same surface; re-sending
             // `enter` without an intervening `leave` is a protocol violation.
-            return;
-        }
-
-        // Release a stale unpaired `enter` left on another surface, or the
-        // client ends up believing two of its windows are focused at once.
-        if let Some(previous) = previous.filter(|prev| prev.alive()) {
-            KeyboardTarget::leave(&previous, seat, data, serial);
+            EnterAction::AlreadyHeld => return,
+            // Release a stale unpaired `enter` left on another surface, or the
+            // client ends up believing two of its windows are focused at once.
+            EnterAction::Enter {
+                stale: Some(previous),
+            } => {
+                KeyboardTarget::leave(&previous, seat, data, serial);
+            }
+            EnterAction::Enter { stale: None } => {}
         }
 
         match self.0.underlying_surface() {
@@ -1082,7 +1119,7 @@ impl KeyboardTarget<State> for CosmicSurface {
     }
 
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: smithay::utils::Serial) {
-        KeyboardEnteredSurface::clear_if(seat, self);
+        KeyboardEnteredSurface::on_leave(seat, self);
 
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
@@ -1168,5 +1205,81 @@ fn with_toplevel_state<T, F: FnOnce(Option<&smithay::wayland::shell::xdg::Toplev
         toplevel.with_pending_state(|pending| cb(Some(pending)))
     } else {
         toplevel.with_committed_state(cb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EnterAction, EnteredTracker};
+
+    fn alive(_: &u32) -> bool {
+        true
+    }
+
+    #[test]
+    fn first_enter_records_and_releases_nothing() {
+        let tracker = EnteredTracker::default();
+        match tracker.on_enter(&1, alive) {
+            EnterAction::Enter { stale: None } => {}
+            other => panic!("expected a clean enter, got {other:?}"),
+        }
+        assert_eq!(tracker.held(alive), Some(1));
+    }
+
+    #[test]
+    fn re_entering_the_holder_is_a_noop() {
+        // Regression: the compositor re-sent `enter` to the surface holding
+        // the focus on every stack extraction (14 enters vs 7 leaves on the
+        // wire in one session).
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        assert!(matches!(
+            tracker.on_enter(&1, alive),
+            EnterAction::AlreadyHeld
+        ));
+        assert_eq!(tracker.held(alive), Some(1));
+    }
+
+    #[test]
+    fn entering_releases_a_stale_alive_holder() {
+        // Regression: a missed leave let a client believe two of its windows
+        // were focused at once (for 71s in the captured session), making it
+        // deny fullscreen requests.
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        match tracker.on_enter(&2, alive) {
+            EnterAction::Enter { stale: Some(1) } => {}
+            other => panic!("expected the stale holder to be released, got {other:?}"),
+        }
+        assert_eq!(tracker.held(alive), Some(2));
+    }
+
+    #[test]
+    fn entering_does_not_release_a_dead_holder() {
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        match tracker.on_enter(&2, |s| *s != 1) {
+            EnterAction::Enter { stale: None } => {}
+            other => panic!("expected no release for a dead holder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn leave_clears_only_the_holder() {
+        // Pairing: a leave for a surface that does not hold the enter must
+        // not clear the record of the one that does.
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        tracker.on_leave(&2);
+        assert_eq!(tracker.held(alive), Some(1));
+        tracker.on_leave(&1);
+        assert_eq!(tracker.held(alive), None);
+    }
+
+    #[test]
+    fn held_ignores_a_dead_holder() {
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        assert_eq!(tracker.held(|_| false), None);
     }
 }

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -1052,11 +1052,16 @@ impl KeyboardTarget<State> for CosmicSurface {
             keys = vec![];
         }
 
+        let previous = KeyboardEnteredSurface::replace(seat, self);
+        if previous.as_ref() == Some(self) {
+            // A focus-target swap resolved to the same surface; re-sending
+            // `enter` without an intervening `leave` is a protocol violation.
+            return;
+        }
+
         // Release a stale unpaired `enter` left on another surface, or the
         // client ends up believing two of its windows are focused at once.
-        if let Some(previous) = KeyboardEnteredSurface::replace(seat, self)
-            .filter(|prev| prev != self && prev.alive())
-        {
+        if let Some(previous) = previous.filter(|prev| prev.alive()) {
             KeyboardTarget::leave(&previous, seat, data, serial);
         }
 

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -1000,6 +1000,46 @@ impl SpaceElement for CosmicSurface {
     }
 }
 
+/// Tracks, per seat, which [`CosmicSurface`] holds the keyboard focus on the
+/// wire (received an `enter` not yet paired with a `leave`). All toplevel
+/// enters/leaves funnel through [`CosmicSurface`]'s [`KeyboardTarget`] impl,
+/// making this the ground truth for focus bookkeeping.
+#[derive(Debug, Default)]
+pub struct KeyboardEnteredSurface(Mutex<Option<CosmicSurface>>);
+
+impl KeyboardEnteredSurface {
+    pub fn get(seat: &Seat<State>) -> Option<CosmicSurface> {
+        seat.user_data()
+            .get_or_insert::<Self, _>(Self::default)
+            .0
+            .lock()
+            .unwrap()
+            .clone()
+            .filter(IsAlive::alive)
+    }
+
+    fn replace(seat: &Seat<State>, surface: &CosmicSurface) -> Option<CosmicSurface> {
+        seat.user_data()
+            .get_or_insert::<Self, _>(Self::default)
+            .0
+            .lock()
+            .unwrap()
+            .replace(surface.clone())
+    }
+
+    fn clear_if(seat: &Seat<State>, surface: &CosmicSurface) {
+        let mut guard = seat
+            .user_data()
+            .get_or_insert::<Self, _>(Self::default)
+            .0
+            .lock()
+            .unwrap();
+        if guard.as_ref() == Some(surface) {
+            *guard = None;
+        }
+    }
+}
+
 impl KeyboardTarget<State> for CosmicSurface {
     fn enter(
         &self,
@@ -1012,6 +1052,14 @@ impl KeyboardTarget<State> for CosmicSurface {
             keys = vec![];
         }
 
+        // Release a stale unpaired `enter` left on another surface, or the
+        // client ends up believing two of its windows are focused at once.
+        if let Some(previous) = KeyboardEnteredSurface::replace(seat, self)
+            .filter(|prev| prev != self && prev.alive())
+        {
+            KeyboardTarget::leave(&previous, seat, data, serial);
+        }
+
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
                 KeyboardTarget::enter(toplevel.wl_surface(), seat, data, keys, serial)
@@ -1021,6 +1069,8 @@ impl KeyboardTarget<State> for CosmicSurface {
     }
 
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: smithay::utils::Serial) {
+        KeyboardEnteredSurface::clear_if(seat, self);
+
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
                 KeyboardTarget::leave(toplevel.wl_surface(), seat, data, serial)

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -1049,6 +1049,46 @@ impl SpaceElement for CosmicSurface {
     }
 }
 
+/// Tracks, per seat, which [`CosmicSurface`] holds the keyboard focus on the
+/// wire (received an `enter` not yet paired with a `leave`). All toplevel
+/// enters/leaves funnel through [`CosmicSurface`]'s [`KeyboardTarget`] impl,
+/// making this the ground truth for focus bookkeeping.
+#[derive(Debug, Default)]
+pub struct KeyboardEnteredSurface(Mutex<Option<CosmicSurface>>);
+
+impl KeyboardEnteredSurface {
+    pub fn get(seat: &Seat<State>) -> Option<CosmicSurface> {
+        seat.user_data()
+            .get_or_insert::<Self, _>(Self::default)
+            .0
+            .lock()
+            .unwrap()
+            .clone()
+            .filter(IsAlive::alive)
+    }
+
+    fn replace(seat: &Seat<State>, surface: &CosmicSurface) -> Option<CosmicSurface> {
+        seat.user_data()
+            .get_or_insert::<Self, _>(Self::default)
+            .0
+            .lock()
+            .unwrap()
+            .replace(surface.clone())
+    }
+
+    fn clear_if(seat: &Seat<State>, surface: &CosmicSurface) {
+        let mut guard = seat
+            .user_data()
+            .get_or_insert::<Self, _>(Self::default)
+            .0
+            .lock()
+            .unwrap();
+        if guard.as_ref() == Some(surface) {
+            *guard = None;
+        }
+    }
+}
+
 impl KeyboardTarget<State> for CosmicSurface {
     fn enter(
         &self,
@@ -1061,6 +1101,14 @@ impl KeyboardTarget<State> for CosmicSurface {
             keys = vec![];
         }
 
+        // Release a stale unpaired `enter` left on another surface, or the
+        // client ends up believing two of its windows are focused at once.
+        if let Some(previous) = KeyboardEnteredSurface::replace(seat, self)
+            .filter(|prev| prev != self && prev.alive())
+        {
+            KeyboardTarget::leave(&previous, seat, data, serial);
+        }
+
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
                 KeyboardTarget::enter(toplevel.wl_surface(), seat, data, keys, serial)
@@ -1070,6 +1118,8 @@ impl KeyboardTarget<State> for CosmicSurface {
     }
 
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: smithay::utils::Serial) {
+        KeyboardEnteredSurface::clear_if(seat, self);
+
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
                 KeyboardTarget::leave(toplevel.wl_surface(), seat, data, serial)

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -72,7 +72,7 @@ use crate::{
     utils::prelude::*,
     wayland::handlers::{
         compositor::FRAME_TIME_FILTER,
-        decoration::{KdeDecorationData, PreferredDecorationMode},
+        decoration::{KdeDecorationData, PreferredDecorationMode, released_kde_mode},
     },
 };
 
@@ -399,8 +399,10 @@ impl CosmicSurface {
                     });
                     with_states(toplevel.wl_surface(), |data| {
                         if let Some(kde_data) = data.data_map.get::<KdeDecorationData>() {
-                            for obj in kde_data.lock().unwrap().objs.iter() {
-                                obj.mode(KdeMode::Server);
+                            let kde_data = kde_data.lock().unwrap();
+                            let mode = released_kde_mode(previous_mode, kde_data.mode);
+                            for obj in kde_data.objs.iter() {
+                                obj.mode(mode);
                             }
                         }
                     })

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -1051,43 +1051,79 @@ impl SpaceElement for CosmicSurface {
     }
 }
 
+/// Enter/leave pairing bookkeeping for keyboard focus, generic so the
+/// decision table is unit-testable (a [`CosmicSurface`] cannot be constructed
+/// without a live compositor).
+#[derive(Debug)]
+pub struct EnteredTracker<S>(Mutex<Option<S>>);
+
+impl<S> Default for EnteredTracker<S> {
+    fn default() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+/// What an `enter` for a surface must translate to on the wire.
+#[derive(Debug)]
+pub enum EnterAction<S> {
+    /// The surface already holds an unpaired `enter` - don't re-send it.
+    AlreadyHeld,
+    /// Send the `enter`, releasing the stale holder first when one exists.
+    Enter { stale: Option<S> },
+}
+
+impl<S: Clone + PartialEq> EnteredTracker<S> {
+    /// The surface currently holding an unpaired `enter`, if it is still alive.
+    pub fn held(&self, alive: impl Fn(&S) -> bool) -> Option<S> {
+        self.0.lock().unwrap().clone().filter(|s| alive(s))
+    }
+
+    /// Record an `enter` for `next` and decide what to send on the wire.
+    pub fn on_enter(&self, next: &S, alive: impl Fn(&S) -> bool) -> EnterAction<S> {
+        let mut guard = self.0.lock().unwrap();
+        if guard.as_ref() == Some(next) {
+            return EnterAction::AlreadyHeld;
+        }
+        let stale = guard.replace(next.clone()).filter(|s| alive(s));
+        EnterAction::Enter { stale }
+    }
+
+    /// Record a `leave` for `left`; a leave for a non-holder changes nothing.
+    pub fn on_leave(&self, left: &S) {
+        let mut guard = self.0.lock().unwrap();
+        if guard.as_ref() == Some(left) {
+            *guard = None;
+        }
+    }
+}
+
 /// Tracks, per seat, which [`CosmicSurface`] holds the keyboard focus on the
 /// wire (received an `enter` not yet paired with a `leave`). All toplevel
 /// enters/leaves funnel through [`CosmicSurface`]'s [`KeyboardTarget`] impl,
 /// making this the ground truth for focus bookkeeping.
 #[derive(Debug, Default)]
-pub struct KeyboardEnteredSurface(Mutex<Option<CosmicSurface>>);
+pub struct KeyboardEnteredSurface(EnteredTracker<CosmicSurface>);
 
 impl KeyboardEnteredSurface {
     pub fn get(seat: &Seat<State>) -> Option<CosmicSurface> {
         seat.user_data()
             .get_or_insert::<Self, _>(Self::default)
             .0
-            .lock()
-            .unwrap()
-            .clone()
-            .filter(IsAlive::alive)
+            .held(IsAlive::alive)
     }
 
-    fn replace(seat: &Seat<State>, surface: &CosmicSurface) -> Option<CosmicSurface> {
+    fn on_enter(seat: &Seat<State>, surface: &CosmicSurface) -> EnterAction<CosmicSurface> {
         seat.user_data()
             .get_or_insert::<Self, _>(Self::default)
             .0
-            .lock()
-            .unwrap()
-            .replace(surface.clone())
+            .on_enter(surface, IsAlive::alive)
     }
 
-    fn clear_if(seat: &Seat<State>, surface: &CosmicSurface) {
-        let mut guard = seat
-            .user_data()
+    fn on_leave(seat: &Seat<State>, surface: &CosmicSurface) {
+        seat.user_data()
             .get_or_insert::<Self, _>(Self::default)
             .0
-            .lock()
-            .unwrap();
-        if guard.as_ref() == Some(surface) {
-            *guard = None;
-        }
+            .on_leave(surface)
     }
 }
 
@@ -1103,16 +1139,16 @@ impl KeyboardTarget<State> for CosmicSurface {
             keys = vec![];
         }
 
-        let previous = KeyboardEnteredSurface::replace(seat, self);
-        if previous.as_ref() == Some(self) {
+        match KeyboardEnteredSurface::on_enter(seat, self) {
             // An `enter` without an intervening `leave` is a protocol violation.
-            return;
-        }
-
-        // Release a stale unpaired `enter` left on another surface, or the
-        // client ends up believing two of its windows are focused at once.
-        if let Some(previous) = previous.filter(|prev| prev.alive()) {
-            KeyboardTarget::leave(&previous, seat, data, serial);
+            EnterAction::AlreadyHeld => return,
+            // Release a stale unpaired `enter` on another surface first.
+            EnterAction::Enter {
+                stale: Some(previous),
+            } => {
+                KeyboardTarget::leave(&previous, seat, data, serial);
+            }
+            EnterAction::Enter { stale: None } => {}
         }
 
         match self.0.underlying_surface() {
@@ -1124,7 +1160,7 @@ impl KeyboardTarget<State> for CosmicSurface {
     }
 
     fn leave(&self, seat: &Seat<State>, data: &mut State, serial: smithay::utils::Serial) {
-        KeyboardEnteredSurface::clear_if(seat, self);
+        KeyboardEnteredSurface::on_leave(seat, self);
 
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => {
@@ -1192,5 +1228,162 @@ fn with_toplevel_state<T, F: FnOnce(Option<&smithay::wayland::shell::xdg::Toplev
         toplevel.with_pending_state(|pending| cb(Some(pending)))
     } else {
         toplevel.with_committed_state(cb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EnterAction, EnteredTracker};
+
+    fn alive(_: &u32) -> bool {
+        true
+    }
+
+    #[test]
+    fn first_enter_records_and_releases_nothing() {
+        let tracker = EnteredTracker::default();
+        match tracker.on_enter(&1, alive) {
+            EnterAction::Enter { stale: None } => {}
+            other => panic!("expected a clean enter, got {other:?}"),
+        }
+        assert_eq!(tracker.held(alive), Some(1));
+    }
+
+    #[test]
+    fn re_entering_the_holder_is_a_noop() {
+        // Regression: the compositor re-sent `enter` to the surface holding
+        // the focus on every stack extraction (14 enters vs 7 leaves on the
+        // wire in one session).
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        assert!(matches!(
+            tracker.on_enter(&1, alive),
+            EnterAction::AlreadyHeld
+        ));
+        assert_eq!(tracker.held(alive), Some(1));
+    }
+
+    #[test]
+    fn entering_releases_a_stale_alive_holder() {
+        // Regression: a missed leave let a client believe two of its windows
+        // were focused at once (for 71s in the captured session), making it
+        // deny fullscreen requests.
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        match tracker.on_enter(&2, alive) {
+            EnterAction::Enter { stale: Some(1) } => {}
+            other => panic!("expected the stale holder to be released, got {other:?}"),
+        }
+        assert_eq!(tracker.held(alive), Some(2));
+    }
+
+    #[test]
+    fn entering_does_not_release_a_dead_holder() {
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        match tracker.on_enter(&2, |s| *s != 1) {
+            EnterAction::Enter { stale: None } => {}
+            other => panic!("expected no release for a dead holder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn leave_clears_only_the_holder() {
+        // Pairing: a leave for a surface that does not hold the enter must
+        // not clear the record of the one that does.
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        tracker.on_leave(&2);
+        assert_eq!(tracker.held(alive), Some(1));
+        tracker.on_leave(&1);
+        assert_eq!(tracker.held(alive), None);
+    }
+
+    #[test]
+    fn held_ignores_a_dead_holder() {
+        let tracker = EnteredTracker::default();
+        tracker.on_enter(&1, alive);
+        assert_eq!(tracker.held(|_| false), None);
+    }
+
+    /// Drives the tracker with every sequence of up to six events over three
+    /// surfaces and checks, after each step, what the client would see on the
+    /// wire: never two surfaces holding an unpaired `enter`, never an `enter`
+    /// re-sent to the holder (nor a leave+enter churn on it), never a `leave`
+    /// to a non-holder, and the record always equal to the surface the client
+    /// believes is focused.
+    #[test]
+    fn every_event_sequence_keeps_the_wire_paired() {
+        #[derive(Clone, Copy, Debug)]
+        enum Event {
+            Enter(u32),
+            Leave(u32),
+            Die(u32),
+        }
+        let events: Vec<Event> = (1..=3)
+            .flat_map(|s| [Event::Enter(s), Event::Leave(s), Event::Die(s)])
+            .collect();
+
+        for len in 1..=6 {
+            for seed in 0..events.len().pow(len) {
+                let tracker = EnteredTracker::default();
+                let mut dead: Vec<u32> = Vec::new();
+                // The client's view: surfaces holding an unpaired `enter`.
+                let mut focused: Vec<u32> = Vec::new();
+                let mut trace: Vec<Event> = Vec::new();
+                let mut rest = seed;
+                for _ in 0..len {
+                    let event = events[rest % events.len()];
+                    rest /= events.len();
+                    trace.push(event);
+                    match event {
+                        // The compositor never focuses a dead surface.
+                        Event::Enter(s) if dead.contains(&s) => {}
+                        Event::Enter(s) => match tracker.on_enter(&s, |x| !dead.contains(x)) {
+                            EnterAction::AlreadyHeld => assert_eq!(
+                                focused,
+                                [s],
+                                "{trace:?}: enter skipped for a surface the client doesn't hold"
+                            ),
+                            EnterAction::Enter { stale } => {
+                                if let Some(stale) = stale {
+                                    assert_ne!(
+                                        stale, s,
+                                        "{trace:?}: leave+enter churn on the surface holding the focus"
+                                    );
+                                    assert!(
+                                        focused.contains(&stale),
+                                        "{trace:?}: leave sent to {stale} without an unpaired enter"
+                                    );
+                                    focused.retain(|f| *f != stale);
+                                }
+                                assert!(
+                                    !focused.contains(&s),
+                                    "{trace:?}: enter re-sent to {s} without an intervening leave"
+                                );
+                                focused.push(s);
+                            }
+                        },
+                        Event::Leave(s) => {
+                            tracker.on_leave(&s);
+                            focused.retain(|f| *f != s);
+                        }
+                        Event::Die(s) => {
+                            dead.push(s);
+                            focused.retain(|f| *f != s);
+                        }
+                    }
+                    assert!(
+                        focused.len() <= 1,
+                        "{trace:?}: client believes {focused:?} are all focused"
+                    );
+                    assert_eq!(
+                        tracker.held(|x| !dead.contains(x)),
+                        focused.first().copied(),
+                        "{trace:?}: tracker disagrees with the wire"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -1101,11 +1101,15 @@ impl KeyboardTarget<State> for CosmicSurface {
             keys = vec![];
         }
 
+        let previous = KeyboardEnteredSurface::replace(seat, self);
+        if previous.as_ref() == Some(self) {
+            // An `enter` without an intervening `leave` is a protocol violation.
+            return;
+        }
+
         // Release a stale unpaired `enter` left on another surface, or the
         // client ends up believing two of its windows are focused at once.
-        if let Some(previous) = KeyboardEnteredSurface::replace(seat, self)
-            .filter(|prev| prev != self && prev.alive())
-        {
+        if let Some(previous) = previous.filter(|prev| prev.alive()) {
             KeyboardTarget::leave(&previous, seat, data, serial);
         }
 

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -519,7 +519,27 @@ impl Common {
 
             if let Some(target) = last_known_focus {
                 if target.alive() {
-                    if focus_target_is_valid(&mut shell, seat, &output, target) {
+                    if focus_target_is_valid(&mut shell, seat, &output, target.clone()) {
+                        // The active tab can change without any set_focus call
+                        // (activation is deferred to an idle, tabs die or get
+                        // reordered) - keep the wire focus on the active tab.
+                        if let KeyboardFocusTarget::Element(mapped) = &target
+                            && let Some(stack) = mapped.stack_ref()
+                            && KeyboardEnteredSurface::get(seat).as_ref() != Some(&stack.active())
+                            && let Some(keyboard) = seat.get_keyboard()
+                            && keyboard.current_focus().as_ref() == Some(&target)
+                        {
+                            std::mem::drop(shell);
+                            let serial = SERIAL_COUNTER.next_serial();
+                            KeyboardTarget::enter(mapped, seat, state, Vec::new(), serial);
+                            KeyboardTarget::modifiers(
+                                mapped,
+                                seat,
+                                state,
+                                keyboard.modifier_state(),
+                                serial,
+                            );
+                        }
                         continue; // Focus is valid
                     } else {
                         trace!("Wrong Window, focus fixup");

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -1,5 +1,8 @@
 use crate::{
-    shell::{CosmicSurface, MinimizedWindow, Shell, Trigger, element::CosmicMapped},
+    shell::{
+        CosmicSurface, MinimizedWindow, Shell, Trigger,
+        element::{CosmicMapped, surface::KeyboardEnteredSurface},
+    },
     state::{Common, State},
     utils::prelude::*,
     wayland::handlers::{xdg_shell::PopupGrabData, xwayland_keyboard_grab::XWaylandGrabSeatData},
@@ -7,7 +10,7 @@ use crate::{
 use indexmap::IndexSet;
 use smithay::{
     desktop::{PopupUngrabStrategy, layer_map_for_output},
-    input::{Seat, pointer::MotionEvent},
+    input::{Seat, keyboard::KeyboardTarget, pointer::MotionEvent},
     output::Output,
     reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface},
     utils::{IsAlive, Point, SERIAL_COUNTER, Serial},
@@ -408,6 +411,17 @@ fn update_focus_state(
             .xwayland_notify_focus_change(target.cloned(), serial);
         ActiveFocus::set(seat, target.cloned());
         keyboard.set_focus(state, target.cloned(), serial);
+        // Smithay skips enter/leave when the focus target is unchanged, but a
+        // stack's active tab may have changed underneath the same target -
+        // move the wire focus to it (an enter must be paired with modifiers).
+        if let Some(KeyboardFocusTarget::Element(mapped)) = target
+            && let Some(stack) = mapped.stack_ref()
+            && keyboard.current_focus().as_ref() == target
+            && KeyboardEnteredSurface::get(seat).as_ref() != Some(&stack.active())
+        {
+            KeyboardTarget::enter(mapped, seat, state, Vec::new(), serial);
+            KeyboardTarget::modifiers(mapped, seat, state, keyboard.modifier_state(), serial);
+        }
         std::mem::drop(keyboard);
 
         //update the focused output or set it to the active output

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -546,7 +546,25 @@ impl Common {
 
             if let Some(target) = last_known_focus {
                 if target.alive() {
-                    if focus_target_is_valid(&mut shell, seat, &output, target) {
+                    if focus_target_is_valid(&mut shell, seat, &output, target.clone()) {
+                        // The active tab can change without a set_focus call
+                        // (deferred activation, tab death) - re-enter it here.
+                        if let KeyboardFocusTarget::Element(mapped) = &target
+                            && let Some(keyboard) = seat.get_keyboard()
+                            && keyboard.current_focus().as_ref() == Some(&target)
+                            && mapped.needs_reenter(seat)
+                        {
+                            std::mem::drop(shell);
+                            let serial = SERIAL_COUNTER.next_serial();
+                            KeyboardTarget::enter(mapped, seat, state, Vec::new(), serial);
+                            KeyboardTarget::modifiers(
+                                mapped,
+                                seat,
+                                state,
+                                keyboard.modifier_state(),
+                                serial,
+                            );
+                        }
                         continue; // Focus is valid
                     } else {
                         trace!("Wrong Window, focus fixup");

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -8,7 +8,7 @@ use indexmap::IndexSet;
 use smithay::{
     backend::input::InputTime,
     desktop::{PopupUngrabStrategy, layer_map_for_output},
-    input::{Seat, pointer::MotionEvent},
+    input::{Seat, keyboard::KeyboardTarget, pointer::MotionEvent},
     output::Output,
     reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface},
     utils::{IsAlive, Point, SERIAL_COUNTER, Serial},
@@ -440,6 +440,15 @@ fn update_focus_state(
             .xwayland_notify_focus_change(target.cloned(), serial);
         ActiveFocus::set(seat, target.cloned());
         keyboard.set_focus(state, target.cloned(), serial);
+        // Smithay skips enter/leave when the focus target is unchanged - re-enter
+        // if the wire focus went stale underneath it (enter pairs with modifiers).
+        if let Some(KeyboardFocusTarget::Element(mapped)) = target
+            && keyboard.current_focus().as_ref() == target
+            && mapped.needs_reenter(seat)
+        {
+            KeyboardTarget::enter(mapped, seat, state, Vec::new(), serial);
+            KeyboardTarget::modifiers(mapped, seat, state, keyboard.modifier_state(), serial);
+        }
         std::mem::drop(keyboard);
 
         //update the focused output or set it to the active output

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4883,10 +4883,19 @@ impl Shell {
                 return None;
             }
 
-            // Must be set before `unmap_surface()`.
-            // `Workspace::unmap_surface` may call intermediate `configure()` internally, which would send
-            // a configure event without the fullscreen state, causing clients like Chromium to cancel the transition.
-            mapped.set_fullscreen(true);
+            // A multi-tab stack extracts via `remove_idx`, which only stages
+            // pending state - the extracted surface's first configure is the
+            // one `map_fullscreen` sends, already carrying `Fullscreen`.
+            // Everything else unmaps through `unmap_element`, which flushes a
+            // configure mid-unmap; pre-set `Fullscreen` on the requesting
+            // surface (never the whole mapped element - that leaks pending
+            // `Fullscreen` onto sibling tabs) so that configure doesn't read
+            // as a denial to clients like Chromium.
+            if !mapped.stack_ref().is_some_and(|s| s.len() > 1)
+                && let Some((target, _)) = mapped.windows().find(|(w, _)| w == surface)
+            {
+                target.set_fullscreen(true);
+            }
 
             let from = workspace.element_geometry(&mapped).unwrap();
             let (surface, state) = workspace.unmap_surface(surface).unwrap();

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2598,6 +2598,7 @@ impl Shell {
         mut state: Option<FullscreenRestoreState>,
         loop_handle: &LoopHandle<'static, State>,
     ) -> CosmicMapped {
+        let mut stack_died = false;
         if let Some(FullscreenRestoreState::Stack { state: stack_state }) = &state {
             if let Some(mapped) = self.mapped().find(|m| **m == stack_state.stack)
                 && let Some(stack) = mapped.stack_ref()
@@ -2606,11 +2607,14 @@ impl Shell {
                 stack.add_window(surface, Some(idx), None);
                 return mapped.clone();
             } else {
+                // The original stack is gone - restore as a fresh single-window
+                // stack so the surface keeps stack decorations.
+                stack_died = true;
                 state = None;
             }
         }
 
-        let window = if state.as_ref().is_some_and(|s| s.was_stack()) {
+        let window = if stack_died || state.as_ref().is_some_and(|s| s.was_stack()) {
             CosmicMapped::from(CosmicStack::new(
                 std::iter::once(surface),
                 loop_handle.clone(),
@@ -2618,6 +2622,10 @@ impl Shell {
                 self.appearance_conf,
             ))
         } else {
+            // Reset forced-SSD/tiled state possibly left over from a stack the
+            // surface was extracted out of mid-transition.
+            surface.try_force_undecorated(false);
+            surface.set_tiled(false);
             CosmicMapped::from(CosmicWindow::new(
                 surface,
                 loop_handle.clone(),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2652,6 +2652,7 @@ impl Shell {
         mut state: Option<FullscreenRestoreState>,
         loop_handle: &LoopHandle<'static, State>,
     ) -> CosmicMapped {
+        let mut stack_died = false;
         if let Some(FullscreenRestoreState::Stack { state: stack_state }) = &state {
             if let Some(mapped) = self.mapped().find(|m| **m == stack_state.stack)
                 && let Some(stack) = mapped.stack_ref()
@@ -2660,11 +2661,14 @@ impl Shell {
                 stack.add_window(surface, Some(idx), None);
                 return mapped.clone();
             } else {
+                // The original stack is gone - restore as a fresh single-window
+                // stack so the surface keeps stack decorations.
+                stack_died = true;
                 state = None;
             }
         }
 
-        let window = if state.as_ref().is_some_and(|s| s.was_stack()) {
+        let window = if stack_died || state.as_ref().is_some_and(|s| s.was_stack()) {
             CosmicMapped::from(CosmicStack::new(
                 std::iter::once(surface),
                 loop_handle.clone(),
@@ -2672,6 +2676,10 @@ impl Shell {
                 self.appearance_conf,
             ))
         } else {
+            // Reset forced-SSD/tiled state possibly left over from a stack the
+            // surface was extracted out of mid-transition.
+            surface.try_force_undecorated(false);
+            surface.set_tiled(false);
             CosmicMapped::from(CosmicWindow::new(
                 surface,
                 loop_handle.clone(),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4942,10 +4942,13 @@ impl Shell {
                 return None;
             }
 
-            // Must be set before `unmap_surface()`.
-            // `Workspace::unmap_surface` may call intermediate `configure()` internally, which would send
-            // a configure event without the fullscreen state, causing clients like Chromium to cancel the transition.
-            mapped.set_fullscreen(true);
+            // Pre-set Fullscreen only where unmap_element flushes a configure
+            // mid-unmap; a multi-tab stack extracts via remove_idx instead.
+            if mapped.stack_ref().is_none_or(|s| s.len() <= 1)
+                && let Some((target, _)) = mapped.windows().find(|(w, _)| w == surface)
+            {
+                target.set_fullscreen(true);
+            }
 
             let from = workspace.element_geometry(&mapped).unwrap();
             let (surface, state) = workspace.unmap_surface(surface).unwrap();

--- a/src/wayland/handlers/decoration.rs
+++ b/src/wayland/handlers/decoration.rs
@@ -9,6 +9,7 @@ use smithay::{
         },
         wayland_server::protocol::wl_surface::WlSurface,
     },
+    utils::IsAlive,
     wayland::{
         compositor::with_states,
         seat::WaylandFocus,
@@ -125,14 +126,11 @@ impl KdeDecorationHandler for State {
     }
 
     fn new_decoration(&mut self, surface: &WlSurface, decoration: &OrgKdeKwinServerDecoration) {
-        let mode = if let Some(mapped) = self.common.shell.read().element_for_surface(surface) {
-            if mapped.is_stack() {
-                KdeMode::Server
-            } else {
-                KdeMode::Client
-            }
-        } else {
-            KdeMode::Client
+        // Send `Server` for a stacked window (forced SSD) without recording
+        // it - `state.mode` tracks the client's own preference.
+        let mode = match self.common.shell.read().element_for_surface(surface) {
+            Some(mapped) if mapped.alive() && mapped.is_stack() => KdeMode::Server,
+            _ => KdeMode::Client,
         };
 
         with_states(surface, |states| {
@@ -143,9 +141,6 @@ impl KdeDecorationHandler for State {
                 .unwrap();
 
             state.objs.push(decoration.clone());
-            if state.mode.is_none() {
-                state.mode = Some(mode)
-            }
         });
 
         decoration.mode(mode);

--- a/src/wayland/handlers/decoration.rs
+++ b/src/wayland/handlers/decoration.rs
@@ -10,6 +10,7 @@ use smithay::{
         },
         wayland_server::protocol::wl_surface::WlSurface,
     },
+    utils::IsAlive,
     wayland::{
         compositor::with_states,
         seat::WaylandFocus,
@@ -232,14 +233,12 @@ impl KdeDecorationHandler for State {
     }
 
     fn new_decoration(&mut self, surface: &WlSurface, decoration: &OrgKdeKwinServerDecoration) {
-        let mode = if let Some(mapped) = self.common.shell.read().element_for_surface(surface) {
-            if mapped.is_stack() {
-                KdeMode::Server
-            } else {
-                KdeMode::from_preference(self.default_decoration())
-            }
-        } else {
-            KdeMode::from_preference(self.default_decoration())
+        let preference = KdeMode::from_preference(self.default_decoration());
+        // A stacked window is sent `Server` (forced SSD), but only the
+        // configured preference is recorded - `state.mode` is the client's.
+        let mode = match self.common.shell.read().element_for_surface(surface) {
+            Some(mapped) if mapped.alive() && mapped.is_stack() => KdeMode::Server,
+            _ => preference,
         };
 
         with_states(surface, |states| {
@@ -251,7 +250,7 @@ impl KdeDecorationHandler for State {
 
             state.objs.push(decoration.clone());
             if state.mode.is_none() {
-                state.mode = Some(mode)
+                state.mode = Some(preference);
             }
         });
 

--- a/src/wayland/handlers/decoration.rs
+++ b/src/wayland/handlers/decoration.rs
@@ -121,6 +121,17 @@ impl FromDecorationPreference for KdeMode {
     }
 }
 
+/// The KDE mode to restore when forced server-side decorations are released:
+/// the xdg preference recorded when they were forced wins, then the client's
+/// own kde request.
+pub fn released_kde_mode(previous_mode: Option<XdgMode>, requested: Option<KdeMode>) -> KdeMode {
+    match previous_mode {
+        Some(XdgMode::ServerSide) => KdeMode::Server,
+        Some(_) => KdeMode::Client,
+        None => requested.unwrap_or(KdeMode::Client),
+    }
+}
+
 pub type KdeDecorationData = Mutex<KdeDecorationSurfaceState>;
 #[derive(Debug, Default)]
 pub struct KdeDecorationSurfaceState {
@@ -279,5 +290,38 @@ impl KdeDecorationHandler for State {
                 state.mode.take();
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KdeMode, XdgMode, released_kde_mode};
+
+    #[test]
+    fn releasing_forced_ssd_restores_the_clients_kde_request() {
+        // Regression: the release path re-sent `Server` (the mode the enable
+        // path sends), so CSD clients protested with request_mode(Client) on
+        // every stack extraction.
+        assert_eq!(
+            released_kde_mode(None, Some(KdeMode::Client)),
+            KdeMode::Client
+        );
+        assert_eq!(
+            released_kde_mode(None, Some(KdeMode::Server)),
+            KdeMode::Server
+        );
+        assert_eq!(released_kde_mode(None, None), KdeMode::Client);
+    }
+
+    #[test]
+    fn the_recorded_xdg_preference_wins_over_the_kde_request() {
+        assert_eq!(
+            released_kde_mode(Some(XdgMode::ClientSide), Some(KdeMode::Server)),
+            KdeMode::Client
+        );
+        assert_eq!(
+            released_kde_mode(Some(XdgMode::ServerSide), Some(KdeMode::Client)),
+            KdeMode::Server
+        );
     }
 }

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -418,6 +418,10 @@ where
                         handle.closed();
                     }
                 }
+                if let Some(handle) = state.foreign_handle.take() {
+                    self.foreign_toplevel_list.remove_toplevel(&handle);
+                }
+                *state = Default::default();
                 dirty = true;
                 false
             }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

Fullscreening a tab out of a stack (e.g. pressing `F` on a video in a stacked Firefox window) was broken in several independent ways. The common root of the worst ones: a stack is a single `KeyboardFocusTarget` wrapping several toplevels, and the bookkeeping for which tab actually holds the wire `wl_keyboard` focus could silently diverge from the active tab. The first four commits replace that guesswork with per-seat ground truth and heal every divergence path; the next five fix independent client-visible bugs around the fullscreen transition (pending-state leaks, decoration modes, dead-toplevel cleanup, restore paths); the final commit pins the new focus invariants with unit tests. Each commit builds individually; details live in the commit messages. Related: #2146.

## The headline bug: the client revokes fullscreen ~30 ms after acking it

`WAYLAND_DEBUG=client` captures (Firefox/GTK3) show the mechanism:

* When the active tab is extracted from the stack, the stack's index-based focus bookkeeping handed the keyboard focus to the newly-active *sibling* tab before immediately leaving it again -- an enter/leave/enter burst on one serial, with the enter arriving before any leave from the requesting surface.
* GTK deactivates the requesting window mid-transition, and Gecko cancels a pending fullscreen transition when its window is deactivated: `unset_fullscreen` ~25-35 ms after the ack.
* Wire correlation: 9/9 failing cycles show this focus dance right after the grant; the single surviving grant (window already extracted, so no stack leave) shows zero keyboard events.

Fixed by the first commit: `previous_keyboard` (a tab index) plus a `reenter` flag are replaced with a per-seat record of which surface actually received an unpaired `wl_keyboard.enter`, maintained at the single choke point all toplevel keyboard enters/leaves pass through (`CosmicSurface::{enter,leave}`). The stack then releases exactly the surface that holds the focus -- and correctly releases nothing when the entered surface was just extracted and took the focus with it.

## Focus series (commits 1-4)

* **shell: Track the keyboard-entered surface instead of guessing by tab index** -- the tracker itself; also fixes the drag-and-drop-into-stack flow where the client believed two of its windows were focused at once for 71 s (Gecko denies `requestFullscreen` while its window isn't the focused one).
* **shell: Don't re-send keyboard enter to a surface that already holds it** -- extraction re-sent `wl_keyboard.enter` to a surface that never received a `leave` (wire captures: 14 enters vs 7 leaves in one session).
* **shell: Follow tab switches with the keyboard focus on all-pointer flows** -- clicking a tab changes the active tab but not the `KeyboardFocusTarget`, so smithay's `set_focus` dedups the update and the wire focus stays on the hidden tab (captured: 15 consecutive fullscreen-button clicks producing zero `set_fullscreen` requests inside one divergence window). The check sits behind `CosmicMapped::needs_reenter()`, so the active-tab logic stays inside the element.
* **shell: Enforce the active-tab keyboard focus invariant in refresh_focus** -- catch-all for active-tab changes that never pass through `set_focus` (deferred tab-bar activation, unminimize-to-a-tab, unstack menu, active tab dying). Same `needs_reenter()` check.

## Fullscreen transition family (commits 5-9)

* **shell: Don't leak pending Fullscreen state to sibling stack tabs** -- `CosmicMapped::set_fullscreen` fans out to every tab and nothing clears the siblings' pending state, so the stack's refresh flushed Fullscreen configures to tile-sized siblings (visibly toggling their chrome) and the stale state froze the stack's slot in `TilingLayout::update_positions`. Multi-tab extraction now stages pending state only -- `map_fullscreen`'s configure asserts Fullscreen itself; the pre-set survives only on the `unmap_element` path, where the mid-unmap configure would otherwise read as a request denial (Chromium).
* **shell: Restore the client's KDE decoration mode when releasing forced SSD** -- releasing forced SSD sent `mode(Server)` again instead of restoring the client's mode; the released mode is now derived by `released_kde_mode()` from the recorded xdg-decoration `previous_mode`, falling back to the client's kde-decoration request. Pinned by a table test.
* **toplevel-info: Notify foreign-toplevel-list clients when culling dead toplevels** -- killing a multi-toplevel client left ghost entries in dock/panel/alt-tab: the dead branch in `ToplevelInfoState::refresh` never released the ext-foreign-toplevel-list handle. Not stack-specific.
* **shell: Don't record the forced KDE Server mode as the client's preference** -- binding a decoration object while stacked recorded the compositor-forced Server mode as the client's preference, so CSD clients got Server re-asserted forever: a compositor headerbar drawn on top of the client's CSD. Rebased over the configurable decoration default (b407ed56): the recorded preference is now the configured default, never the forced mode.
* **shell: Restore fullscreen surface as a stack when its origin stack died** -- if the recorded origin stack is gone at unfullscreen time, the surface silently degraded to a plain floating window still carrying forced-SSD/tiled state (double decoration). Restore into a fresh single-window stack instead, and reset forced state on the plain-window fallback path.

## Tests (commit 10)

Every bug in the focus series regressed silently -- nothing crashed or logged. The enter/leave pairing decision table moves into a small generic `EnteredTracker` (a `CosmicSurface` cannot be constructed without a live compositor, hence the generic parameter) and the wire regressions the series was validated against are pinned as unit tests: no re-sent enter for the surface already holding the focus, releasing a stale holder on enter, and a leave clearing only the surface that actually holds the enter. A model test additionally drives every sequence of up to six enter/leave/death events over three surfaces and checks after each step what the client would see on the wire: never two surfaces holding an unpaired enter, never a re-sent enter, never a leave to a non-holder, and the record always equal to the surface the client believes is focused.

## Testing

Wire validation was done on v2 (identical focus logic; v3 moves the check behind `needs_reenter()`, drops the checked-index commit and adds tests). v3 is rebased on current master, builds per commit, and passes `cargo test --lib`; it has not been re-captured on the wire since the rebase.

On master + this series, Firefox in a 2-tab stack:

1. Fullscreen (YouTube + `F`) engages and **persists** until manually exited (previously revoked in ~30 ms, 9/9 cycles). Verified on the wire across 17 cycles in two stacked Firefox windows: grant `configure(1920, 1080, [fullscreen, activated])`, zero keyboard events to the sibling, every `unset_fullscreen` following the user's own key press -- and the state survives losing `activated` when focus moves to the sibling tab mid-fullscreen.
2. The same capture settles the v1 `set_tiled` question: the grant configure drops the four `tiled_*` states and no client revokes -- the earlier correlation was the focus race, so that commit is gone since v2.
3. The sibling tab no longer receives fullscreen configures or flashes its chrome.
4. On exit the tab returns to its original stack; if the stack died in the meantime it comes back as a single-tab stack, never as a floating window with a doubled titlebar.
5. No COSMIC SSD headerbar over Firefox's CSD in any state.
6. SIGINT on Firefox with a multi-tab stack: all windows *and* their dock/alt-tab entries disappear.
7. All-pointer flow (click a stack tab, then immediately click the player's fullscreen button, keyboard untouched): fullscreen engages on the **first** click -- previously the request was silently denied until something else happened to heal the focus. Verified across 24 fullscreen cycles (`WAYLAND_DEBUG=client` + compositor-side focus tracing): every `set_fullscreen` granted, enter/leave counts exactly balanced, a `modifiers` event after every enter, zero panics.
8. `cargo test --lib`: 10 passed.

The `WAYLAND_DEBUG=client` captures (before/after, plus the `set_tiled` A/B) are available if useful.

Known adjacent issues deliberately left out (happy to file separately): `request_mode` acks the client's KDE mode while force-undecorated is active (the zxdg variant even overwrites `pending.decoration_mode`); `minimized_windows` never retains by aliveness (a dead minimized stack blocks workspace auto-removal); `Shell::mapped()` doesn't search `backup_set`.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
