### PR TITLE
Implement wp_tearing_control_v1 (composited tearing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4813,7 +4813,6 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=efeb597#efeb59768eb9a2d8dae9f71300a56aef06b0c1c4"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1508,7 +1508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2689,7 +2689,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2812,7 +2812,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3422,7 +3422,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4518,7 +4518,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4813,6 +4813,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 [[package]]
 name = "smithay"
 version = "0.7.0"
+source = "git+https://github.com/s0kil/smithay.git?branch=feature%2Fasync-page-flip#1706e84b1d6168aafada407be2c4032760a6e0a3"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -5106,7 +5107,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6125,7 +6126,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,4 @@ lto = "fat"
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { path = "/home/danielsokil/Lab/Smithay/smithay" }
+smithay = { git = "https://github.com/s0kil/smithay.git", branch = "feature/async-page-flip" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,4 @@ lto = "fat"
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "efeb597" }
+smithay = { path = "/home/danielsokil/Lab/Smithay/smithay" }

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -935,6 +935,13 @@ impl SurfaceThreadState {
     /// `Async` presentation hint. Evaluated once per cycle and cached in a
     /// local by the caller so the answer can't change mid-frame.
     fn tearing_mode(&self) -> bool {
+        // Env gate first, before touching any lock: when tearing is disabled
+        // (the default config) this is a cached bool load, so the render hot
+        // path takes zero extra `shell` lock traffic — "zero delta when off".
+        if !tearing::tearing_env_enabled() {
+            return false;
+        }
+
         let shell = self.shell.read();
         let output = self.mirroring.as_ref().unwrap_or(&self.output);
         let hint = shell
@@ -984,6 +991,12 @@ impl SurfaceThreadState {
         // is something to draw. The rate ceiling keeps this below ~500fps by
         // falling back to normal vblank-paced scheduling if we submitted within
         // the last 2ms (rather than busy-spinning an immediate timer).
+        //
+        // This `tearing_mode()` evaluation is deliberately independent of the
+        // one in `redraw()`: this one only decides scheduling, that one decides
+        // submission. If the hint flips between the two, the result is benign
+        // (frame scheduled immediate but submitted sync, or vice versa) — never
+        // a broken state.
         let tearing_immediate = self.tearing_mode()
             && self
                 .last_submit
@@ -1043,7 +1056,10 @@ impl SurfaceThreadState {
     fn redraw(&mut self, estimated_presentation: Duration) -> Result<()> {
         // Evaluate tearing mode once per cycle; every per-frame decision below
         // (cursor-plane compositing, async submit, counters) uses this local so
-        // the answer can't drift mid-frame.
+        // the answer can't drift mid-frame. This evaluation is deliberately
+        // independent of the one in `queue_redraw()` (which decides scheduling);
+        // a hint flip between the two is benign — a frame may be scheduled
+        // immediate but submitted sync, or vice versa, never a broken state.
         let tearing = self.tearing_mode();
         if self.was_tearing && !tearing {
             self.counters.log_and_reset();

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -955,6 +955,10 @@ impl SurfaceThreadState {
                     })
                 })
             });
+
+        // diagnostic: log hint state changes for the fullscreen surface (validation aid)
+        tracing::debug!(hint = ?hint, "tearing_mode evaluation");
+
         tearing::tearing_active(self.mirroring.is_some(), hint)
     }
 
@@ -1063,6 +1067,9 @@ impl SurfaceThreadState {
         let tearing = self.tearing_mode();
         if self.was_tearing && !tearing {
             self.counters.log_and_reset();
+        }
+        if !self.was_tearing && tearing {
+            tracing::info!("tearing mode engaged");
         }
         self.was_tearing = tearing;
 

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1412,7 +1412,10 @@ impl SurfaceThreadState {
                     // Async (tearing) submit: the async flag is scoped to this
                     // one frame inside smithay, which also retries synchronously
                     // on driver rejection (logged there, not surfaced here).
-                    self.counters.submitted += 1;
+                    // `last_submit` is updated here, before the call, so the rate
+                    // ceiling throttles on submission attempts rather than only
+                    // on accepted ones; `counters.submitted` is only incremented
+                    // below once we know the submission was actually accepted.
                     self.last_submit = Some(Instant::now());
                     compositor.with_compositor(|c| {
                         c.queue_frame_with_flags(feedback, FrameFlags::ALLOW_ASYNC_PAGE_FLIP)
@@ -1427,6 +1430,12 @@ impl SurfaceThreadState {
 
                         // Update `state` after `queue_frame`, before any early return from errors
                         if x.is_ok() {
+                            if tearing {
+                                // Only count accepted async submissions; attempts that
+                                // errored (including EmptyFrame) are not "submitted".
+                                self.counters.submitted += 1;
+                            }
+
                             let new_state = QueueState::WaitingForVBlank {
                                 redraw_needed: false,
                             };

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -97,7 +97,7 @@ use std::{
         mpsc::{Receiver, SyncSender},
     },
     thread::JoinHandle,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 mod tearing;
@@ -167,6 +167,17 @@ pub struct SurfaceThreadState {
     /// Plot name for the presentation misprediction plot.
     presentation_misprediction_plot_name: tracy_client::PlotName,
     sequence_delta_plot_name: tracy_client::PlotName,
+
+    /// Tearing-mode async-submit counters, flushed on the tearing→not-tearing
+    /// transition. `rejected` stays 0: smithay handles async-flip rejection
+    /// internally (synchronous same-frame retry) and does not surface it.
+    counters: tearing::TearingCounters,
+    /// Timestamp of the last async (tearing) frame submission. Used to cap the
+    /// commit-driven immediate-rescheduling path at ~500fps.
+    last_submit: Option<Instant>,
+    /// Whether tearing mode was active on the previous render cycle, so the
+    /// counters can be flushed once when tearing turns off.
+    was_tearing: bool,
 }
 
 pub type GbmDrmOutput = DrmOutput<
@@ -560,6 +571,10 @@ fn surface_thread(
         time_since_presentation_plot_name,
         presentation_misprediction_plot_name,
         sequence_delta_plot_name,
+
+        counters: tearing::TearingCounters::default(),
+        last_submit: None,
+        was_tearing: false,
     };
 
     let signal = event_loop.get_signal();
@@ -914,6 +929,28 @@ impl SurfaceThreadState {
         self.send_frame_callbacks();
     }
 
+    /// Whether async (tearing) page flips should be used for this render
+    /// cycle: the `COSMIC_ALLOW_TEARING` env is enabled, the output is not
+    /// mirroring, and the active output's fullscreen surface committed an
+    /// `Async` presentation hint. Evaluated once per cycle and cached in a
+    /// local by the caller so the answer can't change mid-frame.
+    fn tearing_mode(&self) -> bool {
+        let shell = self.shell.read();
+        let output = self.mirroring.as_ref().unwrap_or(&self.output);
+        let hint = shell
+            .workspaces
+            .active(output)
+            .and_then(|(_, workspace)| {
+                let seat = shell.seats.last_active();
+                workspace.get_fullscreen(seat).and_then(|fullscreen| {
+                    fullscreen.surface.wl_surface().map(|surface| {
+                        crate::wayland::handlers::tearing_control::presentation_hint(&surface)
+                    })
+                })
+            });
+        tearing::tearing_active(self.mirroring.is_some(), hint)
+    }
+
     fn queue_redraw(&mut self, force: bool) {
         let Some(_compositor) = self.compositor.as_mut() else {
             return;
@@ -942,7 +979,19 @@ impl SurfaceThreadState {
         let estimated_presentation = self.timings.next_presentation_time(&self.clock);
         let render_start = self.timings.next_render_time(&self.clock);
 
-        let timer = if render_start.is_zero() {
+        // In tearing mode we don't pace rendering to the next estimated vblank:
+        // async flips present immediately, so we render/submit as soon as there
+        // is something to draw. The rate ceiling keeps this below ~500fps by
+        // falling back to normal vblank-paced scheduling if we submitted within
+        // the last 2ms (rather than busy-spinning an immediate timer).
+        let tearing_immediate = self.tearing_mode()
+            && self
+                .last_submit
+                .map_or(true, |last| last.elapsed() >= Duration::from_millis(2));
+
+        let timer = if tearing_immediate {
+            Timer::immediate()
+        } else if render_start.is_zero() {
             trace!("Running late for frame.");
             // TODO triple buffering
             Timer::immediate()
@@ -992,6 +1041,15 @@ impl SurfaceThreadState {
 
     #[profiling::function]
     fn redraw(&mut self, estimated_presentation: Duration) -> Result<()> {
+        // Evaluate tearing mode once per cycle; every per-frame decision below
+        // (cursor-plane compositing, async submit, counters) uses this local so
+        // the answer can't drift mid-frame.
+        let tearing = self.tearing_mode();
+        if self.was_tearing && !tearing {
+            self.counters.log_and_reset();
+        }
+        self.was_tearing = tearing;
+
         let Some(compositor) = self.compositor.as_mut() else {
             return Ok(());
         };
@@ -1050,6 +1108,14 @@ impl SurfaceThreadState {
         if has_active_fullscreen || animations_going {
             // skip overlay plane assign if we have a fullscreen surface or dynamic contents to save on tests
             remove_frame_flags |= FrameFlags::ALLOW_OVERLAY_PLANE_SCANOUT;
+        }
+
+        if tearing {
+            // An async commit may only change the primary plane's framebuffer;
+            // a cursor-plane update inside it is rejected with EINVAL (which
+            // would trigger a permanent sync-fallback storm). Composite the
+            // cursor into the primary plane instead of scanning it out.
+            remove_frame_flags |= FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT;
         }
 
         let mut vrr = matches!(self.vrr_mode, AdaptiveSync::Force);
@@ -1326,7 +1392,20 @@ impl SurfaceThreadState {
                     elem.sync.wait()?;
                 }
 
-                match compositor.queue_frame(feedback) {
+                let queue_result = if tearing {
+                    // Async (tearing) submit: the async flag is scoped to this
+                    // one frame inside smithay, which also retries synchronously
+                    // on driver rejection (logged there, not surfaced here).
+                    self.counters.submitted += 1;
+                    self.last_submit = Some(Instant::now());
+                    compositor.with_compositor(|c| {
+                        c.queue_frame_with_flags(feedback, FrameFlags::ALLOW_ASYNC_PAGE_FLIP)
+                    })
+                } else {
+                    compositor.queue_frame(feedback)
+                };
+
+                match queue_result {
                     x @ Ok(()) | x @ Err(FrameError::EmptyFrame) => {
                         self.timings.submitted_for_presentation(&self.clock);
 

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -100,6 +100,7 @@ use std::{
     time::Duration,
 };
 
+mod tearing;
 mod timings;
 pub use self::timings::Timings;
 

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1069,7 +1069,7 @@ impl SurfaceThreadState {
             self.counters.log_and_reset();
         }
         if !self.was_tearing && tearing {
-            tracing::info!("tearing mode engaged");
+            tracing::warn!("tearing mode engaged");
         }
         self.was_tearing = tearing;
 

--- a/src/backend/kms/surface/tearing.rs
+++ b/src/backend/kms/surface/tearing.rs
@@ -85,7 +85,7 @@ impl TearingCounters {
     // consumed by Task 6
     #[allow(dead_code)]
     pub fn log_and_reset(&mut self) {
-        tracing::info!(
+        tracing::warn!(
             submitted = self.submitted,
             rejected = self.rejected,
             "tearing mode counters"

--- a/src/backend/kms/surface/tearing.rs
+++ b/src/backend/kms/surface/tearing.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Tearing mode policy.
+//!
+//! Decides, per output, whether the KMS surface thread should submit frames
+//! with async (tearing) page flips instead of the usual vsync'd flips. This
+//! module is policy-only: it makes no KMS/rendering decisions itself, it
+//! just answers "should tearing be active right now" given the inputs the
+//! caller (the surface render loop, Task 6) already has on hand.
+//!
+//! Kept deliberately free of deep type dependencies (no `Output`, no
+//! `Shell`, no `SurfaceThreadState`) so the policy is unit-testable without
+//! constructing any of that machinery.
+
+use std::sync::OnceLock;
+
+use crate::wayland::handlers::tearing_control::PresentationHint;
+
+/// Caches the result of reading the `COSMIC_ALLOW_TEARING` environment
+/// variable so we only touch the environment once per process lifetime.
+static TEARING_ENV_ENABLED: OnceLock<bool> = OnceLock::new();
+
+/// Returns whether tearing is allowed by the environment.
+///
+/// Reads `COSMIC_ALLOW_TEARING` once (via [`OnceLock`]) and caches the
+/// result; the env var is considered "on" iff it is exactly `"1"`.
+// consumed by Task 6
+#[allow(dead_code)]
+pub fn tearing_env_enabled() -> bool {
+    *TEARING_ENV_ENABLED.get_or_init(|| {
+        std::env::var("COSMIC_ALLOW_TEARING")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    })
+}
+
+/// Decides whether tearing (async page flips) should be active for an
+/// output right now.
+///
+/// All of the following must hold:
+/// 1. [`tearing_env_enabled`] is `true`.
+/// 2. `mirroring` is `false` (the output is not mirroring another output).
+/// 3. `fullscreen_hint` is `Some(PresentationHint::Async)` — i.e. there is a
+///    fullscreen surface on the output and its tearing-control hint is
+///    `Async`.
+///
+/// The caller is expected to resolve `fullscreen_hint` itself, e.g. via
+/// `workspace.get_fullscreen(seat).map(|fs| presentation_hint(fs.surface.wl_surface()))`
+/// (see `redraw()` in `src/backend/kms/surface/mod.rs` for the existing
+/// accessor chain used for direct-scanout candidacy).
+// consumed by Task 6
+#[allow(dead_code)]
+pub fn tearing_active(mirroring: bool, fullscreen_hint: Option<PresentationHint>) -> bool {
+    tearing_active_inner(tearing_env_enabled(), mirroring, fullscreen_hint)
+}
+
+/// Test-injectable core of [`tearing_active`]; takes the env-enabled bit as
+/// a plain argument instead of reading the process environment, so unit
+/// tests never need to mutate global state.
+fn tearing_active_inner(
+    env_enabled: bool,
+    mirroring: bool,
+    fullscreen_hint: Option<PresentationHint>,
+) -> bool {
+    env_enabled && !mirroring && fullscreen_hint == Some(PresentationHint::Async)
+}
+
+/// Frame submission/rejection counters for tearing mode.
+///
+/// Intended to be accumulated while tearing mode is active on an output and
+/// flushed via [`TearingCounters::log_and_reset`] when the output leaves
+/// tearing mode (or periodically), so operators can see how often tearing
+/// submissions were rejected (e.g. falling back to vsync mid-flight).
+#[derive(Debug, Default)]
+// consumed by Task 6
+#[allow(dead_code)]
+pub struct TearingCounters {
+    pub submitted: u64,
+    pub rejected: u64,
+}
+
+impl TearingCounters {
+    /// Logs the current counters via `tracing::info!` and resets both to
+    /// zero.
+    // consumed by Task 6
+    #[allow(dead_code)]
+    pub fn log_and_reset(&mut self) {
+        tracing::info!(
+            submitted = self.submitted,
+            rejected = self.rejected,
+            "tearing mode counters"
+        );
+        self.submitted = 0;
+        self.rejected = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_disabled_is_always_false() {
+        // Even with mirroring off and a matching fullscreen hint, tearing
+        // must stay off if the env var isn't enabled.
+        assert!(!tearing_active_inner(
+            false,
+            false,
+            Some(PresentationHint::Async)
+        ));
+    }
+
+    #[test]
+    fn mirroring_forces_false() {
+        assert!(!tearing_active_inner(
+            true,
+            true,
+            Some(PresentationHint::Async)
+        ));
+    }
+
+    #[test]
+    fn no_fullscreen_surface_is_false() {
+        assert!(!tearing_active_inner(true, false, None));
+    }
+
+    #[test]
+    fn vsync_hint_is_false() {
+        assert!(!tearing_active_inner(
+            true,
+            false,
+            Some(PresentationHint::Vsync)
+        ));
+    }
+
+    #[test]
+    fn all_conditions_met_is_true() {
+        assert!(tearing_active_inner(
+            true,
+            false,
+            Some(PresentationHint::Async)
+        ));
+    }
+
+    #[test]
+    fn log_and_reset_zeroes_counters() {
+        let mut counters = TearingCounters {
+            submitted: 42,
+            rejected: 7,
+        };
+        counters.log_and_reset();
+        assert_eq!(counters.submitted, 0);
+        assert_eq!(counters.rejected, 0);
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,7 +13,10 @@ use crate::{
     shell::{CosmicSurface, SeatExt, Shell, grabs::SeatMoveGrabState},
     utils::prelude::OutputExt,
     wayland::{
-        handlers::{data_device::get_dnd_icon, image_copy_capture::SessionHolder},
+        handlers::{
+            data_device::get_dnd_icon, image_copy_capture::SessionHolder,
+            tearing_control::TearingControlManagerState,
+        },
         protocols::{
             a11y::A11yState,
             corner_radius::CornerRadiusState,
@@ -280,6 +283,7 @@ pub struct Common {
     pub kde_decoration_state: KdeDecorationState,
     pub xdg_decoration_state: XdgDecorationState,
     pub overlap_notify_state: OverlapNotifyState,
+    pub tearing_control_manager_state: TearingControlManagerState,
     pub a11y_state: A11yState,
     pub dbus_state: DBusState,
     pub keyboard_layout_state: KeyboardLayoutState,
@@ -655,6 +659,7 @@ impl State {
         let output_power_state = OutputPowerState::new::<Self, _>(dh, client_not_sandboxed);
         let overlap_notify_state =
             OverlapNotifyState::new::<Self, _>(dh, client_has_no_security_context);
+        let tearing_control_manager_state = TearingControlManagerState::new::<Self>(dh);
         let presentation_state = PresentationState::new::<Self>(dh, clock.id() as u32);
         let primary_selection_state = PrimarySelectionState::new::<Self>(dh);
         let cosmic_image_capture_source_state =
@@ -780,6 +785,7 @@ impl State {
                 output_configuration_state,
                 output_power_state,
                 overlap_notify_state,
+                tearing_control_manager_state,
                 presentation_state,
                 primary_selection_state,
                 ext_data_control_state,

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -264,6 +264,9 @@ impl CompositorHandler for State {
         // and refresh smithays internal state
         self.common.on_commit(surface);
 
+        // promote the pending wp_tearing_control_v1 presentation hint to current
+        crate::wayland::handlers::tearing_control::on_commit(surface);
+
         // handle initial configure events and map windows if necessary
         let mapped = self.send_initial_configure_and_map(surface);
 

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -35,6 +35,7 @@ pub mod selection;
 pub mod session_lock;
 pub mod shm;
 pub mod tablet_manager;
+pub mod tearing_control;
 pub mod toplevel_info;
 pub mod toplevel_management;
 pub mod workspace;

--- a/src/wayland/handlers/tearing_control.rs
+++ b/src/wayland/handlers/tearing_control.rs
@@ -195,7 +195,7 @@ where
                     state.lock().unwrap().object = Some(control.downgrade());
                 });
 
-                tracing::info!(surface = ?surface.id(), "tearing_control: client created control object");
+                tracing::warn!(surface = ?surface.id(), "tearing_control: client created control object");
             }
             wp_tearing_control_manager_v1::Request::Destroy => {}
             _ => {}
@@ -224,7 +224,7 @@ where
             wp_tearing_control_v1::Request::SetPresentationHint { hint } => {
                 if let WEnum::Value(hint) = hint {
                     let parsed_hint: PresentationHint = hint.into();
-                    tracing::info!(surface = ?surface.id(), hint = ?parsed_hint, "tearing_control: hint set (pending until commit)");
+                    tracing::warn!(surface = ?surface.id(), hint = ?parsed_hint, "tearing_control: hint set (pending until commit)");
                     with_states(&surface, |states| {
                         if let Some(state) = states.data_map.get::<TearingSurfaceData>() {
                             state.lock().unwrap().pending = parsed_hint;
@@ -242,7 +242,7 @@ where
                     }
                 });
 
-                tracing::info!("tearing_control: control destroyed (pending reset to vsync)");
+                tracing::warn!("tearing_control: control destroyed (pending reset to vsync)");
             }
             _ => {}
         }

--- a/src/wayland/handlers/tearing_control.rs
+++ b/src/wayland/handlers/tearing_control.rs
@@ -194,6 +194,8 @@ where
                         .get_or_insert_threadsafe(TearingSurfaceData::default);
                     state.lock().unwrap().object = Some(control.downgrade());
                 });
+
+                tracing::info!(surface = ?surface.id(), "tearing_control: client created control object");
             }
             wp_tearing_control_manager_v1::Request::Destroy => {}
             _ => {}
@@ -221,9 +223,11 @@ where
         match request {
             wp_tearing_control_v1::Request::SetPresentationHint { hint } => {
                 if let WEnum::Value(hint) = hint {
+                    let parsed_hint: PresentationHint = hint.into();
+                    tracing::info!(surface = ?surface.id(), hint = ?parsed_hint, "tearing_control: hint set (pending until commit)");
                     with_states(&surface, |states| {
                         if let Some(state) = states.data_map.get::<TearingSurfaceData>() {
-                            state.lock().unwrap().pending = hint.into();
+                            state.lock().unwrap().pending = parsed_hint;
                         }
                     });
                 }
@@ -237,6 +241,8 @@ where
                         state.lock().unwrap().pending = PresentationHint::Vsync;
                     }
                 });
+
+                tracing::info!("tearing_control: control destroyed (pending reset to vsync)");
             }
             _ => {}
         }

--- a/src/wayland/handlers/tearing_control.rs
+++ b/src/wayland/handlers/tearing_control.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! `wp_tearing_control_v1` support.
+//!
+//! Advertises the `wp_tearing_control_manager_v1` global, letting clients
+//! attach a `wp_tearing_control_v1` object to a `wl_surface` to hint whether
+//! its content is suitable for presentation with tearing (async page flips).
+//!
+//! The presentation hint is double-buffered per the protocol: requests only
+//! update the *pending* value, which is promoted to *current* on the next
+//! `wl_surface.commit` via [`on_commit`]. Other subsystems read the active
+//! hint through [`presentation_hint`].
+
+use std::sync::Mutex;
+
+use smithay::{
+    reexports::{
+        wayland_protocols::wp::tearing_control::v1::server::{
+            wp_tearing_control_manager_v1::{self, WpTearingControlManagerV1},
+            wp_tearing_control_v1::{self, WpTearingControlV1},
+        },
+        wayland_server::{
+            Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
+            protocol::wl_surface::WlSurface,
+        },
+    },
+    wayland::compositor::with_states,
+};
+use wayland_backend::{protocol::WEnum, server::GlobalId};
+
+use crate::state::State;
+
+/// Presentation hint requested by a client for a surface.
+///
+/// This mirrors the protocol's `wp_tearing_control_v1.presentation_hint`
+/// enum. `Vsync` is the default and the state used whenever a surface has no
+/// (live or ever committed) `wp_tearing_control_v1` object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PresentationHint {
+    #[default]
+    Vsync,
+    Async,
+}
+
+impl From<wp_tearing_control_v1::PresentationHint> for PresentationHint {
+    fn from(hint: wp_tearing_control_v1::PresentationHint) -> Self {
+        match hint {
+            wp_tearing_control_v1::PresentationHint::Async => PresentationHint::Async,
+            _ => PresentationHint::Vsync,
+        }
+    }
+}
+
+type TearingSurfaceData = Mutex<TearingSurfaceState>;
+
+#[derive(Debug, Default)]
+struct TearingSurfaceState {
+    /// Set by `set_presentation_hint`, applied on the next commit.
+    pending: PresentationHint,
+    /// The value in effect since the last commit.
+    current: PresentationHint,
+    /// The currently live `wp_tearing_control_v1` object for this surface, if any.
+    /// Used to enforce the "one object per surface" protocol rule; a client is
+    /// free to destroy its object and create a new one later.
+    object: Option<Weak<WpTearingControlV1>>,
+}
+
+/// Returns the current (post-commit) presentation hint for `surface`.
+///
+/// Defaults to [`PresentationHint::Vsync`] if the surface never had a
+/// `wp_tearing_control_v1` object or hasn't committed since one was created.
+pub fn presentation_hint(surface: &WlSurface) -> PresentationHint {
+    with_states(surface, |states| {
+        states
+            .data_map
+            .get::<TearingSurfaceData>()
+            .map(|state| state.lock().unwrap().current)
+    })
+    .unwrap_or_default()
+}
+
+/// Promotes the pending presentation hint to current for `surface`.
+///
+/// Must be called from the compositor's surface commit handling, since
+/// `set_presentation_hint` is double-buffered per the protocol.
+pub fn on_commit(surface: &WlSurface) {
+    with_states(surface, |states| {
+        if let Some(state) = states.data_map.get::<TearingSurfaceData>() {
+            let mut state = state.lock().unwrap();
+            state.current = state.pending;
+        }
+    });
+}
+
+#[derive(Debug)]
+pub struct TearingControlManagerState {
+    global: GlobalId,
+}
+
+impl TearingControlManagerState {
+    pub fn new<D>(dh: &DisplayHandle) -> TearingControlManagerState
+    where
+        D: GlobalDispatch<WpTearingControlManagerV1, ()>
+            + Dispatch<WpTearingControlManagerV1, ()>
+            + Dispatch<WpTearingControlV1, TearingControlUserData>
+            + 'static,
+    {
+        let global = dh.create_global::<D, WpTearingControlManagerV1, _>(1, ());
+        TearingControlManagerState { global }
+    }
+
+    #[allow(dead_code)]
+    pub fn global_id(&self) -> GlobalId {
+        self.global.clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct TearingControlUserData {
+    surface: Weak<WlSurface>,
+}
+
+impl<D> GlobalDispatch<WpTearingControlManagerV1, (), D> for TearingControlManagerState
+where
+    D: GlobalDispatch<WpTearingControlManagerV1, ()>
+        + Dispatch<WpTearingControlManagerV1, ()>
+        + Dispatch<WpTearingControlV1, TearingControlUserData>
+        + 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<WpTearingControlManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl<D> Dispatch<WpTearingControlManagerV1, (), D> for TearingControlManagerState
+where
+    D: Dispatch<WpTearingControlManagerV1, ()>
+        + Dispatch<WpTearingControlV1, TearingControlUserData>
+        + 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        manager: &WpTearingControlManagerV1,
+        request: wp_tearing_control_manager_v1::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            wp_tearing_control_manager_v1::Request::GetTearingControl { id, surface } => {
+                let exists = with_states(&surface, |states| {
+                    states
+                        .data_map
+                        .get::<TearingSurfaceData>()
+                        .is_some_and(|state| {
+                            state
+                                .lock()
+                                .unwrap()
+                                .object
+                                .as_ref()
+                                .is_some_and(|obj| obj.upgrade().is_ok())
+                        })
+                });
+
+                if exists {
+                    manager.post_error(
+                        wp_tearing_control_manager_v1::Error::TearingControlExists as u32,
+                        format!(
+                            "{manager:?}: a wp_tearing_control_v1 object already exists for {surface:?}"
+                        ),
+                    );
+                }
+
+                // A `new_id` argument must always be initialized, even when we
+                // raise a protocol error above (the client will be disconnected).
+                let control = data_init.init(
+                    id,
+                    TearingControlUserData {
+                        surface: surface.downgrade(),
+                    },
+                );
+
+                with_states(&surface, |states| {
+                    let state = states
+                        .data_map
+                        .get_or_insert_threadsafe(TearingSurfaceData::default);
+                    state.lock().unwrap().object = Some(control.downgrade());
+                });
+            }
+            wp_tearing_control_manager_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+impl<D> Dispatch<WpTearingControlV1, TearingControlUserData, D> for TearingControlManagerState
+where
+    D: Dispatch<WpTearingControlV1, TearingControlUserData> + 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        _resource: &WpTearingControlV1,
+        request: wp_tearing_control_v1::Request,
+        data: &TearingControlUserData,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        let Ok(surface) = data.surface.upgrade() else {
+            return;
+        };
+
+        match request {
+            wp_tearing_control_v1::Request::SetPresentationHint { hint } => {
+                if let WEnum::Value(hint) = hint {
+                    with_states(&surface, |states| {
+                        if let Some(state) = states.data_map.get::<TearingSurfaceData>() {
+                            state.lock().unwrap().pending = hint.into();
+                        }
+                    });
+                }
+            }
+            wp_tearing_control_v1::Request::Destroy => {
+                // Per spec: destroying the object reverts the presentation hint
+                // to vsync; being double-buffered, this only takes effect on
+                // the next commit.
+                with_states(&surface, |states| {
+                    if let Some(state) = states.data_map.get::<TearingSurfaceData>() {
+                        state.lock().unwrap().pending = PresentationHint::Vsync;
+                    }
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+smithay::reexports::wayland_server::delegate_global_dispatch!(State: [
+    WpTearingControlManagerV1: ()
+] => TearingControlManagerState);
+smithay::reexports::wayland_server::delegate_dispatch!(State: [
+    WpTearingControlManagerV1: ()
+] => TearingControlManagerState);
+smithay::reexports::wayland_server::delegate_dispatch!(State: [
+    WpTearingControlV1: TearingControlUserData
+] => TearingControlManagerState);


### PR DESCRIPTION
## What

Implements `wp_tearing_control_v1` with **composited tearing** — async page flips of the compositor's own composited buffer. Addresses #248.

- Protocol: `wp_tearing_control_manager_v1` (v1) global; per-surface double-buffered presentation hint (promoted on commit, `tearing_control_exists` error on duplicate controls, destroy resets pending to vsync).
- Policy: an output enters tearing mode iff an opt-in toggle is set (`COSMIC_ALLOW_TEARING=1` env for now), the output is not mirroring, and the focused fullscreen toplevel's committed hint is `async`.
- Frame clock: in tearing mode the estimated-vblank throttle is bypassed — composite is driven by client commits (rate-ceiled ~500fps) and submitted with `FrameFlags::ALLOW_ASYNC_PAGE_FLIP`; frame callbacks are sent immediately, so clients run uncapped.
- Cursor plane is disabled in tearing mode (cursor composites instead): kernel atomic async flips may only change the primary plane FB, so this keeps every async commit valid.
- Depends on smithay async-flip support: Smithay/smithay#2099 (Cargo patch currently points at that branch).

## Why composited tearing

On muxless hybrid laptops (game renders on the dGPU, iGPU scans out the internal panel) direct scanout of client buffers is impossible — the classic "tearing only for direct-scanout fullscreen" design delivers nothing on such machines. Async-flipping the composited buffer does: validated end-to-end on an i915-scanout + NVIDIA-render laptop, CS2 (native Wayland, fullscreen) runs 240fps on a 144Hz eDP with visible tearing, where it was previously FIFO-capped at 144. Compositor cost went *down* (composite-per-commit at ~240/s measured cheaper than the previous 144Hz vsync path in CPU time). Zero rejected async flips observed on i915.

## Current limitations (draft status — seeking direction)

- Composited-tearing only; the direct-scanout fullscreen path does not async-flip yet (planned follow-up — needed for single-GPU desktops).
- Single-output policy; no VRR interaction handling yet.
- Toggle is an env var; should become cosmic-config + Settings UI.
- Xwayland (24.1.12) did not forward tearing hints for an X11 Vulkan IMMEDIATE client on the NVIDIA stack during testing — under investigation whether that's driver- or Xwayland-side; native Wayland clients work.
- No `DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP` gating yet (tracked in the smithay PR).

Implementation was developed with AI assistance and human review/testing on real hardware; happy to iterate per maintainer direction and split/reshape as preferred.
