### PR TITLE
render: `cgmath` -> `glam`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,6 @@ dependencies = [
  "anyhow",
  "bitflags 2.11.0",
  "calloop",
- "cgmath",
  "clap_lex",
  "cosmic-comp-config",
  "cosmic-config",
@@ -804,6 +803,7 @@ dependencies = [
  "egui_plot",
  "futures-executor",
  "futures-util",
+ "glam 0.33.2",
  "i18n-embed",
  "i18n-embed-fl",
  "iced_graphics",
@@ -1194,7 +1194,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1508,7 +1508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2002,6 +2002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
 
 [[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,7 +2267,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "dnd",
- "glam",
+ "glam 0.25.0",
  "lilt",
  "log",
  "mime 0.1.0",
@@ -2383,7 +2389,7 @@ dependencies = [
  "bytemuck",
  "cryoglyph",
  "futures",
- "glam",
+ "glam 0.25.0",
  "guillotiere",
  "iced_debug",
  "iced_graphics",
@@ -2689,7 +2695,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2812,7 +2818,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3422,7 +3428,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4518,7 +4524,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4813,7 +4819,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=efeb597#efeb59768eb9a2d8dae9f71300a56aef06b0c1c4"
+source = "git+https://github.com/smithay/smithay.git?rev=812bd33#812bd33259ff58810dadef6086d8385eeac1ca55"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -4822,7 +4828,6 @@ dependencies = [
  "bitflags 2.11.0",
  "calloop",
  "cc",
- "cgmath",
  "cursor-icon",
  "downcast-rs",
  "drm 0.14.1",
@@ -4832,6 +4837,7 @@ dependencies = [
  "errno",
  "gbm",
  "gl_generator",
+ "glam 0.33.2",
  "glow",
  "indexmap 2.13.0",
  "input",
@@ -5107,7 +5113,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6126,7 +6132,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ parking_lot = "0.12.5"
 logind-zbus = { version = "5.3.2", optional = true }
 futures-executor = { version = "0.3.32" }
 futures-util = "0.3.32"
-cgmath = "0.18.0"
+glam = { version = "0.33", default-features = false, features = ["std"] }
 smallvec = "1.15.2"
 
 [dependencies.id_tree]
@@ -144,4 +144,4 @@ lto = "fat"
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "efeb597" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "812bd33" }

--- a/src/backend/render/shadow.rs
+++ b/src/backend/render/shadow.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, cell::RefCell, collections::HashMap};
 
-use cgmath::{Matrix3, Vector2};
+use glam::{Mat3, Vec2};
 use smithay::{
     backend::renderer::{
         element::Kind,
@@ -113,26 +113,22 @@ impl ShadowShader {
             let mut shader_geo = Rectangle::new(Point::from((-width, -width)), shader_size);
 
             let window_geo = Rectangle::new(Point::new(0., 0.) - offset - shader_geo.loc, geo.size);
-            let area_size = Vector2::new(shader_geo.size.w, shader_geo.size.h);
-            let geo_loc = Vector2::new(-shader_geo.loc.x, -shader_geo.loc.y);
+            let area_size = Vec2::new(shader_geo.size.w as f32, shader_geo.size.h as f32);
+            let geo_loc = Vec2::new(-shader_geo.loc.x as f32, -shader_geo.loc.y as f32);
             shader_geo.loc += offset + geo.loc;
 
-            let input_to_geo = (Matrix3::from_nonuniform_scale(area_size.x, area_size.y)
-                * Matrix3::from_translation(Vector2::new(
+            let input_to_geo = Mat3::from_scale(area_size)
+                * Mat3::from_translation(Vec2::new(
                     -geo_loc.x / area_size.x,
                     -geo_loc.y / area_size.y,
-                )))
-            .cast::<f32>()
-            .unwrap();
+                ));
 
-            let window_geo_loc = Vector2::new(window_geo.loc.x, window_geo.loc.y);
-            let window_input_to_geo = (Matrix3::from_nonuniform_scale(area_size.x, area_size.y)
-                * Matrix3::from_translation(Vector2::new(
+            let window_geo_loc = Vec2::new(window_geo.loc.x as f32, window_geo.loc.y as f32);
+            let window_input_to_geo = Mat3::from_scale(area_size)
+                * Mat3::from_translation(Vec2::new(
                     -window_geo_loc.x / area_size.x,
                     -window_geo_loc.y / area_size.y,
-                )))
-            .cast::<f32>()
-            .unwrap();
+                ));
 
             let element = PixelShaderElement::new(
                 shader,

--- a/src/backend/render/wayland/blur_effect.rs
+++ b/src/backend/render/wayland/blur_effect.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
-use cgmath::{Matrix3, SquareMatrix, Vector2};
+use glam::{Mat3, Vec2};
 use smithay::{
     backend::{
         allocator::Fourcc,
@@ -231,13 +231,11 @@ impl BlurElement {
         // compute input_to_geo so that it crops the extended capture radius
         let geo_scale = {
             let Scale { x, y } = geo.size / extended_geo.size;
-            Matrix3::from_nonuniform_scale(x as f32, y as f32)
-                .invert()
-                .unwrap()
+            Mat3::from_scale(Vec2::new(x as f32, y as f32)).inverse()
         };
         let geo_translation = {
             let offset = geo.loc - extended_geo.loc;
-            Matrix3::from_translation(-Vector2::new(
+            Mat3::from_translation(-Vec2::new(
                 (offset.x / extended_geo.size.w) as f32,
                 (offset.y / extended_geo.size.h) as f32,
             ))

--- a/src/backend/render/wayland/clipped_surface.rs
+++ b/src/backend/render/wayland/clipped_surface.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::{Borrow, BorrowMut};
 
-use cgmath::{Matrix3, Vector2};
+use glam::{Mat3, Vec2};
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 use smithay::{
     backend::renderer::{
@@ -63,18 +63,18 @@ where
         let view = elem.view();
 
         let transform = elem.transform();
-        let transform_matrix = Matrix3::<f32>::from_translation(Vector2::new(0.5, 0.5))
+        let transform_matrix = Mat3::from_translation(Vec2::new(0.5, 0.5))
             * transform.matrix()
-            * Matrix3::<f32>::from_translation(-Vector2::new(0.5, 0.5));
+            * Mat3::from_translation(-Vec2::new(0.5, 0.5));
 
         let geo_scale = {
             let Scale { x, y } = elem_geo.size.to_f64() / geo.size.to_f64();
-            Matrix3::from_nonuniform_scale(x as f32, y as f32)
+            Mat3::from_scale(Vec2::new(x as f32, y as f32))
         };
 
         let geo_translation = {
             let offset = (elem_geo.loc - geo.loc).to_f64();
-            Matrix3::from_translation(Vector2::new(
+            Mat3::from_translation(Vec2::new(
                 (offset.x / elem_geo.size.w as f64) as f32,
                 (offset.y / elem_geo.size.h as f64) as f32,
             ))
@@ -82,10 +82,10 @@ where
 
         let buf_scale = {
             let Scale { x, y } = buf_size.to_f64() / view.src.size.to_f64();
-            Matrix3::from_nonuniform_scale(x as f32, y as f32)
+            Mat3::from_scale(Vec2::new(x as f32, y as f32))
         };
 
-        let buf_translation = Matrix3::from_translation(Vector2::new(
+        let buf_translation = Mat3::from_translation(Vec2::new(
             (view.src.loc.x / buf_size.w as f64) as f32,
             (view.src.loc.y / buf_size.h as f64) as f32,
         ));

--- a/src/wayland/handlers/corner_radius.rs
+++ b/src/wayland/handlers/corner_radius.rs
@@ -3,7 +3,7 @@ use smithay::wayland::compositor::SurfaceData;
 
 use crate::wayland::protocols::corner_radius::{
     CacheableCorners, CacheablePadding, CornerRadiusData, CornerRadiusHandler, CornerRadiusState,
-    CornerRadiusSurface, delegate_corner_radius,
+    delegate_corner_radius,
 };
 
 use crate::state::State;


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Updates smithay to include https://github.com/Smithay/smithay/pull/2095.
Edit: Hmm, maybe glam doesn't need the `float-types` feature, since that's only for f64 (DVec, DMat,...)? Smithay might not need it either. Or should maybe f64 types be used as long as possible and then cast into their f32 counterparts (with e.g. `as_mat3()`)? Or maybe using affine types where possible (e.g. Affine2 is recommended over Mat3 for 2D affine transformations)?

Should I fix clippy in a separate commit (it's a one line change)?