### PR TITLE
main: fix kiosk command with command line options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,11 +81,8 @@ impl State {
                 warn!(?err, "Failed to setup cosmic-session communication");
             }
 
-            let mut args = env::args().skip(1);
-            self.common.kiosk_child = if let Some(exec) = args.next() {
+            self.common.kiosk_child = if let Some(mut command) = self.kiosk_command.take() {
                 // Run command in kiosk mode
-                let mut command = process::Command::new(&exec);
-                command.args(args);
                 command.envs(
                     session::get_env(&self.common).expect("WAYLAND_DISPLAY should be valid UTF-8"),
                 );
@@ -96,7 +93,7 @@ impl State {
                     })
                 };
 
-                info!("Running {:?}", exec);
+                info!("Running {:?}", command.get_program());
                 command
                     .spawn()
                     .map_err(|err| {
@@ -115,8 +112,10 @@ impl State {
 pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
     let raw_args = RawArgs::from_args();
     let mut cursor = raw_args.cursor();
+    raw_args.next_os(&mut cursor);
     let git_hash = option_env!("GIT_HASH").unwrap_or("unknown");
 
+    let mut kiosk_command = None;
     let mut with_xwayland = true;
     // Parse the arguments
     while let Some(arg) = raw_args.next_os(&mut cursor) {
@@ -137,7 +136,11 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
                 );
                 return Ok(());
             }
-            _ => {}
+            _ => {
+                let mut cmd = process::Command::new(arg);
+                cmd.args(raw_args.remaining(&mut cursor));
+                kiosk_command = Some(cmd);
+            }
         }
     }
 
@@ -171,6 +174,7 @@ pub fn run(hooks: crate::hooks::Hooks) -> Result<(), Box<dyn Error>> {
         event_loop.handle(),
         event_loop.get_signal(),
         with_xwayland,
+        kiosk_command,
     );
     // init backend
     backend::init_backend_auto(&display, &mut event_loop, &mut state)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -127,7 +127,7 @@ use std::{
     cmp::min,
     collections::HashSet,
     ffi::OsString,
-    process::Child,
+    process::{Child, Command},
     sync::{Arc, LazyLock, Once, atomic::AtomicBool},
     time::{Duration, Instant},
 };
@@ -225,6 +225,7 @@ pub struct State {
     pub common: Common,
     pub ready: Once,
     pub last_refresh: LastRefresh,
+    pub kiosk_command: Option<Command>,
 }
 smithay::delegate_dispatch2!(State);
 
@@ -633,6 +634,7 @@ impl State {
         handle: LoopHandle<'static, State>,
         signal: LoopSignal,
         with_xwayland: bool,
+        kiosk_command: Option<Command>,
     ) -> State {
         let requested_languages = DesktopLanguageRequester::requested_languages();
         i18n_embed::select(&*LANG_LOADER, &Localizations, &requested_languages)
@@ -810,6 +812,7 @@ impl State {
             backend: BackendData::Unset,
             ready: Once::new(),
             last_refresh: LastRefresh::None,
+            kiosk_command,
         }
     }
 


### PR DESCRIPTION
We were just running whatever was given on the command line as the kiosk command, which meant that if --no-xwayland was given, we'd try execing --no-xwayland.  Preserve the processed command line from the option parser, and run only what's left over as the kiosk command to fix this.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

