### PR TITLE
fix(input): stop cursor sticking to screen edge during cross monitor movement

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -375,21 +375,24 @@ impl State {
                     let original_position = position;
                     position += event.delta().as_global();
                     let shell = self.common.shell.read();
-                    let output = shell
+                    let matching_output = shell
                         .outputs()
                         .find(|output| output.geometry().to_f64().contains(position))
-                        .cloned()
-                        .unwrap_or(current_output.clone());
+                        .cloned();
                     drop(shell);
+                    let needs_clamping = matching_output.is_none();
+                    let output = matching_output.unwrap_or_else(|| current_output.clone());
                     let output_geometry = output.geometry();
-                    position.x = position.x.clamp(
-                        output_geometry.loc.x as f64,
-                        (output_geometry.loc.x + output_geometry.size.w - 1) as f64,
-                    );
-                    position.y = position.y.clamp(
-                        output_geometry.loc.y as f64,
-                        (output_geometry.loc.y + output_geometry.size.h - 1) as f64,
-                    );
+                    if needs_clamping {
+                        position.x = position.x.clamp(
+                            output_geometry.loc.x as f64,
+                            (output_geometry.loc.x + output_geometry.size.w - 1) as f64,
+                        );
+                        position.y = position.y.clamp(
+                            output_geometry.loc.y as f64,
+                            (output_geometry.loc.y + output_geometry.size.h - 1) as f64,
+                        );
+                    }
 
                     if ptr.is_grabbed() {
                         if seat


### PR DESCRIPTION
This PR fixes an issue where the cursor gets stuck on the edge of a display when moving across monitors. This occurs when the mouse is moved slowly from a monitor on the left to a monitor on the right, causing the cursor to get stuck on the edge of the left monitor. The same occurs from top to bottom.

The bug is caused when the coordinates (`f64`) land on the last pixel of a display (e.g. `1919.5`). Since the coordinate is still on Screen A and not yet crossing over to Screen B, it gets clamped back to `1919.0`. The cursor gets stuck in this zone between `size - 1.0` and `size` until a large enough movement occurs to break it out.

This PR fixes this by only clamping the cursor coordinates when the cursor is fully off-screen. If `matching_output` is not `None`, we skip the clamping since the cursor is still in bounds of our monitors. If it is `None`, we clamp it to the edge of the screen.

Fixes #2102 #2407


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.