### PR TITLE
Fix frozen/detached active window hint

### DIFF
--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -1522,49 +1522,6 @@ impl FloatingLayout {
                 .unwrap_or_else(|| (self.space.element_geometry(elem).unwrap().as_local(), alpha));
             let render_location = geometry.loc - elem.geometry().loc.as_local();
 
-            if focused == Some(elem) && !elem.is_maximized(false) {
-                let active_window_hint = crate::theme::active_window_hint(theme);
-                let radius = elem.corner_radius(geometry.size.as_logical(), indicator_thickness);
-
-                if let Some((mode, resize)) = resize_indicator.as_mut() {
-                    let mut resize_geometry = geometry;
-                    resize_geometry.loc -= (18, 18).into();
-                    resize_geometry.size += (36, 36).into();
-
-                    resize.resize(resize_geometry.size.as_logical());
-                    resize.output_enter(output);
-                    resize.push_render_elements(
-                        renderer,
-                        resize_geometry
-                            .loc
-                            .as_logical()
-                            .to_physical_precise_round(output_scale),
-                        output_scale.into(),
-                        alpha * mode.alpha().unwrap_or(1.0),
-                        &mut |elem| push(CosmicMappedRenderElement::Window(elem.into())),
-                        None,
-                    );
-                }
-
-                if indicator_thickness > 0 {
-                    let element = IndicatorShader::focus_element(
-                        renderer,
-                        Key::Window(Usage::FocusIndicator, elem.key()),
-                        geometry,
-                        indicator_thickness,
-                        radius,
-                        alpha,
-                        output_scale,
-                        [
-                            active_window_hint.red,
-                            active_window_hint.green,
-                            active_window_hint.blue,
-                        ],
-                    );
-                    push(element.into());
-                }
-            }
-
             let maybe_map = if let Some(anim) = self.animations.get(elem) {
                 let original_geo = anim.previous_geometry();
                 geometry = anim.geometry(
@@ -1629,6 +1586,50 @@ impl FloatingLayout {
             } else {
                 None
             };
+
+            if focused == Some(elem) && !elem.is_maximized(false) {
+                let active_window_hint = crate::theme::active_window_hint(theme);
+                let radius = elem.corner_radius(geometry.size.as_logical(), indicator_thickness);
+
+                if let Some((mode, resize)) = resize_indicator.as_mut() {
+                    let mut resize_geometry = geometry;
+                    resize_geometry.loc -= (18, 18).into();
+                    resize_geometry.size += (36, 36).into();
+
+                    resize.resize(resize_geometry.size.as_logical());
+                    resize.output_enter(output);
+                    resize.push_render_elements(
+                        renderer,
+                        resize_geometry
+                            .loc
+                            .as_logical()
+                            .to_physical_precise_round(output_scale),
+                        output_scale.into(),
+                        alpha * mode.alpha().unwrap_or(1.0),
+                        &mut |elem| push(CosmicMappedRenderElement::Window(elem.into())),
+                        None,
+                    );
+                }
+
+                if indicator_thickness > 0 {
+                    let element = IndicatorShader::focus_element(
+                        renderer,
+                        Key::Window(Usage::FocusIndicator, elem.key()),
+                        geometry,
+                        indicator_thickness,
+                        radius,
+                        alpha,
+                        output_scale,
+                        [
+                            active_window_hint.red,
+                            active_window_hint.green,
+                            active_window_hint.blue,
+                        ],
+                    );
+                    push(element.into());
+                }
+            }
+
             let map_anim = |elem| {
                 if let Some(map) = maybe_map {
                     map(elem)


### PR DESCRIPTION
This PR reorders the active window hint rendering so it happens after the window’s geometry is calculated.

This fixes a case where the active window hint can appear frozen/detached when unmaximizing a window when the setting keep_style_on_maximize is enabled pop-os/cosmic-panel#601.

This used to be the rendering order before push based rendering. The previous ordering can be seen in [031fdc3](https://github.com/pop-os/cosmic-comp/commit/031fdc389aaa4dac8546e0fc429bbea2295cc00d), before it changed in [e4c0716](https://github.com/pop-os/cosmic-comp/commit/e4c0716951fd69984c582720c4c4572c327b2493).

I searched for issues, PRs, etc. but did not find a reason why the order was changed for push based rendering.

https://github.com/user-attachments/assets/083dc0c9-128a-4a9e-995a-e50ca0c4ec3f

https://github.com/user-attachments/assets/ccb67dde-b583-48ab-aae0-5b9836596dda

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.