### PR TITLE
Fix: Make cursor position more consistant

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -310,7 +310,7 @@ impl State {
                 for seat in self.common.shell.read().seats.iter() {
                     let devices = seat.user_data().get::<Devices>().unwrap();
                     if devices.has_device(&WinitVirtualDevice) {
-                        seat.set_active_output(&self.backend.winit().output);
+                        seat.set_active_output(&self.backend.winit().output, false);
                         break;
                     }
                 }

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -534,7 +534,7 @@ impl State {
             for seat in self.common.shell.read().seats.iter() {
                 let devices = seat.user_data().get::<Devices>().unwrap();
                 if devices.has_device(&device) {
-                    seat.set_active_output(&output);
+                    seat.set_active_output(&output, false);
                     break;
                 }
             }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -550,7 +550,7 @@ impl State {
                             WorkspaceDelta::new_shortcut(),
                             &mut workspace_guard,
                         );
-                        seat.set_active_output(&next_output);
+                        seat.set_active_output(&next_output, false);
                         res
                     };
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -636,7 +636,7 @@ impl State {
                         for session in cursor_sessions_for_output(&shell, &current_output) {
                             session.set_cursor_pos(None);
                         }
-                        seat.set_active_output(&output);
+                        seat.set_active_output(&output, false);
                     }
 
                     for session in cursor_sessions_for_output(&shell, &output) {

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -491,7 +491,7 @@ impl Common {
                 }
                 if !shell.outputs().any(|o| o == &active_output) {
                     if let Some(other) = shell.outputs().next() {
-                        seat.set_active_output(other);
+                        seat.set_active_output(other, true);
                     }
                     continue;
                 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -944,7 +944,7 @@ impl Workspaces {
             if let Some(new_output) = new_output {
                 for seat in seats {
                     if &seat.active_output() == output {
-                        seat.set_active_output(&new_output);
+                        seat.set_active_output(&new_output, true);
                     }
                     if seat.focused_output().as_ref() == Some(output) {
                         seat.set_focused_output(None);
@@ -3144,7 +3144,7 @@ impl Shell {
                 node, focus_stack, ..
             })) => {
                 let new_pos = if follow {
-                    seat.set_active_output(to_output);
+                    seat.set_active_output(to_output, false);
                     self.workspaces
                         .idx_for_handle(to_output, &to)
                         .and_then(|to_idx| {
@@ -3362,7 +3362,7 @@ impl Shell {
 
         let new_pos = if follow {
             if let Some(seat) = seat {
-                seat.set_active_output(&to_output);
+                seat.set_active_output(&to_output, false);
             }
             self.workspaces
                 .idx_for_handle(&to_output, to)
@@ -3473,7 +3473,7 @@ impl Shell {
         }
         let new_pos = if follow {
             if let Some(seat) = seat {
-                seat.set_active_output(&to_output);
+                seat.set_active_output(&to_output, false);
             }
             self.workspaces
                 .idx_for_handle(&to_output, to)

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -241,15 +241,21 @@ pub fn create_seat(
     let pointer = seat.add_pointer();
 
     // If possible, set the cursor's position to the center of the screen upon initialization
-    if let Some(mode) = output.current_mode() {
-        let scale = output.current_scale().fractional_scale();
-        let logical_size = mode.size.to_f64().to_logical(scale);
-        pointer.set_location(Point::new(logical_size.w / 2.0, logical_size.h / 2.0));
+    if let Some(position) = get_logical_center_of_output(output) {
+        pointer.set_location(position);
     }
 
     seat.add_touch();
 
     seat
+}
+
+fn get_logical_center_of_output(output: &Output) -> Option<Point<f64, Logical>> {
+    output.current_mode().map(|mode| {
+        let scale = output.current_scale().fractional_scale();
+        let logical_size = mode.size.to_f64().to_logical(scale);
+        Point::new(logical_size.w / 2.0, logical_size.h / 2.0)
+    })
 }
 
 pub trait SeatExt {
@@ -261,7 +267,7 @@ pub trait SeatExt {
         self.focused_output()
             .unwrap_or_else(|| self.active_output())
     }
-    fn set_active_output(&self, output: &Output);
+    fn set_active_output(&self, output: &Output, move_cursor_to_center: bool);
     fn set_focused_output(&self, output: Option<&Output>);
     fn devices(&self) -> &Devices;
     fn supressed_keys(&self) -> &SupressedKeys;
@@ -309,7 +315,7 @@ impl SeatExt for Seat<State> {
         }
     }
 
-    fn set_active_output(&self, output: &Output) {
+    fn set_active_output(&self, output: &Output, move_cursor_to_center: bool) {
         *self
             .user_data()
             .get::<ActiveOutput>()
@@ -317,6 +323,15 @@ impl SeatExt for Seat<State> {
             .0
             .lock()
             .unwrap() = output.clone();
+
+        if move_cursor_to_center {
+            // Update the position of the cursor to the center
+            if let (Some(pointer), Some(position)) =
+                (self.get_pointer(), get_logical_center_of_output(output))
+            {
+                pointer.set_location(position);
+            }
+        }
     }
 
     fn set_focused_output(&self, output: Option<&Output>) {

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -252,9 +252,13 @@ pub fn create_seat(
 
 fn get_logical_center_of_output(output: &Output) -> Option<Point<f64, Logical>> {
     output.current_mode().map(|mode| {
+        let output_position = output.current_location();
         let scale = output.current_scale().fractional_scale();
         let logical_size = mode.size.to_f64().to_logical(scale);
-        Point::new(logical_size.w / 2.0, logical_size.h / 2.0)
+        Point::new(
+            output_position.x as f64 + logical_size.w / 2.0,
+            output_position.y as f64 + logical_size.h / 2.0,
+        )
     })
 }
 
@@ -276,6 +280,12 @@ pub trait SeatExt {
     fn last_modifier_change(&self) -> Option<Serial>;
     fn pointer_constraint_hint(&self) -> Option<(WlSurface, Point<f64, Logical>)>;
     fn set_pointer_constraint_hint(&self, hint: Option<(WlSurface, Point<f64, Logical>)>);
+
+    fn get_pointer_position_relative_to_active_output(&self) -> Option<Point<f64, Logical>>;
+    fn set_pointer_position_relative_to_active_output(
+        &self,
+        relative_position: Point<f64, Logical>,
+    );
 
     fn cursor_geometry(
         &self,
@@ -385,6 +395,32 @@ impl SeatExt for Seat<State> {
     fn set_pointer_constraint_hint(&self, hint: Option<(WlSurface, Point<f64, Logical>)>) {
         let lock = self.user_data().get::<PointerConstraintHint>().unwrap();
         *lock.0.lock().unwrap() = hint;
+    }
+
+    fn get_pointer_position_relative_to_active_output(&self) -> Option<Point<f64, Logical>> {
+        let output = self.active_output();
+
+        let pointer_position = self.get_pointer()?.current_location();
+        let output_position = output.current_location();
+
+        Some(Point::new(
+            pointer_position.x - output_position.x as f64,
+            pointer_position.y - output_position.y as f64,
+        ))
+    }
+    fn set_pointer_position_relative_to_active_output(
+        &self,
+        relative_position: Point<f64, Logical>,
+    ) {
+        let output = self.active_output();
+        let output_position = output.current_location();
+
+        if let Some(pointer) = self.get_pointer() {
+            pointer.set_location(Point::new(
+                relative_position.x + output_position.x as f64,
+                relative_position.y + output_position.y as f64,
+            ));
+        }
     }
 
     fn cursor_geometry(

--- a/src/shell/seats.rs
+++ b/src/shell/seats.rs
@@ -237,7 +237,16 @@ pub fn create_seat(
         )
     })
     .expect("Failed to load xkb configuration files");
-    seat.add_pointer();
+
+    let pointer = seat.add_pointer();
+
+    // If possible, set the cursor's position to the center of the screen upon initialization
+    if let Some(mode) = output.current_mode() {
+        let scale = output.current_scale().fractional_scale();
+        let logical_size = mode.size.to_f64().to_logical(scale);
+        pointer.set_location(Point::new(logical_size.w / 2.0, logical_size.h / 2.0));
+    }
+
     seat.add_touch();
 
     seat

--- a/src/state.rs
+++ b/src/state.rs
@@ -541,6 +541,13 @@ impl LockedBackend<'_> {
             output.set_adaptive_sync(final_config.0.vrr);
         }
 
+        // Restore cursor position relative to active output
+        for (seat, saved_output, rel_pos) in &saved_cursor_positions {
+            if &seat.active_output() == saved_output {
+                seat.set_pointer_position_relative_to_active_output(*rel_pos);
+            }
+        }
+
         match self {
             LockedBackend::Kms(state) => state.apply_config_for_outputs(
                 test_only,
@@ -585,13 +592,6 @@ impl LockedBackend<'_> {
             }
 
             layer_map_for_output(output).arrange();
-        }
-
-        // Restore cursor position relative to active output
-        for (seat, saved_output, rel_pos) in &saved_cursor_positions {
-            if &seat.active_output() == saved_output {
-                seat.set_pointer_position_relative_to_active_output(*rel_pos);
-            }
         }
 
         // Update layout for changes in resolution, scale, orientation

--- a/src/state.rs
+++ b/src/state.rs
@@ -498,6 +498,20 @@ impl LockedBackend<'_> {
     ) -> Result<(), anyhow::Error> {
         let all_outputs = self.all_outputs();
 
+        // Save the positions of the cursor relative to the output
+        let saved_cursor_positions = {
+            let guard = shell.read();
+            guard
+                .seats
+                .iter()
+                .filter_map(|seat| {
+                    let rel_pos = seat.get_pointer_position_relative_to_active_output()?;
+                    let active_output = seat.active_output();
+                    Some((seat.clone(), active_output, rel_pos))
+                })
+                .collect::<Vec<_>>()
+        };
+
         // update outputs, so that `OutputModeSource`s are correct
         for output in &all_outputs {
             // apply to Output
@@ -571,6 +585,13 @@ impl LockedBackend<'_> {
             }
 
             layer_map_for_output(output).arrange();
+        }
+
+        // Restore cursor position relative to active output
+        for (seat, saved_output, rel_pos) in &saved_cursor_positions {
+            if &seat.active_output() == saved_output {
+                seat.set_pointer_position_relative_to_active_output(*rel_pos);
+            }
         }
 
         // Update layout for changes in resolution, scale, orientation

--- a/src/wayland/handlers/toplevel_management.rs
+++ b/src/wayland/handlers/toplevel_management.rs
@@ -115,7 +115,7 @@ impl ToplevelManagementHandler for State {
                 && self.common.config.cosmic_conf.cursor_follows_focus
                 && let Some(new_pos) = new_pos
             {
-                seat.set_active_output(output);
+                seat.set_active_output(output, false);
                 if let Some(ptr) = seat.get_pointer() {
                     let serial = SERIAL_COUNTER.next_serial();
                     ptr.motion(


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

What this does:
- Cursor is now initialized in the center of the output when a seat is created (A small pet peeve of mine with Cosmic)
- When a output is removed, and the cursor is inside of it, it is set to the center of the 0th index output (see the comment at [src/shell/mod.rs:940](https://github.com/pop-os/cosmic-comp/blob/2d95d46a3705db19eb84cdd471b1daf701c4f975/src/shell/mod.rs#L940))
- Keeps track of the relative position of the cursor to the output when monitors are connected or removed, the cursor isn't teleported about the screen because the geometry changed

I was only able to test this on Wayland, with one external monitor, some more testing would definitely be appreciated!