### PR TITLE
Fix flicker when switching between menus libcosmic apps in tiling mode

### DIFF
--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -4013,6 +4013,7 @@ impl TilingLayout {
         &self,
         renderer: &mut R,
         seat: Option<&Seat<State>>,
+        focused: Option<&CosmicMapped>,
         non_exclusive_zone: Rectangle<i32, Local>,
         overview: (OverviewMode, Option<(SwapIndicator, Option<&Tree<Data>>)>),
         resize_indicator: Option<(ResizeMode, ResizeIndicator)>,
@@ -4143,6 +4144,7 @@ impl TilingLayout {
             old_geometries,
             is_overview,
             seat,
+            focused,
             &self.output,
             percentage,
             draw_groups,
@@ -5276,6 +5278,7 @@ fn render_new_tree_windows<R>(
     old_geometries: Option<HashMap<NodeId, Rectangle<i32, Local>>>,
     is_overview: bool,
     seat: Option<&Seat<State>>,
+    focused: Option<&CosmicMapped>,
     output: &Output,
     percentage: f32,
     transition: Option<f32>,
@@ -5295,14 +5298,19 @@ fn render_new_tree_windows<R>(
     CosmicWindowRenderElement<R>: RenderElement<R>,
     CosmicStackRenderElement<R>: RenderElement<R>,
 {
-    let focused = seat
-        .and_then(|seat| {
-            seat.get_keyboard()
-                .unwrap()
-                .current_focus()
-                .and_then(|target| TilingLayout::currently_focused_node(target_tree, target))
-        })
-        .map(|(id, _)| id);
+    let focused = match seat.and_then(|seat| seat.get_keyboard().unwrap().current_focus()) {
+        Some(target @ KeyboardFocusTarget::Group(_)) => {
+            TilingLayout::currently_focused_node(target_tree, target).map(|(id, _)| id)
+        }
+        _ => focused.and_then(|mapped| {
+            let node_id = mapped.tiling_node_id.lock().unwrap().clone()?;
+            target_tree
+                .get(&node_id)
+                .ok()
+                .filter(|node| node.data().is_mapped(Some(mapped)))
+                .map(|_| node_id)
+        }),
+    };
     let focused_geo = if let Some(focused) = focused.as_ref() {
         geometries
             .as_ref()

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1799,6 +1799,17 @@ impl Workspace {
             self.tiling_layer.render(
                 renderer,
                 render_focus.then_some(last_active_seat),
+                render_focus
+                    .then(|| {
+                        focused.as_ref().and_then(|target| {
+                            if let FocusTarget::Window(mapped) = target {
+                                Some(mapped)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .flatten(),
                 zone,
                 overview,
                 resize_indicator,


### PR DESCRIPTION
Tiling mode uses keyboard focus to draw focus hint, while floating mode uses focus stack.

Sometimes when you open a pop up (for example menus in cosmic-files menu bar) when you're going from one menu to the other menu, for a moment, the system is destroying the old popup and creating a new one, and the keyboard focus is on nothing. That causes the focus hint to disappear for a moment, creating a flicker effect.

This took me a while to figure out. And I'm not sure if the solution below is the best solution. But it does fix the problem.

To reproduce the issue:
- open a cosmic-term
- open a cosmic-files
- make sure you're in tiling mode
- click on one of them and open a menu and try to move the cursor to a neighboring menu
- then click on the other one and do the same
(The issue normally happens the first time that you focus a window and between the first two menus that you open).


You can see it looks like the window is losing focus when I go from one menu to another (Sort to View in cosmic-files):

https://github.com/user-attachments/assets/8f9efc1b-7c56-4c38-bfe4-81d9855cbe72


___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

