### PR TITLE
Disable blur for cursor elements

### DIFF
--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -185,7 +185,6 @@ pub fn draw_surface_cursor<R>(
     surface: &wl_surface::WlSurface,
     location: Point<f64, Logical>,
     scale: impl Into<Scale<f64>>,
-    blur_strength: usize,
     push: &mut dyn FnMut(CursorRenderElement<R>, Point<i32, Physical>),
 ) where
     R: Renderer + ImportAll + AsGlowRenderer,
@@ -213,7 +212,7 @@ pub fn draw_surface_cursor<R>(
         false,
         [0; 4],
         None,
-        blur_strength,
+        0,
         Kind::Cursor,
         &mut |elem| push(elem.into(), h),
         None,
@@ -226,7 +225,6 @@ pub fn draw_dnd_icon<R>(
     surface: &wl_surface::WlSurface,
     location: Point<f64, Logical>,
     scale: impl Into<Scale<f64>>,
-    blur_strength: usize,
     push: &mut dyn FnMut(SurfaceRenderElement<R>),
 ) where
     R: Renderer + ImportAll + AsGlowRenderer,
@@ -249,7 +247,7 @@ pub fn draw_dnd_icon<R>(
         false,
         [0; 4],
         None,
-        blur_strength,
+        0,
         FRAME_TIME_FILTER,
         push,
         None,
@@ -336,7 +334,6 @@ pub fn draw_cursor<R>(
     scale: Scale<f64>,
     buffer_scale: f64,
     time: Time<Monotonic>,
-    blur_strength: usize,
     draw_default: bool,
     push: &mut dyn FnMut(CursorRenderElement<R>, Point<i32, Physical>),
 ) where
@@ -413,7 +410,7 @@ pub fn draw_cursor<R>(
             hotspot.to_physical_precise_round(scale),
         );
     } else if let CursorImageStatus::Surface(ref wl_surface) = cursor_status {
-        draw_surface_cursor(renderer, wl_surface, location, scale, blur_strength, push);
+        draw_surface_cursor(renderer, wl_surface, location, scale, push);
     }
 }
 

--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -479,7 +479,6 @@ pub fn cursor_elements<'a, 'frame, R>(
     seats: impl Iterator<Item = &'a Seat<State>>,
     zoom_state: Option<&ZoomState>,
     theme: &Theme,
-    blur_strength: usize,
     now: Time<Monotonic>,
     output: &Output,
     mode: CursorMode,
@@ -516,7 +515,6 @@ pub fn cursor_elements<'a, 'frame, R>(
                 scale.into(),
                 zoom_scale,
                 now,
-                blur_strength,
                 mode != CursorMode::NotDefault,
                 &mut |elem, hotspot| {
                     push(CosmicElement::Cursor(RescaleRenderElement::from_element(
@@ -541,7 +539,6 @@ pub fn cursor_elements<'a, 'frame, R>(
                 &dnd_icon.surface,
                 (location + dnd_icon.offset.to_f64()).to_i32_round(),
                 scale,
-                blur_strength,
                 &mut |elem| push(CosmicElement::Dnd(elem)),
             );
         }
@@ -738,7 +735,6 @@ where
         seats.iter(),
         zoom_level,
         &theme,
-        blur_strength,
         now,
         output,
         cursor_mode,

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -599,7 +599,6 @@ pub fn render_window_to_buffer(
                     1.0.into(),
                     1.0,
                     common.clock.now(),
-                    blur_strength,
                     true,
                     &mut |elem, hotspot| {
                         elements.push(WindowCaptureElement::CursorElement(
@@ -621,7 +620,6 @@ pub fn render_window_to_buffer(
                     &dnd_icon.surface,
                     (location + dnd_icon.offset.to_f64()).to_i32_round(),
                     1.0,
-                    blur_strength,
                     &mut |elem| {
                         elements.push(
                             RelocateRenderElement::from_element(
@@ -821,7 +819,6 @@ pub fn render_cursor_to_buffer(
             1.0.into(),
             1.0,
             common.clock.now(),
-            0,
             true,
             &mut |elem, _| {
                 elements.push(


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Blur strength was set to non-zero values for cursor elements in most places, and I can't think of a reason why they would need blur, so I removed it.
I can't notice any performance difference or anything, so maybe it was already handled somewhere, but less function arguments is also nice. :)