### PR TITLE
fix: input to cropped tiled windows should be bound to the tile

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -788,7 +788,12 @@ impl State {
                             let shell = self.common.shell.read();
                             State::element_under(global_position, &output, &shell, &seat)
                         };
-                        if let Some(target) = under {
+                        // Grabbing a tiling resize handle (the gap between tiles) must not change keyboard focus
+                        let on_resize_fork = matches!(
+                            seat.get_pointer().unwrap().current_focus(),
+                            Some(PointerFocusTarget::ResizeFork(_))
+                        );
+                        if let Some(target) = under.filter(|_| !on_resize_fork) {
                             if let Some(surface) = target.toplevel().map(Cow::into_owned)
                                 && seat.get_keyboard().unwrap().modifier_state().logo
                                 && !shortcuts_inhibited

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -3180,6 +3180,10 @@ impl TilingLayout {
         let location = location_f64.to_i32_round();
 
         for (mapped, geo) in self.mapped() {
+            // Tiled windows are rendered cropped to their tile (`geo`), so input must be bound to the tile as well
+            if !geo.contains(location) {
+                continue;
+            }
             if !mapped.bbox().contains((location - geo.loc).as_logical()) {
                 continue;
             }
@@ -3244,6 +3248,10 @@ impl TilingLayout {
 
         if matches!(overview, OverviewMode::None) {
             for (mapped, geo) in self.mapped() {
+                // Tiled windows are rendered cropped to their tile (`geo`), so input must be bound to the tile as well
+                if !geo.contains(location) {
+                    continue;
+                }
                 if !mapped.bbox().contains((location - geo.loc).as_logical()) {
                     continue;
                 }


### PR DESCRIPTION
Zen Browser window has a min size, in tiling mode we allow resizing a window beyond its min size.
If I open a Zen window on the top, and another window below it, resize the top one to a very small height, I then can't click on the top of the bottom window, the mouse events are sent to the top window, since the events are in its bbox. But not in its geo.

To reproduce:
- Open a zen browser window (or any window with a min size)
- open another window below it in tiling mode
- Select the top window (it's important)
- Resize to some smaller amount than the window's min
- The top of the bottom window is not accessible anymore, your pointer events goes to the top window

In this video you can see if I resize using the bottom window everything is fine, but if I resize the top window, then the top of the bottom window doesn't receive pointer events:


https://github.com/user-attachments/assets/e0336ce0-48bd-4db7-9f38-5fd098e9d5e2




___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

