### PR TITLE
element/surface: Avoid scanning out translucent surfaces

### DIFF
--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -4,7 +4,10 @@ use crate::{
         wayland::{SurfaceRenderElement, push_render_elements_from_surface_tree},
     },
     shell::focus::target::PointerFocusTarget,
-    wayland::handlers::{compositor::frame_time_filter_fn, corner_radius::surface_corners},
+    wayland::handlers::{
+        background_effect::ComputedBlurRegionCachedState, compositor::frame_time_filter_fn,
+        corner_radius::surface_corners,
+    },
 };
 use std::{
     borrow::Cow,
@@ -19,7 +22,7 @@ use smithay::{
     backend::{
         drm::DrmNode,
         renderer::{
-            ImportAll, Renderer,
+            ImportAll, Renderer, buffer_has_alpha,
             element::{Kind, RenderElementStates, surface::KindEvaluation},
             utils::RendererSurfaceStateUserData,
         },
@@ -48,6 +51,7 @@ use smithay::{
         IsAlive, Logical, Physical, Point, Rectangle, Scale, Serial, Size, user_data::UserDataMap,
     },
     wayland::{
+        alpha_modifier::AlphaModifierSurfaceCachedState,
         compositor::{
             SubsurfaceCachedState, SurfaceData, TraversalAction, get_parent, with_states,
             with_surface_tree_downward,
@@ -81,6 +85,39 @@ fn buffer_node(data: &SurfaceData) -> Option<DrmNode> {
         .and_then(|dmabuf| dmabuf.node())
 }
 
+fn is_likely_translucent(alpha: f32, data: &SurfaceData) -> bool {
+    if alpha < 1.0 {
+        return true;
+    }
+
+    let mut alpha_modifier_state = data.cached_state.get::<AlphaModifierSurfaceCachedState>();
+    let alpha_multiplier = alpha_modifier_state
+        .current()
+        .multiplier_f32()
+        .unwrap_or(1.0);
+    if alpha_multiplier < 1.0 {
+        return true;
+    }
+
+    let Some(surface_state) = data.data_map.get::<RendererSurfaceStateUserData>() else {
+        return false;
+    };
+    let surface_state = surface_state.lock().unwrap();
+    if surface_state
+        .buffer()
+        .is_none_or(|buffer| !buffer_has_alpha(buffer).unwrap_or(true))
+    {
+        return false;
+    }
+
+    let mut blur_state = data.cached_state.get::<ComputedBlurRegionCachedState>();
+    blur_state
+        .current()
+        .blur_region
+        .as_ref()
+        .is_none_or(|region| region.is_empty())
+}
+
 /// Build the [`KindEvaluation`] for a window's surface tree.
 ///
 /// `scanout_node`, when set, is the scan-out target [`DrmNode`] of the output currently being
@@ -89,6 +126,7 @@ fn buffer_node(data: &SurfaceData) -> Option<DrmNode> {
 fn scanout_kind_eval(
     scanout_override: Option<bool>,
     scanout_node: Option<DrmNode>,
+    alpha: f32,
 ) -> KindEvaluation {
     match (scanout_override, scanout_node) {
         // Forced off.
@@ -98,14 +136,14 @@ fn scanout_kind_eval(
         (None, None) => FRAME_TIME_FILTER,
         // Node restriction in effect: only buffers on the scan-out node may be candidates.
         (Some(true), Some(node)) => KindEvaluation::Closure(Box::new(move |data| {
-            if buffer_node(data) == Some(node) {
+            if buffer_node(data) == Some(node) && !is_likely_translucent(alpha, data) {
                 Kind::ScanoutCandidate
             } else {
                 Kind::Unspecified
             }
         })),
         (None, Some(node)) => KindEvaluation::Closure(Box::new(move |data| {
-            if buffer_node(data) == Some(node) {
+            if buffer_node(data) == Some(node) && !is_likely_translucent(alpha, data) {
                 frame_time_filter_fn(data)
             } else {
                 Kind::Unspecified
@@ -879,7 +917,7 @@ impl CosmicSurface {
                         radii,
                         None,
                         blur_strength,
-                        scanout_kind_eval(None, scanout_node),
+                        scanout_kind_eval(None, scanout_node, alpha),
                         push,
                         None,
                     )
@@ -924,7 +962,7 @@ impl CosmicSurface {
                     radii,
                     None,
                     blur_strength,
-                    scanout_kind_eval(scanout_override, scanout_node),
+                    scanout_kind_eval(scanout_override, scanout_node, alpha),
                     push_above,
                     push_below,
                 )
@@ -945,7 +983,7 @@ impl CosmicSurface {
                     radii,
                     None,
                     blur_strength,
-                    scanout_kind_eval(scanout_override, scanout_node),
+                    scanout_kind_eval(scanout_override, scanout_node, alpha),
                     push_above,
                     push_below,
                 )

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -115,7 +115,7 @@ fn is_likely_translucent(alpha: f32, data: &SurfaceData) -> bool {
         .current()
         .blur_region
         .as_ref()
-        .is_none_or(|region| region.is_empty())
+        .is_some_and(|region| !region.is_empty())
 }
 
 /// Build the [`KindEvaluation`] for a window's surface tree.


### PR DESCRIPTION
This is an attempt at working around the flickering issues we see with frosted-glass on some AMD GPUs.

AMD GPUs are currently the most likely to utilize scanning out via overlay-planes however with the color-pipeline drm feature it looks like blending might either not be entirely well defined or buggy on amdgpu, resulting in different perceptions of opacity depending on whether an element is scanned out or composited. (Regardless of any set [`alpha`](https://drmdb.emersion.fr/properties/plane/alpha) or [`pixel blend mode`](https://drmdb.emersion.fr/properties/plane/pixel%20blend%20mode) on the plane.)

Until we have support for color-pipelines, lets try to avoid scanning out any *likely* translucent surfaces. We consider a surface translucent if we either know we are rendering with a non-opaque alpha value (animations or alpha modifier) or the surface has a non-opaque color format *and* an active blur region.

This likely misses some cases, but since the issue was not nearly as obvious before the frosted glass support this should be an effective mitigation.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

