### PR TITLE
feat: add Grid workspace layout

### DIFF
--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -13,10 +13,22 @@ pub struct WorkspaceConfig {
     pub action_on_typing: Action,
     #[serde(default = "default_wraparound")]
     pub workspace_wraparound: bool,
+    #[serde(default = "default_grid_columns")]
+    pub workspace_grid_columns: u32,
+    #[serde(default = "default_grid_rows")]
+    pub workspace_grid_rows: u32,
 }
 
 fn default_wraparound() -> bool {
     true
+}
+
+fn default_grid_columns() -> u32 {
+    3
+}
+
+fn default_grid_rows() -> u32 {
+    2
 }
 
 impl Default for WorkspaceConfig {
@@ -26,6 +38,8 @@ impl Default for WorkspaceConfig {
             workspace_layout: WorkspaceLayout::default(),
             action_on_typing: Action::default(),
             workspace_wraparound: default_wraparound(),
+            workspace_grid_columns: default_grid_columns(),
+            workspace_grid_rows: default_grid_rows(),
         }
     }
 }
@@ -42,6 +56,7 @@ pub enum WorkspaceLayout {
     #[default]
     Vertical,
     Horizontal,
+    Grid,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -204,6 +204,37 @@ impl State {
             }
 
             Action::NextWorkspace => {
+                if self.common.config.cosmic_conf.workspaces.workspace_layout
+                    == WorkspaceLayout::Grid
+                {
+                    let Some(direction) = pattern.inferred_direction() else {
+                        return;
+                    };
+                    let wraparound = self
+                        .common
+                        .config
+                        .cosmic_conf
+                        .workspaces
+                        .workspace_wraparound;
+                    let columns =
+                        self.common.shell.read().workspaces.grid_columns as usize;
+                    let current_output = seat.active_output();
+                    let mut shell = self.common.shell.write();
+                    let active = shell.workspaces.active_num(&current_output).1;
+                    let total = shell.workspaces.len(&current_output);
+                    if let Some(target) =
+                        grid_target_index(active, direction, columns, total, wraparound)
+                    {
+                        let _ = shell.activate(
+                            &current_output,
+                            target,
+                            WorkspaceDelta::new_shortcut(),
+                            &mut self.common.workspace_state.update(),
+                        );
+                    }
+                    return;
+                }
+
                 if let Some(direction) = pattern.inferred_direction()
                     && (((direction == Direction::Left || direction == Direction::Right)
                         && self.common.config.cosmic_conf.workspaces.workspace_layout
@@ -243,6 +274,37 @@ impl State {
             }
 
             Action::PreviousWorkspace => {
+                if self.common.config.cosmic_conf.workspaces.workspace_layout
+                    == WorkspaceLayout::Grid
+                {
+                    let Some(direction) = pattern.inferred_direction() else {
+                        return;
+                    };
+                    let wraparound = self
+                        .common
+                        .config
+                        .cosmic_conf
+                        .workspaces
+                        .workspace_wraparound;
+                    let columns =
+                        self.common.shell.read().workspaces.grid_columns as usize;
+                    let current_output = seat.active_output();
+                    let mut shell = self.common.shell.write();
+                    let active = shell.workspaces.active_num(&current_output).1;
+                    let total = shell.workspaces.len(&current_output);
+                    if let Some(target) =
+                        grid_target_index(active, direction, columns, total, wraparound)
+                    {
+                        let _ = shell.activate(
+                            &current_output,
+                            target,
+                            WorkspaceDelta::new_shortcut(),
+                            &mut self.common.workspace_state.update(),
+                        );
+                    }
+                    return;
+                }
+
                 if let Some(direction) = pattern.inferred_direction()
                     && (((direction == Direction::Left || direction == Direction::Right)
                         && self.common.config.cosmic_conf.workspaces.workspace_layout
@@ -338,6 +400,52 @@ impl State {
             }
 
             x @ Action::MoveToNextWorkspace | x @ Action::SendToNextWorkspace => {
+                if self.common.config.cosmic_conf.workspaces.workspace_layout
+                    == WorkspaceLayout::Grid
+                {
+                    let Some(direction) = pattern.inferred_direction() else {
+                        return;
+                    };
+                    let Some(focused_output) = seat.focused_output() else {
+                        return;
+                    };
+                    let wraparound = self
+                        .common
+                        .config
+                        .cosmic_conf
+                        .workspaces
+                        .workspace_wraparound;
+                    let columns =
+                        self.common.shell.read().workspaces.grid_columns as usize;
+                    let res = {
+                        let mut shell = self.common.shell.write();
+                        let active = shell.workspaces.active_num(&focused_output).1;
+                        let total = shell.workspaces.len(&focused_output);
+                        grid_target_index(active, direction, columns, total, wraparound)
+                            .ok_or(InvalidWorkspaceIndex)
+                            .and_then(|target| {
+                                shell.move_current(
+                                    seat,
+                                    (&focused_output, Some(target)),
+                                    matches!(x, Action::MoveToNextWorkspace),
+                                    Some(direction),
+                                    &mut self.common.workspace_state.update(),
+                                    &self.common.event_loop_handle,
+                                )
+                            })
+                    };
+                    if let Ok(Some((target, _point))) = res {
+                        Shell::set_focus(
+                            self,
+                            Some(&target),
+                            seat,
+                            None,
+                            matches!(x, Action::MoveToNextWorkspace),
+                        );
+                    }
+                    return;
+                }
+
                 if let Some(direction) = pattern.inferred_direction()
                     && (((direction == Direction::Left || direction == Direction::Right)
                         && self.common.config.cosmic_conf.workspaces.workspace_layout
@@ -430,6 +538,52 @@ impl State {
             }
 
             x @ Action::MoveToPreviousWorkspace | x @ Action::SendToPreviousWorkspace => {
+                if self.common.config.cosmic_conf.workspaces.workspace_layout
+                    == WorkspaceLayout::Grid
+                {
+                    let Some(direction) = pattern.inferred_direction() else {
+                        return;
+                    };
+                    let Some(focused_output) = seat.focused_output() else {
+                        return;
+                    };
+                    let wraparound = self
+                        .common
+                        .config
+                        .cosmic_conf
+                        .workspaces
+                        .workspace_wraparound;
+                    let columns =
+                        self.common.shell.read().workspaces.grid_columns as usize;
+                    let res = {
+                        let mut shell = self.common.shell.write();
+                        let active = shell.workspaces.active_num(&focused_output).1;
+                        let total = shell.workspaces.len(&focused_output);
+                        grid_target_index(active, direction, columns, total, wraparound)
+                            .ok_or(InvalidWorkspaceIndex)
+                            .and_then(|target| {
+                                shell.move_current(
+                                    seat,
+                                    (&focused_output, Some(target)),
+                                    matches!(x, Action::MoveToPreviousWorkspace),
+                                    Some(direction),
+                                    &mut self.common.workspace_state.update(),
+                                    &self.common.event_loop_handle,
+                                )
+                            })
+                    };
+                    if let Ok(Some((target, _point))) = res {
+                        Shell::set_focus(
+                            self,
+                            Some(&target),
+                            seat,
+                            None,
+                            matches!(x, Action::MoveToPreviousWorkspace),
+                        );
+                    }
+                    return;
+                }
+
                 if let Some(direction) = pattern.inferred_direction()
                     && (((direction == Direction::Left || direction == Direction::Right)
                         && self.common.config.cosmic_conf.workspaces.workspace_layout
@@ -771,6 +925,12 @@ impl State {
                                 | (Direction::Down, WorkspaceLayout::Vertical) => {
                                     Action::NextWorkspace
                                 }
+                                // Grid mode: all 4 directions stay in the workspace grid;
+                                // the actual direction is re-resolved via
+                                // pattern.inferred_direction() inside NextWorkspace's
+                                // Grid branch, so dispatching through NextWorkspace here
+                                // (regardless of which physical arrow was pressed) is correct.
+                                (_, WorkspaceLayout::Grid) => Action::NextWorkspace,
                                 _ => Action::SwitchOutput(direction),
                             };
 
@@ -829,6 +989,8 @@ impl State {
                             | (Direction::Down, WorkspaceLayout::Vertical) => {
                                 Action::MoveToNextWorkspace
                             }
+                            // Grid mode: see the matching comment in the Focus arm above.
+                            (_, WorkspaceLayout::Grid) => Action::MoveToNextWorkspace,
                             _ => Action::MoveToOutput(direction),
                         };
 
@@ -1114,6 +1276,75 @@ impl State {
     }
 }
 
+// Grid mode: compute the target workspace index for a directional move.
+// Left/Right step by 1 within the current row (wrapping at row edges, staying
+// in the same row). Up/Down step by exactly `columns` (wrapping top<->bottom
+// in the same column). `total` is the current (fixed, in Grid mode) workspace
+// count for this output; rows is derived from it since columns evenly divides
+// the total.
+fn grid_target_index(
+    active: usize,
+    direction: Direction,
+    columns: usize,
+    total: usize,
+    wraparound: bool,
+) -> Option<usize> {
+    let columns = columns.max(1);
+    let rows = (total / columns).max(1);
+    let col = active % columns;
+    let row = active / columns;
+    grid_target_index_inner(active, direction, columns, rows, col, row, wraparound)
+}
+
+fn grid_target_index_inner(
+    active: usize,
+    direction: Direction,
+    columns: usize,
+    rows: usize,
+    col: usize,
+    row: usize,
+    wraparound: bool,
+) -> Option<usize> {
+    match direction {
+        Direction::Left => {
+            if col > 0 {
+                Some(active - 1)
+            } else if wraparound {
+                Some(active + columns - 1)
+            } else {
+                None
+            }
+        }
+        Direction::Right => {
+            if col + 1 < columns {
+                Some(active + 1)
+            } else if wraparound {
+                Some(active - (columns - 1))
+            } else {
+                None
+            }
+        }
+        Direction::Up => {
+            if row > 0 {
+                Some(active - columns)
+            } else if wraparound {
+                Some(active + columns * (rows - 1))
+            } else {
+                None
+            }
+        }
+        Direction::Down => {
+            if row + 1 < rows {
+                Some(active + columns)
+            } else if wraparound {
+                Some(active - columns * (rows - 1))
+            } else {
+                None
+            }
+        }
+    }
+}
+
 fn to_next_workspace(
     shell: &mut Shell,
     seat: &Seat<State>,
@@ -1177,4 +1408,86 @@ fn to_previous_workspace(
         },
         workspace_state,
     )
+}
+
+#[cfg(test)]
+mod grid_tests {
+    use super::*;
+
+    // 3x2 grid, indices:
+    //   0 1 2
+    //   3 4 5
+    const COLS: usize = 3;
+    const TOTAL: usize = 6;
+
+    fn go(active: usize, dir: Direction, wrap: bool) -> Option<usize> {
+        grid_target_index(active, dir, COLS, TOTAL, wrap)
+    }
+
+    #[test]
+    fn right_within_row() {
+        assert_eq!(go(0, Direction::Right, true), Some(1));
+        assert_eq!(go(3, Direction::Right, true), Some(4));
+    }
+
+    #[test]
+    fn right_wraps_within_same_row() {
+        assert_eq!(go(2, Direction::Right, true), Some(0));
+        assert_eq!(go(5, Direction::Right, true), Some(3));
+        assert_eq!(go(2, Direction::Right, false), None);
+        assert_eq!(go(5, Direction::Right, false), None);
+    }
+
+    #[test]
+    fn left_within_row() {
+        assert_eq!(go(1, Direction::Left, true), Some(0));
+        assert_eq!(go(5, Direction::Left, true), Some(4));
+    }
+
+    #[test]
+    fn left_wraps_within_same_row() {
+        assert_eq!(go(0, Direction::Left, true), Some(2));
+        assert_eq!(go(3, Direction::Left, true), Some(5));
+        assert_eq!(go(0, Direction::Left, false), None);
+        assert_eq!(go(3, Direction::Left, false), None);
+    }
+
+    #[test]
+    fn down_preserves_column() {
+        assert_eq!(go(0, Direction::Down, true), Some(3));
+        assert_eq!(go(1, Direction::Down, true), Some(4));
+        assert_eq!(go(2, Direction::Down, true), Some(5));
+    }
+
+    #[test]
+    fn down_wraps_to_top_same_column() {
+        assert_eq!(go(3, Direction::Down, true), Some(0));
+        assert_eq!(go(4, Direction::Down, true), Some(1));
+        assert_eq!(go(5, Direction::Down, true), Some(2));
+        assert_eq!(go(5, Direction::Down, false), None);
+    }
+
+    #[test]
+    fn up_preserves_column() {
+        assert_eq!(go(3, Direction::Up, true), Some(0));
+        assert_eq!(go(4, Direction::Up, true), Some(1));
+        assert_eq!(go(5, Direction::Up, true), Some(2));
+    }
+
+    #[test]
+    fn up_wraps_to_bottom_same_column() {
+        assert_eq!(go(0, Direction::Up, true), Some(3));
+        assert_eq!(go(1, Direction::Up, true), Some(4));
+        assert_eq!(go(2, Direction::Up, true), Some(5));
+        assert_eq!(go(0, Direction::Up, false), None);
+    }
+
+    #[test]
+    fn degenerate_dimensions_do_not_panic() {
+        // columns=0 clamps to 1; single-column grid
+        assert_eq!(grid_target_index(0, Direction::Down, 0, 2, true), Some(1));
+        // 1x1 grid: every move is either None or self-target (never panics)
+        let _ = grid_target_index(0, Direction::Left, 1, 1, true);
+        let _ = grid_target_index(0, Direction::Up, 1, 1, true);
+    }
 }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -136,6 +136,26 @@ impl State {
                     &mut self.common.workspace_state.update(),
                 );
             }
+            SwipeAction::GridMove(direction) => {
+                let columns = self.common.shell.read().workspaces.grid_columns as usize;
+                let current_output = seat.active_output();
+                let mut shell = self.common.shell.write();
+                let active = shell.workspaces.active_num(&current_output).1;
+                let total = shell.workspaces.len(&current_output);
+                if let Some(target) =
+                    grid_target_index(active, direction, columns, total, wraparound)
+                {
+                    let _ = shell.activate(
+                        &current_output,
+                        target,
+                        WorkspaceDelta::new_gesture(matches!(
+                            direction,
+                            Direction::Right | Direction::Down
+                        )),
+                        &mut self.common.workspace_state.update(),
+                    );
+                }
+            }
         }
     }
 
@@ -925,12 +945,15 @@ impl State {
                                 | (Direction::Down, WorkspaceLayout::Vertical) => {
                                     Action::NextWorkspace
                                 }
-                                // Grid mode: all 4 directions stay in the workspace grid;
-                                // the actual direction is re-resolved via
-                                // pattern.inferred_direction() inside NextWorkspace's
-                                // Grid branch, so dispatching through NextWorkspace here
-                                // (regardless of which physical arrow was pressed) is correct.
-                                (_, WorkspaceLayout::Grid) => Action::NextWorkspace,
+                                // Grid: all 4 directions stay in the workspace grid.
+                                // The Grid branches of Next/PreviousWorkspace resolve
+                                // the actual move from the binding's inferred direction.
+                                (Direction::Left | Direction::Up, WorkspaceLayout::Grid) => {
+                                    Action::PreviousWorkspace
+                                }
+                                (Direction::Right | Direction::Down, WorkspaceLayout::Grid) => {
+                                    Action::NextWorkspace
+                                }
                                 _ => Action::SwitchOutput(direction),
                             };
 
@@ -989,8 +1012,13 @@ impl State {
                             | (Direction::Down, WorkspaceLayout::Vertical) => {
                                 Action::MoveToNextWorkspace
                             }
-                            // Grid mode: see the matching comment in the Focus arm above.
-                            (_, WorkspaceLayout::Grid) => Action::MoveToNextWorkspace,
+                            // Grid: see the matching comment in the Focus arm above.
+                            (Direction::Left | Direction::Up, WorkspaceLayout::Grid) => {
+                                Action::MoveToPreviousWorkspace
+                            }
+                            (Direction::Right | Direction::Down, WorkspaceLayout::Grid) => {
+                                Action::MoveToNextWorkspace
+                            }
                             _ => Action::MoveToOutput(direction),
                         };
 

--- a/src/input/gestures/mod.rs
+++ b/src/input/gestures/mod.rs
@@ -16,6 +16,8 @@ pub struct SwipeEvent {
 pub enum SwipeAction {
     NextWorkspace,
     PrevWorkspace,
+    /// Grid layout: a directional workspace move (any of the 4 directions).
+    GridMove(Direction),
 }
 
 #[derive(Debug, Clone)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1090,6 +1090,28 @@ impl State {
                                 3 => None, // TODO: 3 finger gestures
                                 4 => {
                                     if self.common.config.cosmic_conf.workspaces.workspace_layout
+                                        == WorkspaceLayout::Grid
+                                    {
+                                        // Grid: all four directions are workspace moves.
+                                        gesture_state.direction.map(|direction| {
+                                            let direction = if natural_scroll {
+                                                match direction {
+                                                    Direction::Left => Direction::Right,
+                                                    Direction::Right => Direction::Left,
+                                                    Direction::Up => Direction::Down,
+                                                    Direction::Down => Direction::Up,
+                                                }
+                                            } else {
+                                                direction
+                                            };
+                                            SwipeAction::GridMove(direction)
+                                        })
+                                    } else if self
+                                        .common
+                                        .config
+                                        .cosmic_conf
+                                        .workspaces
+                                        .workspace_layout
                                         == WorkspaceLayout::Horizontal
                                     {
                                         match gesture_state.direction {
@@ -1144,6 +1166,13 @@ impl State {
                                     matches!(x, SwipeAction::NextWorkspace),
                                 )
                             }
+                            Some(SwipeAction::GridMove(direction)) => {
+                                self.common.shell.write().update_workspace_delta(
+                                    &seat.active_output(),
+                                    gesture_state.delta,
+                                    matches!(direction, Direction::Right | Direction::Down),
+                                )
+                            }
                             _ => {}
                         }
                     } else {
@@ -1184,6 +1213,22 @@ impl State {
                                     } else {
                                         velocity / seat.active_output().geometry().size.h as f64
                                     };
+                                let _ = self.common.shell.write().end_workspace_swipe(
+                                    &seat.active_output(),
+                                    norm_velocity,
+                                    &mut self.common.workspace_state.update(),
+                                );
+                            }
+                            Some(SwipeAction::GridMove(direction)) => {
+                                let velocity = gesture_state.velocity();
+                                let norm_velocity = if matches!(
+                                    direction,
+                                    Direction::Left | Direction::Right
+                                ) {
+                                    velocity / seat.active_output().geometry().size.w as f64
+                                } else {
+                                    velocity / seat.active_output().geometry().size.h as f64
+                                };
                                 let _ = self.common.shell.write().end_workspace_swipe(
                                     &seat.active_output(),
                                     norm_velocity,

--- a/src/shell/focus/order.rs
+++ b/src/shell/focus/order.rs
@@ -147,6 +147,18 @@ fn render_input_order_internal<R: 'static>(
     let (previous, current_offset) = match previous.as_ref() {
         Some((previous, previous_idx, start)) => {
             let layout = shell.workspaces.layout;
+            // Grid mode: match exhaustiveness is type-based, not value-based, so
+            // shadowing `layout` to a narrower value doesn't satisfy the compiler.
+            // Instead, reduce to a plain bool ("is this move horizontal?") up
+            // front, and match on that below instead of on `layout` directly.
+            // In Grid mode this is based on whether the column changed; `forward`
+            // (computed below) already gives the correct sign for either axis.
+            let is_horizontal_move = if layout == WorkspaceLayout::Grid {
+                let columns = shell.workspaces.grid_columns.max(1) as usize;
+                *previous_idx % columns != current.1 % columns
+            } else {
+                layout == WorkspaceLayout::Horizontal
+            };
 
             let Some(workspace) = shell.workspaces.space_for_handle(previous) else {
                 return ControlFlow::Break(Err(OutputNoMode));
@@ -178,28 +190,20 @@ fn render_input_order_internal<R: 'static>(
                 ),
             };
 
-            let offset = Point::<i32, Logical>::from(match (layout, forward) {
-                (WorkspaceLayout::Vertical, true) => {
-                    (0, (-output_size.h as f32 * percentage).round() as i32)
-                }
-                (WorkspaceLayout::Vertical, false) => {
-                    (0, (output_size.h as f32 * percentage).round() as i32)
-                }
-                (WorkspaceLayout::Horizontal, true) => {
-                    ((-output_size.w as f32 * percentage).round() as i32, 0)
-                }
-                (WorkspaceLayout::Horizontal, false) => {
-                    ((output_size.w as f32 * percentage).round() as i32, 0)
-                }
+            let offset = Point::<i32, Logical>::from(match (is_horizontal_move, forward) {
+                (false, true) => (0, (-output_size.h as f32 * percentage).round() as i32),
+                (false, false) => (0, (output_size.h as f32 * percentage).round() as i32),
+                (true, true) => ((-output_size.w as f32 * percentage).round() as i32, 0),
+                (true, false) => ((output_size.w as f32 * percentage).round() as i32, 0),
             });
 
             (
                 Some((previous, previous_idx, has_fullscreen, offset)),
-                Point::<i32, Logical>::from(match (layout, forward) {
-                    (WorkspaceLayout::Vertical, true) => (0, output_size.h + offset.y),
-                    (WorkspaceLayout::Vertical, false) => (0, -(output_size.h - offset.y)),
-                    (WorkspaceLayout::Horizontal, true) => (output_size.w + offset.x, 0),
-                    (WorkspaceLayout::Horizontal, false) => (-(output_size.w - offset.x), 0),
+                Point::<i32, Logical>::from(match (is_horizontal_move, forward) {
+                    (false, true) => (0, output_size.h + offset.y),
+                    (false, false) => (0, -(output_size.h - offset.y)),
+                    (true, true) => (output_size.w + offset.x, 0),
+                    (true, false) => (-(output_size.w - offset.x), 0),
                 }),
             )
         }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -369,6 +369,9 @@ pub struct WorkspaceSet {
     pub sticky_layer: FloatingLayout,
     pub minimized_windows: Vec<MinimizedWindow>,
     pub workspaces: Vec<Workspace>,
+    /// Some(columns) while the Grid layout is active; workspace protocol
+    /// coordinates are then published as 2D [column, row] instead of [idx].
+    grid_coords_columns: Option<u32>,
 }
 
 fn create_workspace(
@@ -504,6 +507,7 @@ impl WorkspaceSet {
             workspaces: Vec::new(),
             output: output.clone(),
             appearance,
+            grid_coords_columns: None,
         }
     }
 
@@ -628,7 +632,7 @@ impl WorkspaceSet {
             self.workspaces.len() as u8 + 1,
             &workspace.handle,
             workspace.name.as_deref(),
-            // this method is only used by code paths related to dynamic workspaces, so this should be fine
+            self.grid_coords_columns,
         );
         self.workspaces.push(workspace);
     }
@@ -704,6 +708,7 @@ impl WorkspaceSet {
                 i as u8 + 1,
                 &workspace.handle,
                 workspace.name.as_deref(),
+                self.grid_coords_columns,
             );
         }
     }
@@ -921,6 +926,8 @@ impl Workspaces {
         if set.workspaces.is_empty() {
             set.add_empty_workspace(workspace_state);
         }
+        set.grid_coords_columns =
+            (self.layout == WorkspaceLayout::Grid).then_some(self.grid_columns);
         if self.layout == WorkspaceLayout::Grid {
             set.ensure_grid_size(workspace_state, self.grid_columns, self.grid_rows);
         }
@@ -1183,6 +1190,16 @@ impl Workspaces {
         self.grid_rows = config.cosmic_conf.workspaces.workspace_grid_rows.max(1);
         self.appearance = config.cosmic_conf.appearance_settings;
 
+        // Keep protocol coordinates in sync with the layout (2D in Grid mode).
+        let grid_coords =
+            (self.layout == WorkspaceLayout::Grid).then_some(self.grid_columns);
+        for set in self.sets.values_mut() {
+            if set.grid_coords_columns != grid_coords {
+                set.grid_coords_columns = grid_coords;
+                set.update_workspace_idxs(workspace_state);
+            }
+        }
+
         for set in self.sets.values_mut() {
             set.appearance = self.appearance;
             set.sticky_layer.appearance = self.appearance;
@@ -1268,6 +1285,26 @@ impl Workspaces {
                 let Some(max) = self.sets.values().map(|set| set.workspaces.len()).max() else {
                     return;
                 };
+
+                // Grid: fixed count. Keep all sets in sync at
+                // max(current max, columns * rows), skipping the dynamic
+                // trailing-empty/auto-remove behavior below. Never shrinks,
+                // so switching layouts never destroys occupied workspaces.
+                if self.layout == WorkspaceLayout::Grid {
+                    let target = (self.grid_columns as usize)
+                        .saturating_mul(self.grid_rows as usize)
+                        .max(1)
+                        .max(max);
+                    for set in self.sets.values_mut() {
+                        while set.workspaces.len() < target {
+                            set.add_empty_workspace(workspace_state);
+                        }
+                    }
+                    for set in self.sets.values_mut() {
+                        set.refresh()
+                    }
+                    return;
+                }
 
                 for set in self
                     .sets
@@ -5117,9 +5154,18 @@ fn workspace_set_idx(
     idx: u8,
     handle: &WorkspaceHandle,
     name: Option<&str>,
+    grid_columns: Option<u32>,
 ) {
     state.set_workspace_name(handle, name.unwrap_or(&format!("{}", idx)));
-    state.set_workspace_coordinates(handle, &[idx as u32]);
+    match grid_columns.filter(|columns| *columns > 0) {
+        // Grid layout: publish 2D coordinates ([x, y], per the workspace
+        // protocol's convention for the first two dimensions).
+        Some(columns) => {
+            let flat = (idx as u32).saturating_sub(1);
+            state.set_workspace_coordinates(handle, &[flat % columns, flat / columns]);
+        }
+        None => state.set_workspace_coordinates(handle, &[idx as u32]),
+    }
 }
 
 pub fn check_grab_preconditions(

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -687,6 +687,16 @@ impl WorkspaceSet {
         }
     }
 
+    // Grid mode: maintain a fixed `columns * rows` workspace count instead of the
+    // dynamic "always one trailing empty" behavior. Only pads up, never truncates,
+    // so toggling Grid on/off at runtime never destroys a workspace with windows on it.
+    fn ensure_grid_size(&mut self, state: &mut WorkspaceUpdateGuard<State>, columns: u32, rows: u32) {
+        let target = (columns as usize).saturating_mul(rows as usize).max(1);
+        while self.workspaces.len() < target {
+            self.add_empty_workspace(state);
+        }
+    }
+
     fn update_workspace_idxs(&self, state: &mut WorkspaceUpdateGuard<'_, State>) {
         for (i, workspace) in self.workspaces.iter().enumerate() {
             workspace_set_idx(
@@ -824,6 +834,8 @@ pub struct Workspaces {
     pub sets: IndexMap<Output, WorkspaceSet>,
     backup_set: Option<WorkspaceSet>,
     pub layout: WorkspaceLayout,
+    pub grid_columns: u32,
+    pub grid_rows: u32,
     mode: WorkspaceMode,
     autotile: bool,
     autotile_behavior: TileBehavior,
@@ -839,6 +851,8 @@ impl Workspaces {
             sets: IndexMap::new(),
             backup_set: None,
             layout: config.cosmic_conf.workspaces.workspace_layout,
+            grid_columns: config.cosmic_conf.workspaces.workspace_grid_columns.max(1),
+            grid_rows: config.cosmic_conf.workspaces.workspace_grid_rows.max(1),
             mode: config.cosmic_conf.workspaces.workspace_mode,
             autotile: config.cosmic_conf.autotile,
             autotile_behavior: config.cosmic_conf.autotile_behavior,
@@ -906,6 +920,9 @@ impl Workspaces {
         set.workspaces.extend(moved_workspaces);
         if set.workspaces.is_empty() {
             set.add_empty_workspace(workspace_state);
+        }
+        if self.layout == WorkspaceLayout::Grid {
+            set.ensure_grid_size(workspace_state, self.grid_columns, self.grid_rows);
         }
         set.update_workspace_idxs(workspace_state);
         for (i, workspace) in set.workspaces.iter_mut().enumerate() {
@@ -1162,6 +1179,8 @@ impl Workspaces {
         let old_mode = self.mode;
         self.mode = config.cosmic_conf.workspaces.workspace_mode;
         self.layout = config.cosmic_conf.workspaces.workspace_layout;
+        self.grid_columns = config.cosmic_conf.workspaces.workspace_grid_columns.max(1);
+        self.grid_rows = config.cosmic_conf.workspaces.workspace_grid_rows.max(1);
         self.appearance = config.cosmic_conf.appearance_settings;
 
         for set in self.sets.values_mut() {
@@ -1309,7 +1328,11 @@ impl Workspaces {
             }
             WorkspaceMode::OutputBound => {
                 for set in self.sets.values_mut() {
-                    set.ensure_last_empty(workspace_state, xdg_activation_state);
+                    if self.layout == WorkspaceLayout::Grid {
+                        set.ensure_grid_size(workspace_state, self.grid_columns, self.grid_rows);
+                    } else {
+                        set.ensure_last_empty(workspace_state, xdg_activation_state);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Implements the compositor half of pop-os/cosmic-workspaces-epoch#51 (grid-arranged workspaces).

- New `WorkspaceLayout::Grid` variant plus `workspace_grid_columns` / `workspace_grid_rows` (serde defaults 3/2, backward compatible) in `cosmic-comp-config`
- Grid mode keeps a fixed `columns x rows` workspace count (padded up, never destroying occupied workspaces) instead of the dynamic trailing-empty behavior; supported in both `OutputBound` and `Global` modes
- `Next/Previous/MoveTo/SendToWorkspace` become direction-aware in Grid mode via the binding's inferred direction: Left/Right move within the row, Up/Down move by a full row, both wrapping row/column-locally (respecting `workspace_wraparound`); `Focus`/`Move` at grid edges stay in the grid instead of falling through to `SwitchOutput`/`MoveToOutput`
- 4-finger swipes navigate in all four directions (`SwipeAction::GridMove`), honoring natural scrolling; swipe-end velocity normalizes against the axis of the move
- The switch animation slides along the axis of the actual move
- Workspace protocol coordinates are published as 2D `[column, row]` while Grid is active, so clients (e.g. the workspaces overview) can lay out the real grid; linear coordinates are restored when leaving Grid
- Grid math is unit-tested (`grid_tests`, 9 cases incl. wraparound + degenerate dimensions)

Vertical/Horizontal behavior is unchanged; existing config files parse unmodified.

Companion PRs: pop-os/cosmic-settings#2073 (Grid option UI) and pop-os/cosmic-workspaces-epoch#318 (grid overview).
