### PR TITLE
wayland: avoid redraws for empty surface commits

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -599,6 +599,17 @@ impl KmsState {
         }
     }
 
+    pub fn schedule_frame_callbacks(&mut self, output: &Output) {
+        for surface in self
+            .drm_devices
+            .values()
+            .flat_map(|d| d.inner.surfaces.values())
+            .filter(|s| s.output == *output || s.output.mirroring().is_some_and(|o| &o == output))
+        {
+            surface.schedule_frame_callbacks();
+        }
+    }
+
     pub fn target_node_for_output(&self, output: &Output) -> Option<DrmNode> {
         self.drm_devices
             .values()

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -216,6 +216,7 @@ pub enum ThreadCommand {
     UpdateScreenFilter(ScreenFilter),
     VBlank(Option<DrmEventMetadata>),
     ScheduleRender,
+    ScheduleFrameCallbacks,
     AdaptiveSyncAvailable(SyncSender<Result<VrrSupport>>),
     UseAdaptiveSync(AdaptiveSync),
     AllowFrameFlags(bool, FrameFlags),
@@ -389,6 +390,14 @@ impl Surface {
     pub fn schedule_render(&self) {
         if self.dpms {
             let _ = self.thread_command.send(ThreadCommand::ScheduleRender);
+        }
+    }
+
+    pub fn schedule_frame_callbacks(&self) {
+        if self.dpms {
+            let _ = self
+                .thread_command
+                .send(ThreadCommand::ScheduleFrameCallbacks);
         }
     }
 
@@ -593,6 +602,13 @@ fn surface_thread(
                 }
 
                 state.queue_redraw(false);
+            }
+            Event::Msg(ThreadCommand::ScheduleFrameCallbacks) => {
+                if !startup_done.load(Ordering::SeqCst) {
+                    return;
+                }
+
+                state.queue_frame_callbacks();
             }
             Event::Msg(ThreadCommand::UpdateMirroring(mirroring_output)) => {
                 state.update_mirroring(mirroring_output);
@@ -1410,8 +1426,7 @@ impl SurfaceThreadState {
 
     fn queue_estimated_vblank(&mut self, target_presentation_time: Duration, force: bool) {
         match mem::take(&mut self.state) {
-            QueueState::Idle => unreachable!(),
-            QueueState::Queued(_) => (),
+            QueueState::Idle | QueueState::Queued(_) => (),
             QueueState::WaitingForVBlank { .. } => unreachable!(),
             QueueState::WaitingForEstimatedVBlank(token)
             | QueueState::WaitingForEstimatedVBlankAndQueued {
@@ -1443,6 +1458,13 @@ impl SurfaceThreadState {
             })
             .unwrap();
         self.state = QueueState::WaitingForEstimatedVBlank(token);
+    }
+
+    fn queue_frame_callbacks(&mut self) {
+        if self.compositor.is_some() && matches!(self.state, QueueState::Idle) {
+            let estimated_presentation = self.timings.next_presentation_time(&self.clock);
+            self.queue_estimated_vblank(estimated_presentation, false);
+        }
     }
 
     fn update_mirroring(&mut self, mirroring_output: Option<Output>) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -370,6 +370,16 @@ impl BackendData {
         }
     }
 
+    pub fn schedule_frame_callbacks(&mut self, output: &Output) {
+        match self {
+            // Winit drives frame callbacks from its fixed render loop.
+            BackendData::Winit(_) => {}
+            BackendData::X11(state) => state.schedule_render(output),
+            BackendData::Kms(state) => state.schedule_frame_callbacks(output),
+            _ => unreachable!("No backend was initialized"),
+        }
+    }
+
     pub fn dmabuf_imported(
         &mut self,
         client: Option<Client>,

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -5,12 +5,20 @@ use calloop::Interest;
 use smithay::{
     backend::renderer::{
         element::{Kind, surface::KindEvaluation},
-        utils::{on_commit_buffer_handler, with_renderer_surface_state},
+        utils::{
+            CommitCounter, RendererSurfaceStateUserData, SurfaceView, on_commit_buffer_handler,
+            with_renderer_surface_state,
+        },
     },
-    desktop::{LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output},
-    reexports::wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
-    utils::{Clock, Logical, Monotonic, SERIAL_COUNTER, Size, Time},
+    desktop::{
+        LayerSurface, PopupKind, WindowSurfaceType, layer_map_for_output, space::SpaceElement,
+    },
+    reexports::wayland_server::{
+        Client, Resource, backend::ObjectId, protocol::wl_surface::WlSurface,
+    },
+    utils::{Clock, Logical, Monotonic, Rectangle, SERIAL_COUNTER, Size, Time, Transform},
     wayland::{
+        alpha_modifier::AlphaModifierSurfaceCachedState,
         compositor::{
             BufferAssignment, CompositorClientState, CompositorHandler, CompositorState,
             SurfaceAttributes, SurfaceData, TraversalAction, add_blocker, add_post_commit_hook,
@@ -29,6 +37,119 @@ use smithay::{
     xwayland::XWaylandClientData,
 };
 use std::{collections::VecDeque, sync::Mutex, time::Duration};
+
+#[derive(Debug, PartialEq)]
+struct RendererStateSignature {
+    commit: CommitCounter,
+    buffer: Option<ObjectId>,
+    view: Option<SurfaceView>,
+    buffer_scale: i32,
+    buffer_transform: Transform,
+    opaque_regions: Vec<Rectangle<i32, Logical>>,
+}
+
+#[derive(Debug, PartialEq)]
+struct SurfaceStateSignature {
+    surface: ObjectId,
+    alpha_multiplier: Option<u32>,
+    renderer: Option<RendererStateSignature>,
+}
+
+type SurfaceTreeSignature = Vec<SurfaceStateSignature>;
+
+#[derive(Debug, Default)]
+struct LastSurfaceTreeSignature(Mutex<Option<SurfaceTreeSignature>>);
+
+fn surface_tree_commit_state(surface: &WlSurface) -> (SurfaceTreeSignature, bool) {
+    let mut signature = Vec::new();
+    let mut has_frame_callbacks = false;
+
+    with_surface_tree_downward(
+        surface,
+        (),
+        |_, _, _| TraversalAction::DoChildren(()),
+        |surface, states, _| {
+            let alpha_multiplier = states
+                .cached_state
+                .get::<AlphaModifierSurfaceCachedState>()
+                .current()
+                .multiplier();
+            has_frame_callbacks |= !states
+                .cached_state
+                .get::<SurfaceAttributes>()
+                .current()
+                .frame_callbacks
+                .is_empty();
+            let renderer = states
+                .data_map
+                .get::<RendererSurfaceStateUserData>()
+                .map(|state| {
+                    let state = state.lock().unwrap();
+                    RendererStateSignature {
+                        commit: state.current_commit(),
+                        buffer: state.buffer().map(|buffer| Resource::id(&**buffer)),
+                        view: state.view(),
+                        buffer_scale: state.buffer_scale(),
+                        buffer_transform: state.buffer_transform(),
+                        opaque_regions: state.opaque_regions().unwrap_or_default().to_vec(),
+                    }
+                });
+
+            signature.push(SurfaceStateSignature {
+                surface: surface.id(),
+                alpha_multiplier,
+                renderer,
+            });
+        },
+        |_, _, _| true,
+    );
+
+    (signature, has_frame_callbacks)
+}
+
+fn update_surface_tree_signature(surface: &WlSurface) -> (bool, bool) {
+    let (current, has_frame_callbacks) = surface_tree_commit_state(surface);
+
+    let changed = with_states(surface, |states| {
+        let last = states
+            .data_map
+            .get_or_insert_threadsafe(LastSurfaceTreeSignature::default);
+        let mut last = last.0.lock().unwrap();
+        let changed = last.as_ref() != Some(&current);
+        *last = Some(current);
+        changed
+    });
+
+    (changed, has_frame_callbacks)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CommitAction {
+    Render,
+    FrameCallbacksOnly,
+    None,
+}
+
+fn commit_action(
+    renderer_state_changed: bool,
+    mapped: bool,
+    geometry_before: Option<Rectangle<i32, Logical>>,
+    geometry_after: Option<Rectangle<i32, Logical>>,
+    has_frame_callbacks: bool,
+) -> CommitAction {
+    let needs_render = renderer_state_changed
+        || mapped
+        || geometry_before.is_none()
+        || geometry_before != geometry_after;
+
+    if needs_render {
+        CommitAction::Render
+    } else if has_frame_callbacks {
+        CommitAction::FrameCallbacksOnly
+    } else {
+        CommitAction::None
+    }
+}
 
 fn toplevel_ensure_initial_configure(
     toplevel: &ToplevelSurface,
@@ -258,8 +379,16 @@ impl CompositorHandler for State {
     }
 
     fn commit(&mut self, surface: &WlSurface) {
+        let geometry_before = self
+            .common
+            .shell
+            .read()
+            .element_for_surface(surface)
+            .map(SpaceElement::geometry);
+
         // first load the buffer for various smithay helper functions (which also initializes the RendererSurfaceState)
         on_commit_buffer_handler::<Self>(surface);
+        let (renderer_state_changed, has_frame_callbacks) = update_surface_tree_signature(surface);
 
         // and refresh smithays internal state
         self.common.on_commit(surface);
@@ -268,10 +397,26 @@ impl CompositorHandler for State {
         let mapped = self.send_initial_configure_and_map(surface);
 
         let mut shell = self.common.shell.write();
+        let geometry_after = shell
+            .element_for_surface(surface)
+            .map(SpaceElement::geometry);
 
-        // schedule a new render
+        // Only ordinary, already-mapped windows with unchanged renderer and geometry state can
+        // prove that this commit has no visual effect. Keep every ambiguous surface role and
+        // lifecycle transition on the existing render path.
+        let action = commit_action(
+            renderer_state_changed,
+            mapped,
+            geometry_before,
+            geometry_after,
+            has_frame_callbacks,
+        );
         if let Some(output) = shell.visible_output_for_surface(surface) {
-            self.backend.schedule_render(output);
+            match action {
+                CommitAction::Render => self.backend.schedule_render(output),
+                CommitAction::FrameCallbacksOnly => self.backend.schedule_frame_callbacks(output),
+                CommitAction::None => {}
+            }
         }
 
         if mapped {
@@ -369,6 +514,62 @@ impl CompositorHandler for State {
                 shell.workspaces.recalculate();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geometry() -> Rectangle<i32, Logical> {
+        Rectangle::from_size((800, 600).into())
+    }
+
+    #[test]
+    fn unchanged_mapped_window_commit_does_not_need_render() {
+        let geometry = geometry();
+
+        assert_eq!(
+            commit_action(false, false, Some(geometry), Some(geometry), false,),
+            CommitAction::None,
+        );
+    }
+
+    #[test]
+    fn unchanged_commit_with_callback_only_schedules_callbacks() {
+        let geometry = geometry();
+
+        assert_eq!(
+            commit_action(false, false, Some(geometry), Some(geometry), true,),
+            CommitAction::FrameCallbacksOnly,
+        );
+    }
+
+    #[test]
+    fn visual_or_ambiguous_commit_needs_render() {
+        let geometry = geometry();
+        let moved = Rectangle::new((1, 0).into(), geometry.size);
+
+        assert_eq!(
+            commit_action(true, false, Some(geometry), Some(geometry), false,),
+            CommitAction::Render,
+        );
+        assert_eq!(
+            commit_action(false, true, Some(geometry), Some(geometry), false,),
+            CommitAction::Render,
+        );
+        assert_eq!(
+            commit_action(false, false, Some(geometry), Some(moved), false),
+            CommitAction::Render,
+        );
+        assert_eq!(
+            commit_action(false, false, None, None, false),
+            CommitAction::Render,
+        );
+        assert_eq!(
+            commit_action(false, false, Some(geometry), None, false),
+            CommitAction::Render,
+        );
     }
 }
 

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -8,7 +8,7 @@ use smithay::desktop::layer_map_for_output;
 use smithay::{
     desktop::{
         PopupGrab, PopupKeyboardGrab, PopupKind, PopupPointerGrab, PopupUngrabStrategy,
-        WindowSurfaceType, find_popup_root_surface,
+        WindowSurfaceType, find_popup_root_surface, space::SpaceElement,
     },
     input::{Seat, pointer::Focus},
     output::Output,
@@ -348,6 +348,23 @@ impl XdgShellHandler for State {
                 client_compositor_state(client).blocker_cleared(self, &dh);
             }
         }
+
+        if let Some(output) = output.as_ref() {
+            self.backend.schedule_render(output);
+        }
+    }
+
+    fn title_changed(&mut self, surface: ToplevelSurface) {
+        let output = {
+            let shell = self.common.shell.read();
+            let mapped = shell.element_for_surface(surface.wl_surface());
+            mapped.map(SpaceElement::refresh);
+            mapped.and_then(|_| {
+                shell
+                    .visible_output_for_surface(surface.wl_surface())
+                    .cloned()
+            })
+        };
 
         if let Some(output) = output.as_ref() {
             self.backend.schedule_render(output);


### PR DESCRIPTION
## What this changes

`CompositorHandler::commit()` currently calls `schedule_render()` for every commit on a visible surface. Smithay may later find that the output damage is empty and skip drawing, but by then the backend scheduling and render path has already been entered.

This adds a conservative check before scheduling the output. For each committed surface tree, the compositor keeps a value-only signature containing:

- surface identity and tree order;
- attached buffer identity;
- Smithay's damage commit counter;
- surface view, scale, transform, and opaque region;
- the alpha modifier.

The handler also compares the mapped window geometry before and after shell commit processing. Geometry is not part of the persisted surface-tree signature.

The commit handler now has three outcomes:

- schedule a render when that state changed or the commit is otherwise ambiguous;
- schedule frame callbacks without a redraw when the visual state is unchanged but `wl_surface.frame` callbacks are pending;
- do nothing when an already mapped toplevel has neither a visual change nor pending callbacks.

The last case is deliberately narrow. Initial mapping, buffer removal, geometry changes, popups, layer surfaces, lock surfaces, cursor and drag surfaces, fullscreen surfaces, subsurface commits, and other cases that cannot be proven unchanged continue through the existing render path.

A callback-only request uses the existing estimated-vblank timer on KMS. If the output is idle, it arms the timer for the next estimated presentation time and sends frame callbacks without calling `redraw()`. If a render or vblank is already pending, that work delivers the callbacks instead. X11 retains its existing scheduled output pass, while winit continues to use its fixed render loop.

XDG toplevel titles need separate handling because they affect server-side decorations without changing Smithay's renderer surface state. `title_changed()` now refreshes the mapped decoration and schedules its output directly.

This does not pass surface damage rectangles into KMS or replace Smithay's output damage tracking. Smithay still decides which output regions need to be redrawn after the compositor has decided that the renderer needs to wake up at all.

This is independent of the render-timing change and is kept in a separate PR so that the scheduling policy can be reviewed and tested on its own.

## Testing

- `cargo check`
- `cargo test --lib` (4 passed)
- `rustfmt --check` on the touched Rust files
- `git diff --check`
- `make` (release build)
- installed the release binary and verified that its checksum matched the built artifact

The installed build is ready for real-session testing. I have left the runtime-testing checkbox open until that is complete.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
