### PR TITLE
Refactor:  Don't move the cursor at all if "cursor follows focus" is off

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -85,6 +85,9 @@ pub struct CosmicCompConfig {
     pub autotile_behavior: TileBehavior,
     /// Active hint enabled
     pub active_hint: bool,
+    /// Dim the panel (and other layer-shell surfaces) on outputs that do not have keyboard focus.
+    /// Only takes effect with more than one output
+    pub dim_inactive_panels: bool,
     /// Enables changing keyboard focus to windows when the cursor passes into them
     pub focus_follows_cursor: bool,
     /// Enables warping the cursor to the focused window when focus changes due to keyboard input
@@ -130,6 +133,7 @@ impl Default for CosmicCompConfig {
             autotile: Default::default(),
             autotile_behavior: Default::default(),
             active_hint: true,
+            dim_inactive_panels: false,
             focus_follows_cursor: false,
             cursor_follows_focus: false,
             focus_follows_cursor_delay: 250,

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -81,7 +81,10 @@ use smithay::{
     utils::{
         IsAlive, Logical, Monotonic, Physical, Point, Rectangle, Scale, Size, Time, Transform,
     },
-    wayland::{compositor::with_states, dmabuf::get_dmabuf, session_lock::LockSurface},
+    wayland::{
+        compositor::with_states, dmabuf::get_dmabuf, session_lock::LockSurface,
+        shell::wlr_layer::Layer as WlrLayer,
+    },
 };
 
 #[cfg(feature = "debug")]
@@ -95,6 +98,9 @@ pub mod wayland;
 use self::element::{AsGlowRenderer, CosmicElement};
 
 use super::kms::Timings;
+
+/// Alpha applied to panel / layer-shell surfaces on outputs without keyboard focus when `dim_inactive_panels` is enabled.
+const INACTIVE_PANEL_DIM: f32 = 0.6;
 
 pub type GlMultiRenderer<'a> =
     MultiRenderer<'a, 'a, GbmGlowBackend<DrmDeviceFd>, GbmGlowBackend<DrmDeviceFd>>;
@@ -791,6 +797,12 @@ where
         0
     };
 
+    // Dim panel / layer-shell surfaces on outputs that don't have keyboard focus, as a hint
+    // for which output keyboard-driven shortcuts act on. Only meaningful with multiple outputs
+    let dim_inactive_panels = shell.dim_inactive_panels
+        && shell.outputs().count() > 1
+        && last_active_seat.keyboard_or_active_output() != *output;
+
     let output_size = output
         .geometry()
         .size
@@ -852,6 +864,13 @@ where
                     .map(|id| id.namespace_for_workspace(workspace_idx))
                     .unwrap_or(workspace_idx);
 
+                // Match the dimming of the parent layer surface (panel menus, etc.).
+                let popup_alpha = if dim_inactive_panels {
+                    INACTIVE_PANEL_DIM
+                } else {
+                    1.0
+                };
+
                 push_render_elements_from_surface_tree(
                     renderer,
                     popup.wl_surface(),
@@ -861,7 +880,7 @@ where
                         .to_physical_precise_round(scale),
                     geometry.to_local(output).as_logical().to_f64(),
                     Scale::from(scale),
-                    1.0,
+                    popup_alpha,
                     false,
                     radii,
                     None,
@@ -901,6 +920,13 @@ where
                     .map(|id| id.namespace_for_workspace(workspace_idx))
                     .unwrap_or(workspace_idx);
 
+                // Keep the wallpaper (background layer) at full brightness and only dim panels, docks, notifications, etc.
+                let layer_alpha = if dim_inactive_panels && layer.layer() != WlrLayer::Background {
+                    INACTIVE_PANEL_DIM
+                } else {
+                    1.0
+                };
+
                 push_render_elements_from_surface_tree(
                     renderer,
                     layer.wl_surface(),
@@ -910,7 +936,7 @@ where
                         .to_physical_precise_round(scale),
                     geometry.to_f64(),
                     Scale::from(scale),
-                    1.0,
+                    layer_alpha,
                     false,
                     radii,
                     padded.to_f64(),

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -783,14 +783,14 @@ where
         .lock()
         .unwrap()
         .is_some();
-    let focused_output = last_active_seat.focused_or_active_output();
+    let keyboard_output = last_active_seat.keyboard_or_active_output();
     let set = shell.workspaces.sets.get(output).ok_or(OutputNoMode)?;
     let workspace = set
         .workspaces
         .iter()
         .find(|w| w.handle == current.0)
         .ok_or(OutputNoMode)?;
-    let is_active_space = workspace.output == focused_output;
+    let is_active_space = workspace.output == keyboard_output;
     let active_hint = if shell.active_hint {
         theme.cosmic().active_hint as u8
     } else {
@@ -799,9 +799,8 @@ where
 
     // Dim panel / layer-shell surfaces on outputs that don't have keyboard focus, as a hint
     // for which output keyboard-driven shortcuts act on. Only meaningful with multiple outputs
-    let dim_inactive_panels = shell.dim_inactive_panels
-        && shell.outputs().count() > 1
-        && last_active_seat.keyboard_or_active_output() != *output;
+    let dim_inactive_panels =
+        shell.dim_inactive_panels && shell.outputs().count() > 1 && keyboard_output != *output;
 
     let output_size = output
         .geometry()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -912,6 +912,23 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                     state.common.update_config();
                 }
             }
+            "dim_inactive_panels" => {
+                let new = get_config::<bool>(&config, "dim_inactive_panels");
+                if new != state.common.config.cosmic_conf.dim_inactive_panels {
+                    state.common.config.cosmic_conf.dim_inactive_panels = new;
+                    state.common.update_config();
+                    let outputs = state
+                        .common
+                        .shell
+                        .read()
+                        .outputs()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    for output in &outputs {
+                        state.backend.schedule_render(output);
+                    }
+                }
+            }
             "descale_xwayland" => {
                 let new = get_config::<XwaylandDescaling>(&config, "descale_xwayland");
                 if new != state.common.config.cosmic_conf.descale_xwayland {

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -697,7 +697,7 @@ impl State {
             }
 
             Action::MigrateWorkspaceToOutput(direction) => {
-                let active_output = seat.active_output();
+                let active_output = seat.keyboard_or_active_output();
                 let (active, next_output) = {
                     let shell = self.common.shell.read();
 
@@ -840,7 +840,7 @@ impl State {
                                 .as_ref()
                                 .is_some_and(|(serial, _, _)| *serial == last_mod_serial)
                             {
-                                let current_output = seat.active_output();
+                                let current_output = seat.keyboard_or_active_output();
                                 let workspace_idx = shell.workspaces.active_num(&current_output).1;
                                 shell.previous_workspace_idx = Some((
                                     last_mod_serial,
@@ -880,7 +880,7 @@ impl State {
                         Shell::set_focus(self, Some(&shift), seat, None, true);
                     }
                     _ => {
-                        let current_output = seat.active_output();
+                        let current_output = seat.keyboard_or_active_output();
                         let mut shell = self.common.shell.write();
                         let workspace = shell.active_space(&current_output).unwrap();
                         if let Some(FocusTarget::Window(focused_window)) =
@@ -973,17 +973,15 @@ impl State {
                 &self.common.config,
                 self.common.event_loop_handle.clone(),
             ),
-            // NOTE: implementation currently assumes actions that apply to outputs should apply to the active output
-            // rather than the output that has keyboard focus
             Action::ToggleOrientation => {
-                let output = seat.active_output();
+                let output = seat.keyboard_or_active_output();
                 let mut shell = self.common.shell.write();
                 let workspace = shell.active_space_mut(&output).unwrap();
                 workspace.tiling_layer.update_orientation(None, seat);
             }
 
             Action::Orientation(orientation) => {
-                let output = seat.active_output();
+                let output = seat.keyboard_or_active_output();
                 let mut shell = self.common.shell.write();
                 let workspace = shell.active_space_mut(&output).unwrap();
                 workspace
@@ -1026,7 +1024,7 @@ impl State {
                         }
                     });
                 } else {
-                    let output = seat.active_output();
+                    let output = seat.keyboard_or_active_output();
                     let mut shell = self.common.shell.write();
                     let workspace = shell.workspaces.active_mut(&output).unwrap();
                     let mut guard = self.common.workspace_state.update();

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -19,6 +19,7 @@ use cosmic_settings_config::shortcuts;
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection};
 use smithay::{
     input::{Seat, pointer::MotionEvent},
+    output::Output,
     utils::{Point, Serial},
 };
 #[cfg(not(feature = "debug"))]
@@ -119,11 +120,13 @@ impl State {
             .workspaces
             .workspace_wraparound;
 
+        // Gesture actions target the output under the cursor, not the keyboard-focused one.
+        let output = seat.active_output();
         match action {
             SwipeAction::NextWorkspace => {
                 let _ = to_next_workspace(
                     &mut self.common.shell.write(),
-                    seat,
+                    &output,
                     true,
                     wraparound,
                     &mut self.common.workspace_state.update(),
@@ -132,7 +135,7 @@ impl State {
             SwipeAction::PrevWorkspace => {
                 let _ = to_previous_workspace(
                     &mut self.common.shell.write(),
-                    seat,
+                    &output,
                     true,
                     wraparound,
                     &mut self.common.workspace_state.update(),
@@ -181,7 +184,8 @@ impl State {
             }
 
             Action::Workspace(key_num) => {
-                let current_output = seat.active_output();
+                // Keyboard actions target the keyboard-focused output, not the cursor's.
+                let current_output = seat.keyboard_or_active_output();
                 let workspace = match key_num {
                     0 => 9,
                     x => x - 1,
@@ -192,10 +196,11 @@ impl State {
                     WorkspaceDelta::new_shortcut(),
                     &mut self.common.workspace_state.update(),
                 );
+                seat.set_keyboard_output(Some(&current_output));
             }
 
             Action::LastWorkspace => {
-                let current_output = seat.active_output();
+                let current_output = seat.keyboard_or_active_output();
                 let mut shell = self.common.shell.write();
                 let workspace = shell.workspaces.len(&current_output).saturating_sub(1);
                 let _ = shell.activate(
@@ -204,6 +209,8 @@ impl State {
                     WorkspaceDelta::new_shortcut(),
                     &mut self.common.workspace_state.update(),
                 );
+                drop(shell);
+                seat.set_keyboard_output(Some(&current_output));
             }
 
             Action::NextWorkspace => {
@@ -218,9 +225,10 @@ impl State {
                     return;
                 }
 
+                let current_output = seat.keyboard_or_active_output();
                 let next = to_next_workspace(
                     &mut self.common.shell.write(),
-                    seat,
+                    &current_output,
                     false,
                     self.common
                         .config
@@ -229,6 +237,9 @@ impl State {
                         .workspace_wraparound,
                     &mut self.common.workspace_state.update(),
                 );
+                if next.is_ok() {
+                    seat.set_keyboard_output(Some(&current_output));
+                }
                 if next.is_err()
                     && propagate
                     && let Some(inferred) = pattern.inferred_direction()
@@ -258,9 +269,10 @@ impl State {
                     return;
                 }
 
+                let current_output = seat.keyboard_or_active_output();
                 let previous = to_previous_workspace(
                     &mut self.common.shell.write(),
-                    seat,
+                    &current_output,
                     false,
                     self.common
                         .config
@@ -269,6 +281,9 @@ impl State {
                         .workspace_wraparound,
                     &mut self.common.workspace_state.update(),
                 );
+                if previous.is_ok() {
+                    seat.set_keyboard_output(Some(&current_output));
+                }
                 if previous.is_err()
                     && propagate
                     && let Some(inferred) = pattern.inferred_direction()
@@ -530,7 +545,7 @@ impl State {
             }
 
             Action::SwitchOutput(direction) => {
-                let current_output = seat.active_output();
+                let current_output = seat.keyboard_or_active_output();
                 let mut shell = self.common.shell.write();
 
                 let next_output = shell.next_output(&current_output, direction).cloned();
@@ -555,17 +570,15 @@ impl State {
                         }
 
                         let idx = shell.workspaces.active_num(&next_output).1;
-                        let res = shell.activate(
+                        shell.activate(
                             &next_output,
                             idx,
                             WorkspaceDelta::new_shortcut(),
                             &mut workspace_guard,
-                        );
-                        seat.set_active_output(&next_output);
-                        res
+                        )
                     };
 
-                    if let Ok(new_pos) = res {
+                    if res.is_ok() {
                         let workspace = shell.workspaces.active(&next_output).unwrap().1;
                         let new_target = workspace
                             .focus_stack
@@ -575,23 +588,28 @@ impl State {
                             .map(Into::<KeyboardFocusTarget>::into);
                         std::mem::drop(shell);
 
+                        // Make the keyboard output "stick" to the target even if it has no
+                        // focusable window, so the focus indicator and subsequent keyboard
+                        // actions track it.
+                        seat.set_keyboard_output(Some(&next_output));
+
+                        // Only move keyboard focus. The cursor stays on its own output unless
+                        // the user opted into cursor-follows-focus.
                         let update_cursor = self.common.config.cosmic_conf.cursor_follows_focus;
                         Shell::set_focus(self, new_target.as_ref(), seat, None, update_cursor);
 
-                        if let Some(ptr) = seat.get_pointer() {
-                            // Update cursor position if `set_focus` didn't already
-                            if !update_cursor {
-                                ptr.motion(
-                                    self,
-                                    None,
-                                    &MotionEvent {
-                                        location: new_pos.to_f64().as_logical(),
-                                        serial,
-                                        time,
-                                    },
-                                );
-                            }
-                            ptr.frame(self);
+                        // The keyboard output changed, which flips the panel-dim state on both
+                        // the old and new output. Switching to an empty output produces no
+                        // window damage there, so redraw every output to update the indicator.
+                        let outputs = self
+                            .common
+                            .shell
+                            .read()
+                            .outputs()
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        for output in &outputs {
+                            self.backend.schedule_render(output);
                         }
                     }
                 }
@@ -761,7 +779,7 @@ impl State {
                                     .as_ref()
                                     .is_some_and(|(serial, _, _)| *serial == last_mod_serial)
                                 {
-                                    let current_output = seat.active_output();
+                                    let current_output = seat.keyboard_or_active_output();
                                     let workspace_idx =
                                         shell.workspaces.active_num(&current_output).1;
                                     shell.previous_workspace_idx = Some((
@@ -801,7 +819,8 @@ impl State {
                     }
                     FocusResult::Handled => {}
                     FocusResult::Some(target) => {
-                        Shell::set_focus(self, Some(&target), seat, None, true);
+                        let update_cursor = self.common.config.cosmic_conf.cursor_follows_focus;
+                        Shell::set_focus(self, Some(&target), seat, None, update_cursor);
                     }
                 }
             }
@@ -1062,7 +1081,7 @@ impl State {
         let (token, data) = self.common.xdg_activation_state.create_external_token(None);
         let (token, data) = (token.clone(), data.clone());
 
-        let output = shell.seats.last_active().active_output();
+        let output = shell.seats.last_active().keyboard_or_active_output();
         let workspace = shell.active_space_mut(&output).unwrap();
         let handle = workspace.handle;
         std::mem::drop(shell);
@@ -1131,12 +1150,12 @@ impl State {
 
 fn to_next_workspace(
     shell: &mut Shell,
-    seat: &Seat<State>,
+    output: &Output,
     gesture: bool,
     wraparound: bool,
     workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
 ) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
-    let current_output = seat.active_output();
+    let current_output = output.clone();
     let active = shell.workspaces.active_num(&current_output).1;
     let mut workspace = active.checked_add(1).ok_or(InvalidWorkspaceIndex)?;
 
@@ -1161,12 +1180,12 @@ fn to_next_workspace(
 
 fn to_previous_workspace(
     shell: &mut Shell,
-    seat: &Seat<State>,
+    output: &Output,
     gesture: bool,
     wraparound: bool,
     workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
 ) -> Result<Point<i32, Global>, InvalidWorkspaceIndex> {
-    let current_output = seat.active_output();
+    let current_output = output.clone();
     let active = shell.workspaces.active_num(&current_output).1;
     let workspace = active.checked_sub(1).unwrap_or(if wraparound {
         shell

--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -430,6 +430,10 @@ impl CosmicMapped {
         }
     }
 
+    pub fn is_sticky(&self) -> bool {
+        self.active_window().is_sticky()
+    }
+
     pub fn pending_size(&self) -> Option<Size<i32, Logical>> {
         match &self.element {
             CosmicMappedInternal::Stack(s) => s.pending_size(),

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -248,8 +248,17 @@ impl Shell {
         let workspace = if let Some(workspace) = workspace {
             self.workspaces.space_for_handle_mut(&workspace.0).unwrap()
         } else {
-            //should this be the active output or the focused output?
-            self.active_space_mut(&seat.focused_or_active_output())
+            let output = match &target {
+                FocusTarget::Window(mapped) => self
+                    .workspaces
+                    .sets
+                    .iter()
+                    .find(|(_, set)| set.sticky_layer.mapped().any(|m| m == mapped))
+                    .map(|(output, _)| output.clone()),
+                FocusTarget::Fullscreen(_) => None,
+            };
+
+            self.active_space_mut(&output.unwrap_or_else(|| seat.keyboard_or_active_output()))
                 .unwrap()
         };
 

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -446,14 +446,14 @@ fn update_focus_state(
             // Get focused output calls visible_output_for_surface internally
             // what should happen if the target is some, but it's not visible?
             // should this be an error?
-            seat.set_focused_output(
-                state
-                    .common
-                    .shell
-                    .read()
-                    .get_output_for_focus(seat)
-                    .as_ref(),
-            )
+            let focused_output = state.common.shell.read().get_output_for_focus(seat);
+            seat.set_focused_output(focused_output.as_ref());
+            // Keep the sticky keyboard output in sync whenever we actually gain focus.
+            // It is intentionally *not* cleared in the `else` branch below, so keyboard
+            // actions keep targeting this output even after switching to an empty workspace.
+            if focused_output.is_some() {
+                seat.set_keyboard_output(focused_output.as_ref());
+            }
         } else {
             seat.set_focused_output(None);
         };
@@ -520,6 +520,14 @@ impl Common {
                 if focused_output.is_some_and(|f| !shell.outputs().any(|o| &f == o)) {
                     seat.set_focused_output(None);
                 }
+                // Drop the sticky keyboard output too if its output was removed, otherwise
+                // keyboard actions would keep targeting a gone output.
+                if seat
+                    .keyboard_output()
+                    .is_some_and(|k| !shell.outputs().any(|o| &k == o))
+                {
+                    seat.set_keyboard_output(None);
+                }
                 if !shell.outputs().any(|o| o == &active_output) {
                     if let Some(other) = shell.outputs().next() {
                         seat.set_active_output(other);
@@ -530,7 +538,9 @@ impl Common {
 
             update_pointer_focus(state, seat);
 
-            let output = seat.focused_or_active_output();
+            // Prefer the sticky keyboard output so keyboard focus doesn't get pulled back to
+            // the cursor's output when the keyboard-focused output has no focusable window
+            let output = seat.keyboard_or_active_output();
             let mut shell = state.common.shell.write();
             let last_known_focus = ActiveFocus::get(seat);
 

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -282,7 +282,7 @@ impl Shell {
                     return None;
                 }
 
-                let output = seat.focused_or_active_output();
+                let output = seat.keyboard_or_active_output();
                 let space = self.active_space(&output).unwrap();
                 let stack = space.focus_stack.get(seat);
                 stack.last().and_then(|target| match target {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -281,6 +281,7 @@ pub struct Shell {
 
     theme: cosmic::Theme,
     pub active_hint: bool,
+    pub dim_inactive_panels: bool,
     overview_mode: OverviewMode,
     swap_indicator: Option<SwapIndicator>,
     resize_mode: ResizeMode,
@@ -1573,6 +1574,7 @@ impl Common {
         let mut shell = self.shell.write();
         let shell_ref = &mut *shell;
         shell_ref.active_hint = self.config.cosmic_conf.active_hint;
+        shell_ref.dim_inactive_panels = self.config.cosmic_conf.dim_inactive_panels;
         shell_ref.appearance_conf = self.config.cosmic_conf.appearance_settings;
         if let Some(zoom_state) = shell_ref.zoom_state.as_mut() {
             zoom_state.increment = self.config.cosmic_conf.accessibility_zoom.increment;
@@ -1705,6 +1707,7 @@ impl Shell {
 
             theme,
             active_hint: config.cosmic_conf.active_hint,
+            dim_inactive_panels: config.cosmic_conf.dim_inactive_panels,
             overview_mode: OverviewMode::None,
             swap_indicator: None,
             resize_mode: ResizeMode::None,
@@ -2850,8 +2853,10 @@ impl Shell {
             _ => None,
         };
 
+        let seat_output = seat.keyboard_or_active_output();
+
         let should_be_fullscreen = output.is_some();
-        let mut output = output.unwrap_or_else(|| seat.active_output());
+        let mut output = output.unwrap_or_else(|| seat_output.clone());
 
         // this is beyond stupid, just to make the borrow checker happy
         let workspace = if let Some(handle) = workspace_handle.filter(|handle| {
@@ -2892,7 +2897,7 @@ impl Shell {
 
         let workspace_output = workspace.output.clone();
         let was_activated = workspace_handle.is_some()
-            && (workspace_output != seat.active_output() || active_handle != workspace.handle);
+            && (workspace_output != seat_output || active_handle != workspace.handle);
         let workspace_handle = workspace.handle;
         let is_dialog = layout::is_dialog(&window);
         let floating_exception = layout::has_floating_exception(&self.tiling_exceptions, &window);
@@ -2903,7 +2908,7 @@ impl Shell {
                 workspace_state.add_workspace_state(&workspace_handle, WState::Urgent);
             }
 
-            return (workspace_output == seat.active_output() && active_handle == workspace_handle)
+            return (workspace_output == seat_output && active_handle == workspace_handle)
                 .then_some(KeyboardFocusTarget::Fullscreen(window));
         }
 
@@ -2918,7 +2923,7 @@ impl Shell {
             if was_activated {
                 workspace_state.add_workspace_state(&workspace_handle, WState::Urgent);
             }
-            return (workspace_output == seat.active_output() && active_handle == workspace_handle)
+            return (workspace_output == seat_output && active_handle == workspace_handle)
                 .then_some(KeyboardFocusTarget::Element(focused));
         }
 
@@ -2960,8 +2965,7 @@ impl Shell {
             self.maximize_request(&mapped, &seat, false, loop_handle);
         }
 
-        let new_target = if (workspace_output == seat.active_output()
-            && active_handle == workspace_handle)
+        let new_target = if (workspace_output == seat_output && active_handle == workspace_handle)
             || should_be_sticky
         {
             // TODO: enforce focus stealing prevention by also checking the same rules as for the else case.
@@ -4016,7 +4020,7 @@ impl Shell {
         let Some(target) = seat.get_keyboard().unwrap().current_focus() else {
             return FocusResult::None;
         };
-        let output = seat.active_output();
+        let output = seat.keyboard_or_active_output();
 
         if matches!(target, KeyboardFocusTarget::Fullscreen(_)) {
             return FocusResult::None;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -508,6 +508,12 @@ impl WorkspaceSet {
         }
     }
 
+    fn refresh_focus_stacks(&mut self) {
+        for workspace in &mut self.workspaces {
+            workspace.refresh_focus_stack();
+        }
+    }
+
     fn activate(
         &mut self,
         idx: usize,
@@ -612,6 +618,7 @@ impl WorkspaceSet {
             self.workspaces[self.active].refresh();
         }
         self.sticky_layer.refresh();
+        self.refresh_focus_stacks();
     }
 
     fn add_empty_workspace(&mut self, state: &mut WorkspaceUpdateGuard<State>) {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4814,7 +4814,11 @@ impl Shell {
         ) {
             return;
         }
-        let set = self.workspaces.sets.get_mut(&seat.active_output()).unwrap();
+        let set = self
+            .workspaces
+            .sets
+            .get_mut(&seat.keyboard_or_active_output())
+            .unwrap();
         let workspace = &mut set.workspaces[set.active];
 
         let maybe_window = workspace.focus_stack.get(seat).iter().next().cloned();

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -203,6 +203,15 @@ struct ActiveOutput(pub Mutex<Output>);
 /// The output which currently has keyboard focus
 struct FocusedOutput(pub Mutex<Option<Output>>);
 
+/// The output that keyboard-driven actions (e.g. workspace switching) should target.
+///
+/// Unlike [`FocusedOutput`], this is "sticky": it tracks the output that last held keyboard
+/// focus and is updated on keyboard-driven output/workspace switches, but it is *not* cleared
+/// when the currently focused workspace has no focusable window. This keeps keyboard shortcuts
+/// acting on the same output even after switching to an empty workspace, and it is never moved
+/// by pointer motion.
+struct KeyboardOutput(pub Mutex<Option<Output>>);
+
 #[derive(Default)]
 pub struct PointerConstraintHint(pub Mutex<Option<(WlSurface, Point<f64, Logical>)>>);
 
@@ -229,6 +238,7 @@ pub fn create_seat(
     userdata.insert_if_missing_threadsafe(CursorState::default);
     userdata.insert_if_missing_threadsafe(|| ActiveOutput(Mutex::new(output.clone())));
     userdata.insert_if_missing_threadsafe(|| FocusedOutput(Mutex::new(None)));
+    userdata.insert_if_missing_threadsafe(|| KeyboardOutput(Mutex::new(None)));
     userdata.insert_if_missing_threadsafe(PointerConstraintHint::default);
     userdata.insert_if_missing_threadsafe(|| Mutex::new(CursorImageStatus::default_named()));
 
@@ -280,8 +290,17 @@ pub trait SeatExt {
         self.focused_output()
             .unwrap_or_else(|| self.active_output())
     }
+    /// The output keyboard-driven actions should target (sticky keyboard focus), see
+    /// [`KeyboardOutput`]. Returns `None` if no output has held keyboard focus yet.
+    fn keyboard_output(&self) -> Option<Output>;
+    /// The output keyboard-driven actions should target, falling back to the cursor's output.
+    fn keyboard_or_active_output(&self) -> Output {
+        self.keyboard_output()
+            .unwrap_or_else(|| self.active_output())
+    }
     fn set_active_output(&self, output: &Output);
     fn set_focused_output(&self, output: Option<&Output>);
+    fn set_keyboard_output(&self, output: Option<&Output>);
     fn devices(&self) -> &Devices;
     fn supressed_keys(&self) -> &SupressedKeys;
     fn supressed_buttons(&self) -> &SupressedButtons;
@@ -331,6 +350,12 @@ impl SeatExt for Seat<State> {
         }
     }
 
+    fn keyboard_output(&self) -> Option<Output> {
+        self.user_data()
+            .get::<KeyboardOutput>()
+            .and_then(|x| x.0.lock().unwrap().clone())
+    }
+
     fn set_active_output(&self, output: &Output) {
         *self
             .user_data()
@@ -345,6 +370,16 @@ impl SeatExt for Seat<State> {
         *self
             .user_data()
             .get::<FocusedOutput>()
+            .unwrap()
+            .0
+            .lock()
+            .unwrap() = output.cloned();
+    }
+
+    fn set_keyboard_output(&self, output: Option<&Output>) {
+        *self
+            .user_data()
+            .get::<KeyboardOutput>()
             .unwrap()
             .0
             .lock()

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -499,7 +499,7 @@ impl Workspace {
         self.is_empty() && !self.has_activation_token(xdg_activation_state) && !self.pinned
     }
 
-    /// cleans up any window that is not alive anymore
+    /// Drops focus stack entries for windows that are no longer in this workspace.
     pub fn refresh_focus_stack(&mut self) {
         for (seat, stack) in self.focus_stack.0.iter_mut() {
             let fullscreen_surfaces: Vec<&CosmicSurface> = self
@@ -526,10 +526,18 @@ impl Workspace {
                     .mapped()
                     .chain(self.tiling_layer.mapped().map(|(w, _)| w))
                     .chain(move_mapped.iter())
+                    .chain(
+                        self.minimized_windows
+                            .iter()
+                            .flat_map(MinimizedWindow::mapped),
+                    )
             };
             stack.retain(|w| match w {
                 FocusTarget::Fullscreen(s) => fullscreen_surfaces.contains(&s),
-                FocusTarget::Window(w) => mapped().any(|m| w == m),
+                // Sticky windows live in the `WorkspaceSet`, not in our own layers, but are
+                // shown on whichever workspace is current, so a focused one legitimately sits
+                // in this stack
+                FocusTarget::Window(w) => w.is_sticky() || mapped().any(|m| w == m),
             });
         }
     }
@@ -1767,13 +1775,17 @@ impl Workspace {
 
             self.floating_layer.render(
                 renderer,
-                focused.as_ref().and_then(|target| {
-                    if let FocusTarget::Window(mapped) = target {
-                        Some(mapped)
-                    } else {
-                        None
-                    }
-                }),
+                render_focus
+                    .then(|| {
+                        focused.as_ref().and_then(|target| {
+                            if let FocusTarget::Window(mapped) = target {
+                                Some(mapped)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .flatten(),
                 resize_indicator.clone(),
                 indicator_thickness,
                 alpha,

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -385,8 +385,8 @@ impl State {
             let initial_size = if let Some(output) = pending.fullscreen.as_ref() {
                 Some(output.geometry().size.as_logical())
             } else if pending.maximized {
-                let active_output = shell.seats.last_active().active_output();
-                let zone = layer_map_for_output(&active_output).non_exclusive_zone();
+                let output = pending.seat.keyboard_or_active_output();
+                let zone = layer_map_for_output(&output).non_exclusive_zone();
                 Some(zone.size)
             } else {
                 None

--- a/src/wayland/handlers/layer_shell.rs
+++ b/src/wayland/handlers/layer_shell.rs
@@ -27,10 +27,12 @@ impl WlrLayerShellHandler for State {
     ) {
         let mut shell = self.common.shell.write();
         let seat = shell.seats.last_active().clone();
+        // When a layer-shell client (e.g. the launcher / window switcher) doesn't pin an
+        // output, place it on the keyboard-focused output rather than the cursor's
         let output = wl_output
             .as_ref()
             .and_then(Output::from_resource)
-            .unwrap_or_else(|| seat.active_output());
+            .unwrap_or_else(|| seat.keyboard_or_active_output());
         shell.pending_layers.push(PendingLayer {
             surface: LayerSurface::new(surface, namespace),
             output,

--- a/src/wayland/handlers/xdg_activation.rs
+++ b/src/wayland/handlers/xdg_activation.rs
@@ -54,7 +54,7 @@ impl XdgActivationHandler for State {
                     let shell = self.common.shell.read();
                     shell.seats.last_active().clone()
                 });
-            let output = seat.active_output();
+            let output = seat.keyboard_or_active_output();
             let mut shell = self.common.shell.write();
             let Some(workspace) = shell.active_space_mut(&output) else {
                 debug!(?token, "created urgent token for privileged client");
@@ -93,7 +93,7 @@ impl XdgActivationHandler for State {
             .unwrap_or(false);
 
         if valid {
-            let output = seat.active_output();
+            let output = seat.keyboard_or_active_output();
             let mut shell = self.common.shell.write();
             let Some(workspace) = shell.active_space_mut(&output) else {
                 data.user_data
@@ -145,7 +145,7 @@ impl XdgActivationHandler for State {
                         };
 
                         let seat = shell.seats.last_active().clone();
-                        let current_output = seat.active_output();
+                        let current_output = seat.keyboard_or_active_output();
                         let current_workspace = shell.active_space(&current_output).unwrap().handle;
 
                         if target_workspace == current_workspace {
@@ -181,7 +181,7 @@ impl State {
         let mut shell = self.common.shell.write();
 
         let seat = shell.seats.last_active().clone();
-        let current_output = seat.active_output();
+        let current_output = seat.keyboard_or_active_output();
 
         if let Some(element) = shell.element_for_surface(surface).cloned() {
             if element.is_minimized() {


### PR DESCRIPTION
Currently cosmic-comp considers the output with the cursor to be the active output. This forces us to move the cursor to other outputs when a user is using the keyboard to switch focus. Because other wise even though a window on another output is selected, the keyboard shortcuts happen on the old output with the cursor. But people [don't like](https://github.com/pop-os/cosmic-comp/issues/930) when the cursor jumps around.
Warping the cursor around is jarring, and not warping it makes being keyboard-only on a multi-monitor setup impossible.

One of the issues currently in cosmic-comp is if you have "cursor follows focus" off, then if you switch focus to another window on another output, the cursor stays on the old output which means your keyboard shortcuts will happen somewhere that you're not looking at anymore. The solution to that was to move the cursor. I created a [pr](https://github.com/pop-os/cosmic-comp/pull/2410). But people [hate](https://github.com/pop-os/cosmic-epoch/issues/3121) [it](https://github.com/pop-os/cosmic-comp/pull/2457) when the cursor jumps around so we had to [revert it](https://github.com/pop-os/cosmic-comp/pull/2499).

There is a thread [here](https://github.com/pop-os/cosmic-epoch/issues/2233) with more discussion, and [here](https://chat.pop-os.org/pop-os/pl/ykifswdoyfyydcwsy4dfyticac)'s my chat with Maria.

Proposed solution:
I propose we separate keyboard-originated shortcuts and pointer-originated shortcuts. Any pointer-originated shortcut (such as 4-finger swipe) should happen on the output that has the pointer, any keyboard-originated action should happen on the screen with the keyboard focus (such as super+alt+h/l, or super+t).

Challenge:
- Currently cosmic-comp's `focused_output` won't focus an output that doesn't have an open window. I propose we add a new struct that holds the output that has the keyboard focus, even if it doesn't have any windows open.
- Currently if you switch output to another output that doesn't have a window open your only indicator is the fact that the cursor pops up in the middle of the screen, otherwise there is no way to tell where your keyboard focus is. I propose adding a config to dim the panel on outputs that do not have keyboard focus (this is what MacOS does for example).

This PR works, and shows what I mean.Even though there may be more places that we need to use the correct active output.

To see the dimming of the panels on the inactive outputs add `~/.config/cosmic/com.system76.CosmicComp/v1/dim_inactive_panels` and set it to `true`.


EDIT: I have been using this for weeks with "cursor follows focus" off. It's very nice. Everything behaves as you'd expect. and the cursor stays where you leave it.

I'd appreciate any feedback. 
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

