### PR TITLE
Skip stale frame extents when maximizing/fullscreening

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -270,8 +270,12 @@ impl CosmicSurface {
                 toplevel.with_pending_state(|state| state.size = Some(geo.size.as_logical()))
             }
             WindowSurface::X11(surface) => {
-                let _ =
-                    surface.configure_with_sync(geo.as_logical() + surface.frame_extents(), None);
+                let frame_extents = if surface.is_maximized() || surface.is_fullscreen() {
+                    Default::default()
+                } else {
+                    surface.frame_extents()
+                };
+                let _ = surface.configure_with_sync(geo.as_logical() + frame_extents, None);
             }
         }
     }


### PR DESCRIPTION
PR #2441 added the client's advertised _GTK_FRAME_EXTENTS to the geometry sent in configure_with_sync() so XWayland CSD windows (e.g. Firefox) wouldn't shrink. But set_maximized()/set_geometry() are called back-to-back, and Smithay's internal maximized/fullscreen state updates synchronously while the client's _GTK_FRAME_EXTENTS does not update until it processes the configure. This meant the window was briefly configured larger than the output using its old, pre-maximize shadow extents, leaving it jutting past the screen edge until an unrelated reconfigure (e.g. focus change on alt-tab) caught up with the client's now-zeroed extents.

GTK clients always drop their CSD shadows when maximized or fullscreen, so once is_maximized()/is_fullscreen() report true, skip frame_extents() and use zero instead of waiting for the client to confirm it.

Fixes #2503

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.