### PR TITLE
Various cursor image-copy fixes

### DIFF
--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1674,7 +1674,7 @@ fn send_screencopy_result<'a>(
     pre_postprocess_data: &mut PrePostprocessData,
     tx: &std::sync::mpsc::Sender<PendingImageCopyData>,
     frame_result: &RenderFrameResult<GbmBuffer, GbmFramebuffer, CosmicElement<GlMultiRenderer<'a>>>,
-    elements: &[CosmicElement<GlMultiRenderer>],
+    elements: &[CosmicElement<GlMultiRenderer<'a>>],
     (session, frame, res): (
         &ScreencopySessionRef,
         ScreencopyFrame,
@@ -1855,6 +1855,8 @@ fn send_screencopy_result<'a>(
         transform,
         damage.as_deref(),
         sync,
+        // Don't reference `Buffer`s since we blit from framebuffer/postprocess buffer
+        vec![],
     )? {
         if frame_result.is_empty {
             data.frame

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -41,7 +41,9 @@ use crate::{
             compositor::FRAME_TIME_FILTER,
             corner_radius::{pad_rect, surface_corners, surface_padding},
             data_device::get_dnd_icon,
-            image_copy_capture::{FrameHolder, SessionData, render_session},
+            image_copy_capture::{
+                FrameHolder, SessionData, render_element_buffers, render_session,
+            },
         },
         protocols::workspace::WorkspaceHandle,
     },
@@ -1505,11 +1507,16 @@ where
                             }
                         }
 
-                        Ok(RenderOutputResult {
-                            damage: res.0,
-                            sync,
-                            states: res.1,
-                        })
+                        let buffers = render_element_buffers(renderer, &elements);
+
+                        Ok((
+                            RenderOutputResult {
+                                damage: res.0,
+                                sync,
+                                states: res.1,
+                            },
+                            buffers,
+                        ))
                     },
                 )? {
                     pending_image_copy_data.send_success_when_ready(

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2426,7 +2426,7 @@ impl State {
                 if is_legal(pos_in_element) {
                     let x = workspace_origin.x + origin.x + pos_in_element.x;
                     let y = workspace_origin.y + origin.y + pos_in_element.y;
-                    Some((Point::new(x, y), output.clone()))
+                    Some((Point::<_, Global>::new(x, y), output.clone()))
                 } else {
                     None
                 }
@@ -2437,10 +2437,10 @@ impl State {
 
         if let Some((point, output)) = point_and_output {
             let original_position = pointer.current_location();
-            pointer.set_location(point);
+            pointer.set_location(point.as_logical());
 
             let mut shell = self.common.shell.write();
-            shell.update_pointer_position(point.as_global().to_local(&output), &output);
+            shell.update_pointer_position(point.to_local(&output), &output);
 
             let seat = shell
                 .seats
@@ -2458,7 +2458,7 @@ impl State {
                 let output_geometry = output.geometry();
                 for session in cursor_sessions_for_output(&shell, &output) {
                     if let Some(cursor_geometry) = seat.cursor_geometry(
-                        point.to_buffer(
+                        point.as_logical().to_buffer(
                             output.current_scale().fractional_scale(),
                             output.current_transform(),
                             &output_geometry.size.to_f64().as_logical(),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2510,7 +2510,7 @@ fn mapped_output_for_device<'a, D: Device + 'static>(
     map_to_output.or_else(|| shell.builtin_output())
 }
 
-fn update_output_image_copy_cursor_position(
+pub fn update_output_image_copy_cursor_position(
     shell: &Shell,
     clock: &Clock<Monotonic>,
     output: &Output,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     input::gestures::{GestureState, SwipeAction},
     shell::{
-        CursorGeometry, LastModifierChange, SeatExt, Trigger,
+        LastModifierChange, SeatExt, Trigger,
         focus::{
             Stage, render_input_order,
             target::{KeyboardFocusTarget, PointerFocusTarget},
@@ -25,7 +25,8 @@ use crate::{
     },
     utils::{prelude::*, quirks::workspace_overview_is_open},
     wayland::handlers::{
-        image_copy_capture::SessionHolder, xwayland_keyboard_grab::XWaylandGrabSeat,
+        image_copy_capture::{SessionHolder, cursor_capture_constraints},
+        xwayland_keyboard_grab::XWaylandGrabSeat,
     },
 };
 use calloop::{
@@ -60,15 +61,12 @@ use smithay::{
     output::Output,
     reexports::{
         input::Device as InputDevice,
-        wayland_server::{
-            Resource as _,
-            protocol::{wl_shm::Format as ShmFormat, wl_surface::WlSurface},
-        },
+        wayland_server::{Resource as _, protocol::wl_surface::WlSurface},
     },
-    utils::{Logical, Point, Rectangle, SERIAL_COUNTER, Serial, Size},
+    utils::{Logical, Point, Rectangle, SERIAL_COUNTER, Serial},
     wayland::{
         compositor::CompositorHandler,
-        image_copy_capture::{BufferConstraints, CursorSessionRef},
+        image_copy_capture::CursorSessionRef,
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitorSeat,
         pointer_constraints::{PointerConstraint, with_pointer_constraint},
         seat::WaylandFocus,
@@ -640,7 +638,7 @@ impl State {
                     }
 
                     for session in cursor_sessions_for_output(&shell, &output) {
-                        if let Some(CursorGeometry { geometry, hotspot }) = seat.cursor_geometry(
+                        if let Some(cursor_geometry) = seat.cursor_geometry(
                             (position - output_geometry.loc.to_f64())
                                 .as_logical()
                                 .to_buffer(
@@ -650,24 +648,18 @@ impl State {
                                 ),
                             self.common.clock.now(),
                         ) {
+                            let constraints = cursor_capture_constraints(Some(cursor_geometry));
                             if session
                                 .current_constraints()
-                                .map(|constraint| constraint.size != geometry.size)
+                                .map(|current_constraints| {
+                                    current_constraints.size != constraints.size
+                                })
                                 .unwrap_or(true)
                             {
-                                let mut cursor_size = geometry.size;
-                                // Client shouldn't try to allocate 0x0 buffer
-                                if cursor_size == Size::new(0, 0) {
-                                    cursor_size = Size::new(1, 1);
-                                }
-                                session.update_constraints(BufferConstraints {
-                                    size: cursor_size,
-                                    shm: vec![ShmFormat::Argb8888],
-                                    dma: None,
-                                });
+                                session.update_constraints(constraints);
                             }
-                            session.set_cursor_hotspot(hotspot);
-                            session.set_cursor_pos(Some(geometry.loc));
+                            session.set_cursor_hotspot(cursor_geometry.hotspot);
+                            session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
                         }
                     }
                 }
@@ -709,7 +701,7 @@ impl State {
 
                     let shell = self.common.shell.read();
                     for session in cursor_sessions_for_output(&shell, &output) {
-                        if let Some(CursorGeometry { geometry, hotspot }) = seat.cursor_geometry(
+                        if let Some(cursor_geometry) = seat.cursor_geometry(
                             (position - output_geometry.loc.to_f64())
                                 .as_logical()
                                 .to_buffer(
@@ -719,24 +711,18 @@ impl State {
                                 ),
                             self.common.clock.now(),
                         ) {
+                            let constraints = cursor_capture_constraints(Some(cursor_geometry));
                             if session
                                 .current_constraints()
-                                .map(|constraint| constraint.size != geometry.size)
+                                .map(|current_constraints| {
+                                    current_constraints.size != constraints.size
+                                })
                                 .unwrap_or(true)
                             {
-                                let mut cursor_size = geometry.size;
-                                // Client shouldn't try to allocate 0x0 buffer
-                                if cursor_size == Size::new(0, 0) {
-                                    cursor_size = Size::new(1, 1);
-                                }
-                                session.update_constraints(BufferConstraints {
-                                    size: cursor_size,
-                                    shm: vec![ShmFormat::Argb8888],
-                                    dma: None,
-                                });
+                                session.update_constraints(constraints);
                             }
-                            session.set_cursor_hotspot(hotspot);
-                            session.set_cursor_pos(Some(geometry.loc));
+                            session.set_cursor_hotspot(cursor_geometry.hotspot);
+                            session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
                         }
                     }
                 }
@@ -2471,7 +2457,7 @@ impl State {
 
                 let output_geometry = output.geometry();
                 for session in cursor_sessions_for_output(&shell, &output) {
-                    if let Some(CursorGeometry { geometry, hotspot }) = seat.cursor_geometry(
+                    if let Some(cursor_geometry) = seat.cursor_geometry(
                         point.to_buffer(
                             output.current_scale().fractional_scale(),
                             output.current_transform(),
@@ -2479,19 +2465,16 @@ impl State {
                         ),
                         self.common.clock.now(),
                     ) {
+                        let constraints = cursor_capture_constraints(Some(cursor_geometry));
                         if session
                             .current_constraints()
-                            .map(|constraint| constraint.size != geometry.size)
+                            .map(|current_constraints| current_constraints.size != constraints.size)
                             .unwrap_or(true)
                         {
-                            session.update_constraints(BufferConstraints {
-                                size: geometry.size,
-                                shm: vec![ShmFormat::Argb8888],
-                                dma: None,
-                            });
+                            session.update_constraints(constraints);
                         }
-                        session.set_cursor_hotspot(hotspot);
-                        session.set_cursor_pos(Some(geometry.loc));
+                        session.set_cursor_hotspot(cursor_geometry.hotspot);
+                        session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
                     }
                 }
             }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -63,7 +63,7 @@ use smithay::{
         input::Device as InputDevice,
         wayland_server::{Resource as _, protocol::wl_surface::WlSurface},
     },
-    utils::{Logical, Point, Rectangle, SERIAL_COUNTER, Serial},
+    utils::{Clock, Logical, Monotonic, Point, Rectangle, SERIAL_COUNTER, Serial},
     wayland::{
         compositor::CompositorHandler,
         image_copy_capture::CursorSessionRef,
@@ -637,31 +637,13 @@ impl State {
                         seat.set_active_output(&output);
                     }
 
-                    for session in cursor_sessions_for_output(&shell, &output) {
-                        if let Some(cursor_geometry) = seat.cursor_geometry(
-                            (position - output_geometry.loc.to_f64())
-                                .as_logical()
-                                .to_buffer(
-                                    output.current_scale().fractional_scale(),
-                                    output.current_transform(),
-                                    &output_geometry.size.to_f64().as_logical(),
-                                ),
-                            self.common.clock.now(),
-                        ) {
-                            let constraints = cursor_capture_constraints(Some(cursor_geometry));
-                            if session
-                                .current_constraints()
-                                .map(|current_constraints| {
-                                    current_constraints.size != constraints.size
-                                })
-                                .unwrap_or(true)
-                            {
-                                session.update_constraints(constraints);
-                            }
-                            session.set_cursor_hotspot(cursor_geometry.hotspot);
-                            session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
-                        }
-                    }
+                    update_output_image_copy_cursor_position(
+                        &shell,
+                        &self.common.clock,
+                        &output,
+                        &seat,
+                        position,
+                    );
                 }
             }
             InputEvent::PointerMotionAbsolute { event, .. } => {
@@ -700,31 +682,13 @@ impl State {
                     ptr.frame(self);
 
                     let shell = self.common.shell.read();
-                    for session in cursor_sessions_for_output(&shell, &output) {
-                        if let Some(cursor_geometry) = seat.cursor_geometry(
-                            (position - output_geometry.loc.to_f64())
-                                .as_logical()
-                                .to_buffer(
-                                    output.current_scale().fractional_scale(),
-                                    output.current_transform(),
-                                    &output_geometry.size.to_f64().as_logical(),
-                                ),
-                            self.common.clock.now(),
-                        ) {
-                            let constraints = cursor_capture_constraints(Some(cursor_geometry));
-                            if session
-                                .current_constraints()
-                                .map(|current_constraints| {
-                                    current_constraints.size != constraints.size
-                                })
-                                .unwrap_or(true)
-                            {
-                                session.update_constraints(constraints);
-                            }
-                            session.set_cursor_hotspot(cursor_geometry.hotspot);
-                            session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
-                        }
-                    }
+                    update_output_image_copy_cursor_position(
+                        &shell,
+                        &self.common.clock,
+                        &output,
+                        &seat,
+                        position,
+                    );
                 }
             }
             InputEvent::PointerButton { event, .. } => {
@@ -2478,28 +2442,13 @@ impl State {
                     self.common.config.cosmic_conf.accessibility_zoom.view_moves,
                 );
 
-                let output_geometry = output.geometry();
-                for session in cursor_sessions_for_output(&shell, &output) {
-                    if let Some(cursor_geometry) = seat.cursor_geometry(
-                        point.as_logical().to_buffer(
-                            output.current_scale().fractional_scale(),
-                            output.current_transform(),
-                            &output_geometry.size.to_f64().as_logical(),
-                        ),
-                        self.common.clock.now(),
-                    ) {
-                        let constraints = cursor_capture_constraints(Some(cursor_geometry));
-                        if session
-                            .current_constraints()
-                            .map(|current_constraints| current_constraints.size != constraints.size)
-                            .unwrap_or(true)
-                        {
-                            session.update_constraints(constraints);
-                        }
-                        session.set_cursor_hotspot(cursor_geometry.hotspot);
-                        session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
-                    }
-                }
+                update_output_image_copy_cursor_position(
+                    &shell,
+                    &self.common.clock,
+                    &output,
+                    &seat,
+                    point,
+                );
             }
         }
     }
@@ -2559,4 +2508,37 @@ fn mapped_output_for_device<'a, D: Device + 'static>(
         None
     };
     map_to_output.or_else(|| shell.builtin_output())
+}
+
+fn update_output_image_copy_cursor_position(
+    shell: &Shell,
+    clock: &Clock<Monotonic>,
+    output: &Output,
+    seat: &Seat<State>,
+    position: Point<f64, Global>,
+) {
+    let output_geometry = output.geometry();
+    for session in cursor_sessions_for_output(&shell, &output) {
+        if let Some(cursor_geometry) = seat.cursor_geometry(
+            (position - output_geometry.loc.to_f64())
+                .as_logical()
+                .to_buffer(
+                    output.current_scale().fractional_scale(),
+                    output.current_transform(),
+                    &output_geometry.size.to_f64().as_logical(),
+                ),
+            clock.now(),
+        ) {
+            let constraints = cursor_capture_constraints(Some(cursor_geometry));
+            if session
+                .current_constraints()
+                .map(|current_constraints| current_constraints.size != constraints.size)
+                .unwrap_or(true)
+            {
+                session.update_constraints(constraints);
+            }
+            session.set_cursor_hotspot(cursor_geometry.hotspot);
+            session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
+        }
+    }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     input::gestures::{GestureState, SwipeAction},
     shell::{
-        LastModifierChange, SeatExt, Trigger,
+        CursorGeometry, LastModifierChange, SeatExt, Trigger,
         focus::{
             Stage, render_input_order,
             target::{KeyboardFocusTarget, PointerFocusTarget},
@@ -640,7 +640,7 @@ impl State {
                     }
 
                     for session in cursor_sessions_for_output(&shell, &output) {
-                        if let Some((geometry, offset)) = seat.cursor_geometry(
+                        if let Some(CursorGeometry { geometry, hotspot }) = seat.cursor_geometry(
                             (position - output_geometry.loc.to_f64())
                                 .as_logical()
                                 .to_buffer(
@@ -666,7 +666,7 @@ impl State {
                                     dma: None,
                                 });
                             }
-                            session.set_cursor_hotspot(offset);
+                            session.set_cursor_hotspot(hotspot);
                             session.set_cursor_pos(Some(geometry.loc));
                         }
                     }
@@ -709,7 +709,7 @@ impl State {
 
                     let shell = self.common.shell.read();
                     for session in cursor_sessions_for_output(&shell, &output) {
-                        if let Some((geometry, offset)) = seat.cursor_geometry(
+                        if let Some(CursorGeometry { geometry, hotspot }) = seat.cursor_geometry(
                             (position - output_geometry.loc.to_f64())
                                 .as_logical()
                                 .to_buffer(
@@ -735,7 +735,7 @@ impl State {
                                     dma: None,
                                 });
                             }
-                            session.set_cursor_hotspot(offset);
+                            session.set_cursor_hotspot(hotspot);
                             session.set_cursor_pos(Some(geometry.loc));
                         }
                     }
@@ -2471,7 +2471,7 @@ impl State {
 
                 let output_geometry = output.geometry();
                 for session in cursor_sessions_for_output(&shell, &output) {
-                    if let Some((geometry, offset)) = seat.cursor_geometry(
+                    if let Some(CursorGeometry { geometry, hotspot }) = seat.cursor_geometry(
                         point.to_buffer(
                             output.current_scale().fractional_scale(),
                             output.current_transform(),
@@ -2490,7 +2490,7 @@ impl State {
                                 dma: None,
                             });
                         }
-                        session.set_cursor_hotspot(offset);
+                        session.set_cursor_hotspot(hotspot);
                         session.set_cursor_pos(Some(geometry.loc));
                     }
                 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2436,8 +2436,31 @@ impl State {
         };
 
         if let Some((point, output)) = point_and_output {
+            // TODO: Replace with `wl_pointer.warp`
             let original_position = pointer.current_location();
-            pointer.set_location(point.as_logical());
+            let serial = SERIAL_COUNTER.next_serial();
+            let under = State::surface_under(point, &output, &self.common.shell.write())
+                .map(|(target, pos)| (target, pos.as_logical()));
+            let time = self.common.clock.now();
+            pointer.relative_motion(
+                self,
+                under.clone(),
+                &RelativeMotionEvent {
+                    delta: (0., 0.).into(),
+                    delta_unaccel: (0., 0.).into(),
+                    utime: time.as_micros(),
+                },
+            );
+            pointer.motion(
+                self,
+                under,
+                &MotionEvent {
+                    location: point.as_logical(),
+                    serial,
+                    time: time.as_millis(),
+                },
+            );
+            pointer.frame(self);
 
             let mut shell = self.common.shell.write();
             shell.update_pointer_position(point.to_local(&output), &output);

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -378,6 +378,14 @@ fn update_focus_state(
                     .cloned()
                     .unwrap_or(seat.active_output());
 
+                crate::input::update_output_image_copy_cursor_position(
+                    &shell,
+                    &state.common.clock,
+                    &output,
+                    seat,
+                    new_pos,
+                );
+
                 let focus = State::surface_under(new_pos, &output, &shell)
                     .map(|(focus, loc)| (focus, loc.as_logical()));
                 //drop here to avoid multiple borrows

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     shell::{
-        CosmicSurface, SeatExt,
+        CosmicSurface, CursorGeometry, SeatExt,
         element::{CosmicMapped, CosmicStack, CosmicWindow},
         layout::tiling::ResizeForkTarget,
         zoom::ZoomFocusTarget,
@@ -272,7 +272,7 @@ impl PointerFocusTarget {
             None
         };
 
-        let cursor_hotspot = if let Some((_, hotspot)) =
+        let cursor_hotspot = if let Some(CursorGeometry { hotspot, .. }) =
             seat.cursor_geometry((0.0, 0.0), Duration::from_millis(event.time as u64).into())
         {
             hotspot

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -243,6 +243,12 @@ pub fn create_seat(
     seat
 }
 
+#[derive(Debug, Copy, Clone)]
+pub struct CursorGeometry {
+    pub geometry: Rectangle<i32, Buffer>,
+    pub hotspot: Point<i32, Buffer>,
+}
+
 pub trait SeatExt {
     fn id(&self) -> usize;
 
@@ -266,7 +272,7 @@ pub trait SeatExt {
         &self,
         loc: impl Into<Point<f64, Buffer>>,
         time: Time<Monotonic>,
-    ) -> Option<(Rectangle<i32, Buffer>, Point<i32, Buffer>)>;
+    ) -> Option<CursorGeometry>;
     fn cursor_image_status(&self) -> CursorImageStatus;
     fn set_cursor_image_status(&self, status: CursorImageStatus);
 }
@@ -367,7 +373,7 @@ impl SeatExt for Seat<State> {
         &self,
         loc: impl Into<Point<f64, Buffer>>,
         time: Time<Monotonic>,
-    ) -> Option<(Rectangle<i32, Buffer>, Point<i32, Buffer>)> {
+    ) -> Option<CursorGeometry> {
         let location = loc.into().to_i32_round();
 
         match self.cursor_image_status() {
@@ -386,7 +392,10 @@ impl SeatExt for Seat<State> {
                     (geo.loc.x, geo.loc.y).into(),
                     geo.size.to_buffer(1, Transform::Normal),
                 );
-                Some((buffer_geo, (hotspot.x, hotspot.y).into()))
+                Some(CursorGeometry {
+                    geometry: buffer_geo,
+                    hotspot: (hotspot.x, hotspot.y).into(),
+                })
             }
             CursorImageStatus::Named(cursor_icon) => {
                 let seat_userdata = self.user_data();
@@ -398,10 +407,13 @@ impl SeatExt for Seat<State> {
                     .get_named_cursor(cursor_icon)
                     .get_image(1, time.as_millis());
 
-                Some((
-                    Rectangle::new(location, (frame.width as i32, frame.height as i32).into()),
-                    (frame.xhot as i32, frame.yhot as i32).into(),
-                ))
+                Some(CursorGeometry {
+                    geometry: Rectangle::new(
+                        location,
+                        (frame.width as i32, frame.height as i32).into(),
+                    ),
+                    hotspot: (frame.xhot as i32, frame.yhot as i32).into(),
+                })
             }
             CursorImageStatus::Hidden => None,
         }

--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -14,6 +14,7 @@ use smithay::{
         },
     },
     desktop::space::SpaceElement,
+    input::{Seat, pointer::PointerHandle},
     output::Output,
     reexports::wayland_server::protocol::{wl_pointer::WlPointer, wl_shm::Format as ShmFormat},
     utils::{Buffer as BufferCoords, Point, Size, Transform},
@@ -30,7 +31,7 @@ use smithay::{
 };
 
 use crate::{
-    shell::CosmicSurface,
+    shell::{CosmicSurface, Shell},
     state::{BackendData, State},
     utils::prelude::{
         OutputExt, PointExt, PointGlobalExt, PointLocalExt, RectExt, RectLocalExt, SeatExt,
@@ -43,6 +44,14 @@ mod user_data;
 pub use self::render::*;
 use self::user_data::*;
 pub use self::user_data::{FrameHolder, ImageCopySessions, SessionData, SessionHolder};
+
+fn seat_for_wl_pointer<'a>(shell: &'a Shell, pointer: &WlPointer) -> Option<&'a Seat<State>> {
+    let pointer_handle = PointerHandle::<State>::from_resource(pointer)?;
+    shell
+        .seats
+        .iter()
+        .find(|seat| seat.get_pointer().is_some_and(|p| p == pointer_handle))
+}
 
 impl ImageCopyCaptureHandler for State {
     fn image_copy_capture_state(&mut self) -> &mut ImageCopyCaptureState {
@@ -73,15 +82,12 @@ impl ImageCopyCaptureHandler for State {
     fn cursor_capture_constraints(
         &mut self,
         _source: &ImageCaptureSource,
-        _pointer: &WlPointer,
+        pointer: &WlPointer,
     ) -> Option<BufferConstraints> {
-        let size = if let Some((geometry, _)) = self
-            .common
-            .shell
-            .read()
-            .seats
-            .last_active()
-            .cursor_geometry((0.0, 0.0), self.common.clock.now())
+        let shell = self.common.shell.read();
+        let seat = seat_for_wl_pointer(&shell, pointer)?;
+        let size = if let Some((geometry, _)) =
+            seat.cursor_geometry((0.0, 0.0), self.common.clock.now())
         {
             geometry.size
         } else {
@@ -149,20 +155,23 @@ impl ImageCopyCaptureHandler for State {
 
     fn new_cursor_session(&mut self, session: CursorSession) {
         let (pointer_loc, pointer_size, hotspot) = {
-            let seat = self.common.shell.read().seats.last_active().clone();
+            let shell = self.common.shell.read();
+            if let Some(seat) = seat_for_wl_pointer(&shell, &session.pointer()) {
+                let pointer = seat.get_pointer().unwrap();
+                let pointer_loc = pointer.current_location().to_i32_round().as_global();
 
-            let pointer = seat.get_pointer().unwrap();
-            let pointer_loc = pointer.current_location().to_i32_round().as_global();
+                let (pointer_size, hotspot) = if let Some((geometry, hotspot)) =
+                    seat.cursor_geometry((0.0, 0.0), self.common.clock.now())
+                {
+                    (geometry.size, hotspot)
+                } else {
+                    (Size::from((64, 64)), Point::from((0, 0)))
+                };
 
-            let (pointer_size, hotspot) = if let Some((geometry, hotspot)) =
-                seat.cursor_geometry((0.0, 0.0), self.common.clock.now())
-            {
-                (geometry.size, hotspot)
+                (pointer_loc, pointer_size, hotspot)
             } else {
-                (Size::from((64, 64)), Point::from((0, 0)))
-            };
-
-            (pointer_loc, pointer_size, hotspot)
+                (Point::new(0, 0), Size::from((64, 64)), Point::from((0, 0)))
+            }
         };
 
         session.user_data().insert_if_missing_threadsafe(|| {
@@ -299,8 +308,11 @@ impl ImageCopyCaptureHandler for State {
             return;
         }
 
-        let seat = self.common.shell.read().seats.last_active().clone();
-        render_cursor_to_buffer(self, session, frame, &seat);
+        let shell = self.common.shell.read();
+        if let Some(seat) = seat_for_wl_pointer(&shell, &session.pointer()).cloned() {
+            drop(shell);
+            render_cursor_to_buffer(self, session, frame, &seat);
+        }
     }
 
     fn frame_aborted(&mut self, frame: FrameRef) {

--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -31,7 +31,7 @@ use smithay::{
 };
 
 use crate::{
-    shell::{CosmicSurface, Shell},
+    shell::{CosmicSurface, CursorGeometry, Shell},
     state::{BackendData, State},
     utils::prelude::{
         OutputExt, PointExt, PointGlobalExt, PointLocalExt, RectExt, RectLocalExt, SeatExt,
@@ -86,7 +86,7 @@ impl ImageCopyCaptureHandler for State {
     ) -> Option<BufferConstraints> {
         let shell = self.common.shell.read();
         let seat = seat_for_wl_pointer(&shell, pointer)?;
-        let size = if let Some((geometry, _)) =
+        let size = if let Some(CursorGeometry { geometry, .. }) =
             seat.cursor_geometry((0.0, 0.0), self.common.clock.now())
         {
             geometry.size
@@ -160,7 +160,7 @@ impl ImageCopyCaptureHandler for State {
                 let pointer = seat.get_pointer().unwrap();
                 let pointer_loc = pointer.current_location().to_i32_round().as_global();
 
-                let (pointer_size, hotspot) = if let Some((geometry, hotspot)) =
+                let (pointer_size, hotspot) = if let Some(CursorGeometry { geometry, hotspot }) =
                     seat.cursor_geometry((0.0, 0.0), self.common.clock.now())
                 {
                     (geometry.size, hotspot)

--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -45,12 +45,34 @@ pub use self::render::*;
 use self::user_data::*;
 pub use self::user_data::{FrameHolder, ImageCopySessions, SessionData, SessionHolder};
 
+fn default_cursor_size() -> Size<i32, BufferCoords> {
+    Size::new(64, 64)
+}
+
 fn seat_for_wl_pointer<'a>(shell: &'a Shell, pointer: &WlPointer) -> Option<&'a Seat<State>> {
     let pointer_handle = PointerHandle::<State>::from_resource(pointer)?;
     shell
         .seats
         .iter()
         .find(|seat| seat.get_pointer().is_some_and(|p| p == pointer_handle))
+}
+
+pub fn cursor_capture_constraints(cursor_geometry: Option<CursorGeometry>) -> BufferConstraints {
+    let size = if let Some(cursor_geometry) = cursor_geometry {
+        let mut size = cursor_geometry.geometry.size;
+        // Client shouldn't try to allocate 0x0 buffer
+        if size == Size::new(0, 0) {
+            size = Size::new(1, 1);
+        }
+        size
+    } else {
+        default_cursor_size()
+    };
+    BufferConstraints {
+        size,
+        shm: vec![ShmFormat::Argb8888],
+        dma: None,
+    }
 }
 
 impl ImageCopyCaptureHandler for State {
@@ -86,19 +108,8 @@ impl ImageCopyCaptureHandler for State {
     ) -> Option<BufferConstraints> {
         let shell = self.common.shell.read();
         let seat = seat_for_wl_pointer(&shell, pointer)?;
-        let size = if let Some(CursorGeometry { geometry, .. }) =
-            seat.cursor_geometry((0.0, 0.0), self.common.clock.now())
-        {
-            geometry.size
-        } else {
-            Size::from((64, 64))
-        };
-
-        Some(BufferConstraints {
-            size,
-            shm: vec![ShmFormat::Argb8888],
-            dma: None,
-        })
+        let cursor_geometry = seat.cursor_geometry((0.0, 0.0), self.common.clock.now());
+        Some(cursor_capture_constraints(cursor_geometry))
     }
 
     fn new_session(&mut self, session: Session) {
@@ -165,12 +176,12 @@ impl ImageCopyCaptureHandler for State {
                 {
                     (geometry.size, hotspot)
                 } else {
-                    (Size::from((64, 64)), Point::from((0, 0)))
+                    (default_cursor_size(), Point::from((0, 0)))
                 };
 
                 (pointer_loc, pointer_size, hotspot)
             } else {
-                (Point::new(0, 0), Size::from((64, 64)), Point::from((0, 0)))
+                (Point::new(0, 0), default_cursor_size(), Point::from((0, 0)))
             }
         };
 

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -614,6 +614,11 @@ pub fn render_window_to_buffer(
         let pointer_loc = pointer.current_location().to_i32_round().as_global();
         let mut location = None;
         if let Some(element) = shell.element_for_surface(toplevel)
+            && pointer
+                .current_focus()
+                .and_then(|f| f.toplevel(&shell))
+                .as_ref()
+                == Some(toplevel)
             && element.has_active_window(toplevel)
             && let Some(workspace) = shell.space_for(element)
             && let Some(geometry) = workspace.element_geometry(element)

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -9,7 +9,7 @@ use smithay::{
             buffer_dimensions, buffer_type,
             damage::{Error as DTError, OutputDamageTracker, RenderOutputResult},
             element::{
-                RenderElement,
+                RenderElement, UnderlyingStorage,
                 utils::{Relocate, RelocateRenderElement},
             },
             gles::{GlesError, GlesRenderbuffer},
@@ -58,10 +58,30 @@ use crate::{
 
 use super::{super::data_device::get_dnd_icon, user_data::SessionHolder};
 
+pub fn render_element_buffers<R, E>(
+    renderer: &mut R,
+    elements: &[E],
+) -> Vec<smithay::backend::renderer::utils::Buffer>
+where
+    R: AsGlowRenderer,
+    E: RenderElement<R>,
+{
+    elements
+        .iter()
+        .filter_map(|elem| match elem.underlying_storage(renderer) {
+            Some(UnderlyingStorage::Wayland(buffer)) => Some(buffer.clone()),
+            Some(UnderlyingStorage::Memory(_)) | None => None,
+        })
+        .collect()
+}
+
 pub struct PendingImageCopyData {
     pub frame: Frame,
     pub damage: Vec<smithay::utils::Rectangle<i32, BufferCoords>>,
     pub sync: SyncPoint,
+    // Hold reference so `wl_buffer` isn't released and sync point isn't signaled
+    // until image copy completes.
+    _buffers: Vec<smithay::backend::renderer::utils::Buffer>,
 }
 
 impl PendingImageCopyData {
@@ -104,6 +124,7 @@ pub fn submit_buffer<R>(
     transform: Transform,
     damage: Option<&[Rectangle<i32, Physical>]>,
     mut sync: SyncPoint,
+    buffers: Vec<smithay::backend::renderer::utils::Buffer>,
 ) -> Result<Option<PendingImageCopyData>, R::Error>
 where
     R: ExportMem + AsGlowRenderer,
@@ -182,6 +203,7 @@ where
             })
             .collect(),
         sync,
+        _buffers: buffers,
     }))
 }
 
@@ -201,7 +223,13 @@ where
         &'d mut OutputDamageTracker,
         usize,
         Vec<Rectangle<i32, BufferCoords>>,
-    ) -> Result<RenderOutputResult<'d>, DTError<R::Error>>,
+    ) -> Result<
+        (
+            RenderOutputResult<'d>,
+            Vec<smithay::backend::renderer::utils::Buffer>,
+        ),
+        DTError<R::Error>,
+    >,
 {
     let mut session_user_data = session.lock().unwrap();
 
@@ -245,30 +273,25 @@ where
         .as_mut()
         .map(|(_, tex)| renderer.bind(tex).map_err(DTError::Rendering))
         .transpose()?;
-    let res = render_fn(
+    let (result, buffers) = render_fn(
         &frame.buffer(),
         renderer,
         fb.as_mut(),
         dt,
         age,
         frame.damage(),
-    );
+    )?;
 
-    match res {
-        Ok(result) => submit_buffer(
-            frame,
-            renderer,
-            fb.as_mut(),
-            transform,
-            result.damage.map(|x| x.as_slice()),
-            result.sync,
-        )
-        .map_err(DTError::Rendering),
-        Err(err) => {
-            frame.fail(CaptureFailureReason::Unknown);
-            Err(err)
-        }
-    }
+    submit_buffer(
+        frame,
+        renderer,
+        fb.as_mut(),
+        transform,
+        result.damage.map(|x| x.as_slice()),
+        result.sync,
+        buffers,
+    )
+    .map_err(DTError::Rendering)
 }
 
 pub fn render_workspace_to_buffer(
@@ -316,7 +339,13 @@ pub fn render_workspace_to_buffer(
         common: &mut Common,
         output: &Output,
         handle: (WorkspaceHandle, usize),
-    ) -> Result<RenderOutputResult<'d>, DTError<R::Error>>
+    ) -> Result<
+        (
+            RenderOutputResult<'d>,
+            Vec<smithay::backend::renderer::utils::Buffer>,
+        ),
+        DTError<R::Error>,
+    >
     where
         R: AsGlowRenderer,
         R::TextureId: Send + Clone + 'static,
@@ -356,7 +385,7 @@ pub fn render_workspace_to_buffer(
                 .collect()
         });
 
-        if let Ok(dmabuf) = get_dmabuf(buffer) {
+        let (res, elements) = if let Ok(dmabuf) = get_dmabuf(buffer) {
             let mut dmabuf = dmabuf.clone();
             let mut fb = renderer.bind(&mut dmabuf).map_err(DTError::Rendering)?;
             render_workspace(
@@ -374,8 +403,7 @@ pub fn render_workspace_to_buffer(
                 handle,
                 cursor_mode,
                 ElementFilter::ExcludeWorkspaceOverview,
-            )
-            .map(|res| res.0)
+            )?
         } else {
             let target = offscreen.expect("shm buffers should have an offscreen target");
             render_workspace(
@@ -393,9 +421,12 @@ pub fn render_workspace_to_buffer(
                 handle,
                 cursor_mode,
                 ElementFilter::ExcludeWorkspaceOverview,
-            )
-            .map(|res| res.0)
-        }
+            )?
+        };
+
+        let buffers = render_element_buffers(renderer, &elements);
+
+        Ok((res, buffers))
     }
 
     let draw_cursor = session.draw_cursor();
@@ -549,7 +580,13 @@ pub fn render_window_to_buffer(
         common: &mut Common,
         toplevel: &CosmicSurface,
         geometry: Rectangle<i32, Logical>,
-    ) -> Result<RenderOutputResult<'d>, DTError<R::Error>>
+    ) -> Result<
+        (
+            RenderOutputResult<'d>,
+            Vec<smithay::backend::renderer::utils::Buffer>,
+        ),
+        DTError<R::Error>,
+    >
     where
         R: AsGlowRenderer,
         R::TextureId: Send + Clone + 'static,
@@ -650,16 +687,20 @@ pub fn render_window_to_buffer(
             None,
         );
 
-        if let Ok(dmabuf) = get_dmabuf(buffer) {
+        let res = if let Ok(dmabuf) = get_dmabuf(buffer) {
             let mut dmabuf_clone = dmabuf.clone();
             let mut fb = renderer
                 .bind(&mut dmabuf_clone)
                 .map_err(DTError::Rendering)?;
-            dt.render_output(renderer, &mut fb, age, &elements, Color32F::TRANSPARENT)
+            dt.render_output(renderer, &mut fb, age, &elements, Color32F::TRANSPARENT)?
         } else {
             let fb = offscreen.expect("shm buffer should have an offscreen target");
-            dt.render_output(renderer, fb, age, &elements, Color32F::TRANSPARENT)
-        }
+            dt.render_output(renderer, fb, age, &elements, Color32F::TRANSPARENT)?
+        };
+
+        let buffers = render_element_buffers(renderer, &elements);
+
+        Ok((res, buffers))
     }
 
     let common = &mut state.common;
@@ -797,7 +838,13 @@ pub fn render_cursor_to_buffer(
         additional_damage: Vec<Rectangle<i32, BufferCoords>>,
         common: &mut Common,
         seat: &Seat<State>,
-    ) -> Result<RenderOutputResult<'d>, DTError<R::Error>>
+    ) -> Result<
+        (
+            RenderOutputResult<'d>,
+            Vec<smithay::backend::renderer::utils::Buffer>,
+        ),
+        DTError<R::Error>,
+    >
     where
         R: AsGlowRenderer,
         R::TextureId: Send + Clone + 'static,
@@ -830,16 +877,20 @@ pub fn render_cursor_to_buffer(
             },
         );
 
-        if let Ok(dmabuf) = get_dmabuf(buffer) {
+        let res = if let Ok(dmabuf) = get_dmabuf(buffer) {
             let mut dmabuf_clone = dmabuf.clone();
             let mut fb = renderer
                 .bind(&mut dmabuf_clone)
                 .map_err(DTError::Rendering)?;
-            dt.render_output(renderer, &mut fb, age, &elements, [0.0, 0.0, 0.0, 0.0])
+            dt.render_output(renderer, &mut fb, age, &elements, [0.0, 0.0, 0.0, 0.0])?
         } else {
             let fb = offscreen.expect("shm buffers should have offscreen target");
-            dt.render_output(renderer, fb, age, &elements, [0.0, 0.0, 0.0, 0.0])
-        }
+            dt.render_output(renderer, fb, age, &elements, [0.0, 0.0, 0.0, 0.0])?
+        };
+
+        let buffers = render_element_buffers(renderer, &elements);
+
+        Ok((res, buffers))
     }
 
     let common = &mut state.common;

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -20,16 +20,14 @@ use smithay::{
     desktop::space::SpaceElement,
     input::Seat,
     output::{Output, OutputNoMode},
-    reexports::wayland_server::protocol::{wl_buffer::WlBuffer, wl_shm::Format as ShmFormat},
+    reexports::wayland_server::protocol::wl_buffer::WlBuffer,
     utils::{
         Buffer as BufferCoords, IsAlive, Logical, Physical, Point, Rectangle, Scale, Size,
         Transform,
     },
     wayland::{
         dmabuf::get_dmabuf,
-        image_copy_capture::{
-            BufferConstraints, CaptureFailureReason, CursorSessionRef, Frame, SessionRef,
-        },
+        image_copy_capture::{CaptureFailureReason, CursorSessionRef, Frame, SessionRef},
         seat::WaylandFocus,
         shm::{shm_format_to_fourcc, with_buffer_contents, with_buffer_contents_mut},
     },
@@ -45,7 +43,7 @@ use crate::{
         render_workspace,
         wayland::SurfaceRenderElement,
     },
-    shell::{CosmicMappedRenderElement, CosmicSurface, CursorGeometry, WorkspaceRenderElement},
+    shell::{CosmicMappedRenderElement, CosmicSurface, WorkspaceRenderElement},
     state::{Common, KmsNodes, State},
     utils::prelude::{PointExt, PointGlobalExt, RectExt, RectLocalExt, SeatExt},
     wayland::{
@@ -56,7 +54,9 @@ use crate::{
     },
 };
 
-use super::{super::data_device::get_dnd_icon, user_data::SessionHolder};
+use super::{
+    super::data_device::get_dnd_icon, cursor_capture_constraints, user_data::SessionHolder,
+};
 
 pub fn render_element_buffers<R, E>(
     renderer: &mut R,
@@ -802,25 +802,17 @@ pub fn render_cursor_to_buffer(
     seat: &Seat<State>,
 ) {
     let buffer = frame.buffer();
-    let mut cursor_size = seat
-        .cursor_geometry((0.0, 0.0), state.common.clock.now())
-        .map(|CursorGeometry { geometry, .. }| geometry.size)
-        .unwrap_or_else(|| Size::from((64, 64)));
+    let cursor_geometry = seat.cursor_geometry((0.0, 0.0), state.common.clock.now());
+    let constraints = cursor_capture_constraints(cursor_geometry);
     let buffer_size = buffer_dimensions(&buffer).unwrap();
-    // Client shouldn't try to allocate 0x0 buffer
-    if cursor_size == Size::new(0, 0) {
-        cursor_size = Size::new(1, 1);
-    }
-    if buffer_size != cursor_size {
-        let constraints = BufferConstraints {
-            size: cursor_size,
-            shm: vec![ShmFormat::Argb8888],
-            dma: None,
-        };
-        session.update_constraints(constraints);
+    if buffer_size != constraints.size {
+        session.update_constraints(constraints.clone());
         if let Some(data) = session.user_data().get::<SessionData>() {
             *data.lock().unwrap() = SessionUserData::new(OutputDamageTracker::new(
-                cursor_size.to_logical(1, Transform::Normal).to_physical(1),
+                constraints
+                    .size
+                    .to_logical(1, Transform::Normal)
+                    .to_physical(1),
                 1.0,
                 Transform::Normal,
             ));

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -45,7 +45,7 @@ use crate::{
         render_workspace,
         wayland::SurfaceRenderElement,
     },
-    shell::{CosmicMappedRenderElement, CosmicSurface, WorkspaceRenderElement},
+    shell::{CosmicMappedRenderElement, CosmicSurface, CursorGeometry, WorkspaceRenderElement},
     state::{Common, KmsNodes, State},
     utils::prelude::{PointExt, PointGlobalExt, RectExt, RectLocalExt, SeatExt},
     wayland::{
@@ -804,7 +804,7 @@ pub fn render_cursor_to_buffer(
     let buffer = frame.buffer();
     let mut cursor_size = seat
         .cursor_geometry((0.0, 0.0), state.common.clock.now())
-        .map(|(geo, _hotspot)| geo.size)
+        .map(|CursorGeometry { geometry, .. }| geometry.size)
         .unwrap_or_else(|| Size::from((64, 64)));
     let buffer_size = buffer_dimensions(&buffer).unwrap();
     // Client shouldn't try to allocate 0x0 buffer


### PR DESCRIPTION
There are more edge cases around image-copy to address, as well as inconsistency between handling of `PointerMotion`/`PointerMotionAbsolute`, along with more code deduplication, workspace capture, and https://github.com/pop-os/cosmic-comp/pull/2248. But the changes here should be a good incremental improvement.

The changes related to metadata cursor capture won't have an effect without https://github.com/pop-os/xdg-desktop-portal-cosmic/pull/175.

This also has a change to hold a references to `Buffer`, that should prevent some potential synchronization issues (though in most cases it should have no effect). And it also changes the pointer warp behavior to send `wl_pointer::motion`, which seems to match Gnome.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

