### PR TITLE
fix: improve screen edge mouse pointer accuracy

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -337,7 +337,7 @@ impl State {
                                 // Constraint does not apply if not within region
                                 if !constraint.region().is_none_or(|x| {
                                     x.contains(
-                                        (ptr.current_location() - *surface_loc).to_i32_round(),
+                                        (ptr.current_location() - *surface_loc).to_i32_floor(),
                                     )
                                 }) {
                                     return;
@@ -382,14 +382,25 @@ impl State {
                         .unwrap_or(current_output.clone());
                     drop(shell);
                     let output_geometry = output.geometry();
-                    position.x = position.x.clamp(
-                        output_geometry.loc.x as f64,
-                        (output_geometry.loc.x + output_geometry.size.w - 1) as f64,
-                    );
-                    position.y = position.y.clamp(
-                        output_geometry.loc.y as f64,
-                        (output_geometry.loc.y + output_geometry.size.h - 1) as f64,
-                    );
+
+                    let scale = output.current_scale().fractional_scale();
+                    let physical = output
+                        .current_mode()
+                        .map(|mode| output.current_transform().transform_size(mode.size))
+                        .unwrap_or_default();
+                    let logical = physical.to_f64().to_logical(scale);
+                    let output_geometry_loc = output_geometry.loc.to_f64();
+                    // output_geometry.size is a rounded value and may undershoot/overshoot the accurate logical size
+                    // We constrain the position with:
+                    // - output_geometry.size so that we don't send leave events to a fullscreen app
+                    // - logical size so that the position doesn't end up outside the actual size of the output
+                    // See https://github.com/pop-os/cosmic-comp/pull/2568
+                    let max_x = output_geometry_loc.x
+                        + logical.w.min(output_geometry.size.w as f64).next_down();
+                    let max_y = output_geometry_loc.y
+                        + logical.h.min(output_geometry.size.h as f64).next_down();
+                    position.x = position.x.clamp(output_geometry_loc.x, max_x);
+                    position.y = position.y.clamp(output_geometry_loc.y, max_y);
 
                     if ptr.is_grabbed() {
                         if seat
@@ -543,7 +554,7 @@ impl State {
 
                             if let Some(region) = &confine_region
                                 && !region
-                                    .contains((pos.as_logical() - *surface_loc).to_i32_round())
+                                    .contains((pos.as_logical() - *surface_loc).to_i32_floor())
                             {
                                 return (false, None);
                             }
@@ -614,7 +625,7 @@ impl State {
                                         PointerConstraint::Confined(confined) => confined.region(),
                                     };
                                     let point =
-                                        (ptr.current_location() - surface_location).to_i32_round();
+                                        (ptr.current_location() - surface_location).to_i32_floor();
                                     if region.is_none_or(|region| region.contains(point)) {
                                         constraint.activate();
                                     }
@@ -2210,7 +2221,7 @@ impl State {
                         if Rectangle::new(offset.as_local(), output_geo.size)
                             .intersection(output_geo)
                             .is_some_and(|geometry| {
-                                geometry.contains(global_pos.to_local(output).to_i32_round())
+                                geometry.contains(global_pos.to_local(output).to_i32_floor())
                             })
                             && let Some(element) = workspace.popup_element_under(location, seat)
                         {
@@ -2224,7 +2235,7 @@ impl State {
                         if Rectangle::new(offset.as_local(), output_geo.size)
                             .intersection(output_geo)
                             .is_some_and(|geometry| {
-                                geometry.contains(global_pos.to_local(output).to_i32_round())
+                                geometry.contains(global_pos.to_local(output).to_i32_floor())
                             })
                             && let Some(element) = workspace.toplevel_element_under(location, seat)
                         {
@@ -2427,7 +2438,7 @@ impl State {
                         if let Some(constraint) = constraint
                             && let Some(region) = constraint.region()
                         {
-                            let point_in_surface = (p - surface_offset.to_f64()).to_i32_round();
+                            let point_in_surface = (p - surface_offset.to_f64()).to_i32_floor();
                             return region.contains(point_in_surface);
                         }
                         true

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -530,7 +530,7 @@ impl CosmicStack {
             let geo = p.windows.lock().unwrap()[p.active.load(Ordering::SeqCst)].geometry();
 
             if surface_type.contains(WindowSurfaceType::TOPLEVEL) {
-                let point_i32 = relative_pos.to_i32_round::<i32>();
+                let point_i32 = relative_pos.to_i32_floor::<i32>();
                 if (point_i32.x - geo.loc.x >= -RESIZE_BORDER && point_i32.x - geo.loc.x < 0)
                     || (point_i32.y - geo.loc.y >= -RESIZE_BORDER && point_i32.y - geo.loc.y < 0)
                     || (point_i32.x - geo.loc.x >= geo.size.w

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -113,7 +113,7 @@ impl Focus {
         location: Point<f64, Logical>,
     ) -> Option<Focus> {
         let geo = surface.geometry();
-        let loc = location.to_i32_round::<i32>() - geo.loc;
+        let loc = location.to_i32_floor::<i32>() - geo.loc;
         if loc.y < 0 && loc.x < 0 {
             Some(Focus::ResizeTopLeft)
         } else if loc.y < 0 && loc.x >= geo.size.w {
@@ -292,7 +292,7 @@ impl CosmicWindow {
             {
                 let geo = p.window.geometry();
 
-                let point_i32 = relative_pos.to_i32_round::<i32>();
+                let point_i32 = relative_pos.to_i32_floor::<i32>();
                 let ssd_height = if has_ssd { SSD_HEIGHT } else { 0 };
 
                 if (point_i32.x - geo.loc.x >= -RESIZE_BORDER && point_i32.x - geo.loc.x < 0)

--- a/src/shell/grabs/menu/mod.rs
+++ b/src/shell/grabs/menu/mod.rs
@@ -548,7 +548,7 @@ impl PointerGrab<State> for MenuGrab {
                 let mut bbox = elem.iced.bbox();
                 bbox.loc = elem.position.as_logical();
 
-                bbox.contains(event_location.to_i32_round())
+                bbox.contains(event_location.to_i32_floor())
             }) {
                 let element = &mut elements[i];
 
@@ -753,7 +753,7 @@ impl TouchGrab<State> for MenuGrab {
                 let mut bbox = elem.iced.bbox();
                 bbox.loc = elem.position.as_logical();
 
-                bbox.contains(event_location.to_i32_round())
+                bbox.contains(event_location.to_i32_floor())
             }) {
                 let element = &mut elements[i];
 

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -3150,7 +3150,7 @@ impl TilingLayout {
         location_f64: Point<f64, Local>,
         seat: &Seat<State>,
     ) -> Option<KeyboardFocusTarget> {
-        let location = location_f64.to_i32_round();
+        let location = location_f64.to_i32_floor();
 
         for (mapped, geo) in self.mapped() {
             if !mapped.bbox().contains((location - geo.loc).as_logical()) {
@@ -3177,7 +3177,7 @@ impl TilingLayout {
         location_f64: Point<f64, Local>,
         seat: &Seat<State>,
     ) -> Option<KeyboardFocusTarget> {
-        let location = location_f64.to_i32_round();
+        let location = location_f64.to_i32_floor();
 
         for (mapped, geo) in self.mapped() {
             // Tiled windows are rendered cropped to their tile (`geo`), so input must be bound to the tile as well
@@ -3209,7 +3209,7 @@ impl TilingLayout {
         overview: OverviewMode,
         seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Local>)> {
-        let location = location_f64.to_i32_round();
+        let location = location_f64.to_i32_floor();
 
         if matches!(overview, OverviewMode::None) {
             for (mapped, geo) in self.mapped() {
@@ -3244,7 +3244,7 @@ impl TilingLayout {
     ) -> Option<(PointerFocusTarget, Point<f64, Local>)> {
         let tree = &self.queue.trees.back().unwrap().0;
         let root = tree.root_node_id()?;
-        let location = location_f64.to_i32_round();
+        let location = location_f64.to_i32_floor();
 
         if matches!(overview, OverviewMode::None) {
             for (mapped, geo) in self.mapped() {
@@ -3305,7 +3305,7 @@ impl TilingLayout {
                         ..
                     },
                 )) => {
-                    let test_point = (location.to_f64() - last_geometry.loc.to_f64()
+                    let test_point = (location_f64 - last_geometry.loc.to_f64()
                         + mapped.geometry().loc.to_f64().as_local())
                     .as_logical();
                     mapped
@@ -3410,7 +3410,7 @@ impl TilingLayout {
         }
 
         let location_f64 = location_f64.unwrap();
-        let location = location_f64.to_i32_round();
+        let location = location_f64.to_i32_floor();
 
         if matches!(
             overview.active_trigger(),
@@ -3660,7 +3660,7 @@ impl TilingLayout {
                             TargetZone::WindowStack(id, last_geometry)
                         } else {
                             let left_right = {
-                                let relative_loc = (location.x - last_geometry.loc.x) as f64;
+                                let relative_loc = location_f64.x - last_geometry.loc.x as f64;
                                 if relative_loc < last_geometry.size.w as f64 / 2.0 {
                                     (Direction::Left, relative_loc / last_geometry.size.w as f64)
                                 } else {
@@ -3671,7 +3671,7 @@ impl TilingLayout {
                                 }
                             };
                             let up_down = {
-                                let relative_loc = (location.y - last_geometry.loc.y) as f64;
+                                let relative_loc = location_f64.y - last_geometry.loc.y as f64;
                                 if relative_loc < last_geometry.size.h as f64 / 2.0 {
                                     (Direction::Up, relative_loc / last_geometry.size.h as f64)
                                 } else {

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -785,7 +785,7 @@ impl Workspace {
         location: Point<f64, Global>,
         seat: &Seat<State>,
     ) -> Option<KeyboardFocusTarget> {
-        if !self.output.geometry().contains(location.to_i32_round()) {
+        if !self.output.geometry().contains(location.to_i32_floor()) {
             return None;
         }
         let location = location.to_local(&self.output);
@@ -834,7 +834,7 @@ impl Workspace {
         location: Point<f64, Global>,
         seat: &Seat<State>,
     ) -> Option<KeyboardFocusTarget> {
-        if !self.output.geometry().contains(location.to_i32_round()) {
+        if !self.output.geometry().contains(location.to_i32_floor()) {
             return None;
         }
         let location = location.to_local(&self.output);
@@ -884,7 +884,7 @@ impl Workspace {
         overview: OverviewMode,
         seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Global>)> {
-        if !self.output.geometry().contains(location.to_i32_round()) {
+        if !self.output.geometry().contains(location.to_i32_floor()) {
             return None;
         }
         let location = location.to_local(&self.output);
@@ -934,7 +934,7 @@ impl Workspace {
         overview: OverviewMode,
         seat: &Seat<State>,
     ) -> Option<(PointerFocusTarget, Point<f64, Global>)> {
-        if !self.output.geometry().contains(location.to_i32_round()) {
+        if !self.output.geometry().contains(location.to_i32_floor()) {
             return None;
         }
         let location = location.to_local(&self.output);

--- a/src/wayland/handlers/pointer_constraints.rs
+++ b/src/wayland/handlers/pointer_constraints.rs
@@ -63,7 +63,7 @@ impl PointerConstraintsHandler for State {
                     if let Some(region) = constraint.region() {
                         if let Some(surface_location) = surface_location
                             && let position = pointer.current_location()
-                            && let point = (position - surface_location.as_logical()).to_i32_round()
+                            && let point = (position - surface_location.as_logical()).to_i32_floor()
                             && region.contains(point)
                         {
                             constraint.activate();


### PR DESCRIPTION
This fixes scrolling by moving to the edge in games when using scaling.
For testing purposes I encountered the initial issue in XCOM 2 and The Guild - Europa 1410 Demo in 3840*2160 at 175% scale but I think a lot of games were affected.

The current implementation removed 1 from the logical size as the upper margin of the clamp, which could easily remove several physical pixels and the mouse pointer would never reach the edges which resulted in games not scrolling down and right properly.

We now use 2 extra steps, first we use a margin of (last logical pixel + edge) / 2.
Then we limit the size to the floating value of the logical size. This is necessary as the values we get from Wayland are rounded and we can easily overflow into the upper bound otherwise.

I made a simple rust test:
<details>
<summary>Test code</summary>

```rust
const RESOLUTIONS: [(f64, f64); 5] = [(1280.0, 720.0), (1920.0, 1080.0), (2560.0, 1440.0), (3840.0, 2160.0), (7680.0, 4320.0)];
const SCALINGS: [f64; 11] = [0.5, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.25, 2.50, 2.75, 3.0];

fn ret_result(b: bool) -> &'static str {
	if b {
		return "\x1b[92mSuccess\x1b[0m";
	}

	return "\x1b[91mFailure\x1b[0m";
}

struct Counters {
	success_old: u64,
	success_new: u64,
	total: u64,
}

impl Counters {
	fn new() -> Counters {
		Counters {
			success_old: 0,
			success_new: 0,
			total: 0,
		}
	}

	fn test_old(&mut self, b: bool) -> &'static str {
		if b {
			self.success_old += 1;
		}

		return ret_result(b);
	}

	fn test_new(&mut self, b: bool) -> &'static str {
		if b {
			self.success_new += 1;
		}

		return ret_result(b);
	}
}

fn main() {
	let mut count = Counters::new();
	for scaling in SCALINGS {
		println!("At {}% scaling:", scaling * 100.0);
		for resolution in RESOLUTIONS {
			println!("{}x{}", resolution.0, resolution.1);
			let logical_size = (resolution.0 / scaling, resolution.1 / scaling);
			let logical_geometry_size = (logical_size.0.round(), logical_size.1.round());
			let physical_last_pixels = (resolution.0 - 1.0, resolution.1 - 1.0);
			let current_actual_last_pixels = (((logical_geometry_size.0 - 1.0) * scaling).floor(), ((logical_geometry_size.1 - 1.0) * scaling).floor());

			let logical_last_pixels_with_scaled_edge = (
				((resolution.0 - 1.0) / scaling + (logical_geometry_size.0.min(logical_size.0))) / 2.0,
				((resolution.1 - 1.0) / scaling + (logical_geometry_size.1.min(logical_size.1))) / 2.0,
			);
			let physical_last_pixel_with_scaled_edge = ((logical_last_pixels_with_scaled_edge.0 * scaling).floor(), (logical_last_pixels_with_scaled_edge.1 * scaling).floor());

			let old = count.test_old(current_actual_last_pixels == physical_last_pixels);
			let success_new = physical_last_pixel_with_scaled_edge == physical_last_pixels;
			let new = count.test_new(success_new);
			count.total += 1;
			println!("old: {}, logical_edge: {}", old, new);

			if !success_new {
				println!("logical_size: {:?}", logical_size);
				println!("geometry_size: {:?}", logical_geometry_size);
				println!("real_last_pixels: {:?}", physical_last_pixels);
				println!("current_actual_last_pixels: {:?}", current_actual_last_pixels);
				println!("physical_last_pixel_with_scaled_edge: {:?}", physical_last_pixel_with_scaled_edge);
			}
		}
		println!("=====================================================")
	}

	println!("old: {}/{}", count.success_old, count.total);
	println!("new: {}/{}", count.success_new, count.total);
}
```
</details>

<details>
<summary>Results</summary>

```
At 50% scaling:
1280x720
old: Success, logical_edge: Success
1920x1080
old: Success, logical_edge: Success
2560x1440
old: Success, logical_edge: Success
3840x2160
old: Success, logical_edge: Success
7680x4320
old: Success, logical_edge: Success
=====================================================
At 75% scaling:
1280x720
old: Success, logical_edge: Success
1920x1080
old: Success, logical_edge: Success
2560x1440
old: Success, logical_edge: Success
3840x2160
old: Success, logical_edge: Success
7680x4320
old: Success, logical_edge: Success
=====================================================
At 100% scaling:
1280x720
old: Success, logical_edge: Success
1920x1080
old: Success, logical_edge: Success
2560x1440
old: Success, logical_edge: Success
3840x2160
old: Success, logical_edge: Success
7680x4320
old: Success, logical_edge: Success
=====================================================
At 125% scaling:
1280x720
old: Failure, logical_edge: Success
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Success
7680x4320
old: Failure, logical_edge: Success
=====================================================
At 150% scaling:
1280x720
old: Failure, logical_edge: Success
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Success
7680x4320
old: Failure, logical_edge: Success
=====================================================
At 175% scaling:
1280x720
old: Failure, logical_edge: Success
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Success
7680x4320
old: Success, logical_edge: Success
=====================================================
At 200% scaling:
1280x720
old: Failure, logical_edge: Success
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Success
7680x4320
old: Failure, logical_edge: Success
=====================================================
At 225% scaling:
1280x720
old: Failure, logical_edge: Success
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Success
7680x4320
old: Failure, logical_edge: Success
=====================================================
At 250% scaling:
1280x720
old: Failure, logical_edge: Success
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Success
7680x4320
old: Failure, logical_edge: Success
=====================================================
At 275% scaling:
1280x720
old: Failure, logical_edge: Failure
logical_size: (465.45454545454544, 261.8181818181818)
geometry_size: (465.0, 262.0)
real_last_pixels: (1279.0, 719.0)
current_actual_last_pixels: (1276.0, 717.0)
physical_last_pixel_with_scaled_edge: (1278.0, 719.0)
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Failure
logical_size: (1396.3636363636363, 785.4545454545455)
geometry_size: (1396.0, 785.0)
real_last_pixels: (3839.0, 2159.0)
current_actual_last_pixels: (3836.0, 2156.0)
physical_last_pixel_with_scaled_edge: (3839.0, 2158.0)
7680x4320
old: Failure, logical_edge: Success
=====================================================
At 300% scaling:
1280x720
old: Failure, logical_edge: Success
1920x1080
old: Failure, logical_edge: Success
2560x1440
old: Failure, logical_edge: Success
3840x2160
old: Failure, logical_edge: Success
7680x4320
old: Failure, logical_edge: Success
=====================================================
old: 16/55
new: 53/55
```
</details>

So we go from 16/55 tests passed to 53/55, the 2 failures are at very high scaling(275%) and are the result of the rounding of the geometry_size where the shortfall can be >= 1 pixels at those scales. I have no easy solution for this.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

