### PR TITLE
fix: release active popup grabs on toplevel destruction. If a window …

### DIFF
--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -317,8 +317,45 @@ impl XdgShellHandler for State {
     }
 
     fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {
+        for (popup, _) in smithay::desktop::PopupManager::popups_for_surface(surface.wl_surface()) {
+            if let smithay::desktop::PopupKind::Xdg(ref xdg_popup) = popup {
+                xdg_popup.send_popup_done();
+            }
+        }
+
         let (output, clients) = {
             let mut shell = self.common.shell.write();
+
+            for seat in shell.seats.iter() {
+                if let Some(data) = seat.user_data().get::<PopupGrabData>() {
+                    let mut should_ungrab = false;
+                    let grab = data.take();
+                    if let Some(ref grab) = grab {
+                        if grab.has_ended() {
+                            should_ungrab = true;
+                        } else if let Some(target) = grab.current_grab() {
+                            if let Some(wl_surface) = target.wl_surface() {
+                                if wl_surface.as_ref() == surface.wl_surface()
+                                    || smithay::desktop::PopupManager::popups_for_surface(
+                                        surface.wl_surface(),
+                                    )
+                                    .any(|(p, _)| p.wl_surface() == wl_surface.as_ref())
+                                {
+                                    should_ungrab = true;
+                                }
+                            }
+                        }
+                    }
+                    if should_ungrab {
+                        if let Some(mut grab) = grab {
+                            grab.ungrab(PopupUngrabStrategy::All);
+                        }
+                    } else {
+                        data.set(grab);
+                    }
+                }
+            }
+
             let seat = shell.seats.last_active().clone();
 
             // Clean up pending_windows for surfaces that were never mapped.


### PR DESCRIPTION

### The Problem

When a client window is destroyed, any active Wayland popup grabs associated with the seat are not automatically cleared. The compositor remains in a grab state, redirecting all keyboard and mouse inputs to a non-existent surface. The user's desktop becomes unresponsive (mouse cursor still moves, but clicks are ignored and keyboard shortcuts stop working).

### How to Reproduce
1. Open a terminal and launch several background processes (e.g., local development servers/workers).
2. Abruptly close the terminal or kill the terminal processes all at once.
3. This triggers a client process crash, causing the system's crash reporter dialog (`apport-gtk` or similar) to spawn a modal popup.
4. Because the grab state was orphaned during the abrupt client close, the input focus gets permanently locked, rendering the desktop session frozen.

I submitted a bug report three weeks ago via the Pop! OS github repository.
check [https://github.com/pop-os/pop/issues/4030](https://github.com/pop-os/pop/issues/4030)

### Video Demonstration on testing device 


https://github.com/user-attachments/assets/fbea36b3-1147-44d9-95ba-760723e69500


### System Specifications Summary

Device Model: Lenovo ThinkPad (Modal 20S00043UK)
Processor: Intel(R) Core(TM) i5-10210U 
RAM: 16 GB System Memory
GPU: Intel CometLake-U GT2 [UHD Graphics]
Display Interface: `/dev/fb0`
Storage: 512GB SanDisk SSD


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Thank you guys! :) I really like Pop os and appreciate your works