### PR TITLE
main: notify readiness on non-systemd systems

### DIFF
--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -27,9 +27,9 @@ pub fn ready(common: &Common) {
             ),
             Err(err) => error!(?err, "Failed to run systemctl although booted with systemd",),
         };
+    }
 
-        if let Err(err) = notify(false, &[NotifyState::Ready]) {
-            error!(?err, "Failed to notify systemd");
-        }
+    if let Err(err) = notify(false, &[NotifyState::Ready]) {
+        error!(?err, "Failed to notify systemd");
     }
 }


### PR DESCRIPTION
Other service supervisors implement systemd's readiness notification protocol.  For example, s6 implements it with the
[s6-notify-fd-from-socket][1] program.  `libsystemd::daemon::notify` already checks for `NOTIFY_SOCKET` being set, which should be sufficient to tell if systemd-style readiness notification is wanted.

[1]: https://skarnet.org/software/s6/s6-notify-fd-from-socket.html

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

