### PR TITLE
[Render] Use `Affine2` where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=812bd33#812bd33259ff58810dadef6086d8385eeac1ca55"
+source = "git+https://github.com/smithay/smithay.git?rev=1ed69cb#1ed69cb55e9d0e9f38887c3b7d53d24365c4b14f"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,4 @@ lto = "fat"
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "812bd33" }
+smithay = { git = "https://github.com/smithay/smithay.git", rev = "1ed69cb" }

--- a/src/backend/render/shadow.rs
+++ b/src/backend/render/shadow.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, cell::RefCell, collections::HashMap};
 
-use glam::{Mat3, Vec2};
+use glam::{Affine2, Mat3, Vec2};
 use smithay::{
     backend::renderer::{
         element::Kind,
@@ -117,18 +117,22 @@ impl ShadowShader {
             let geo_loc = Vec2::new(-shader_geo.loc.x as f32, -shader_geo.loc.y as f32);
             shader_geo.loc += offset + geo.loc;
 
-            let input_to_geo = Mat3::from_scale(area_size)
-                * Mat3::from_translation(Vec2::new(
-                    -geo_loc.x / area_size.x,
-                    -geo_loc.y / area_size.y,
-                ));
+            let input_to_geo = Mat3::from(
+                Affine2::from_scale(area_size)
+                    * Affine2::from_translation(Vec2::new(
+                        -geo_loc.x / area_size.x,
+                        -geo_loc.y / area_size.y,
+                    )),
+            );
 
             let window_geo_loc = Vec2::new(window_geo.loc.x as f32, window_geo.loc.y as f32);
-            let window_input_to_geo = Mat3::from_scale(area_size)
-                * Mat3::from_translation(Vec2::new(
-                    -window_geo_loc.x / area_size.x,
-                    -window_geo_loc.y / area_size.y,
-                ));
+            let window_input_to_geo = Mat3::from(
+                Affine2::from_scale(area_size)
+                    * Affine2::from_translation(Vec2::new(
+                        -window_geo_loc.x / area_size.x,
+                        -window_geo_loc.y / area_size.y,
+                    )),
+            );
 
             let element = PixelShaderElement::new(
                 shader,

--- a/src/backend/render/wayland/blur_effect.rs
+++ b/src/backend/render/wayland/blur_effect.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
-use glam::{Mat3, Vec2};
+use glam::{Affine2, Mat3, Vec2};
 use smithay::{
     backend::{
         allocator::Fourcc,
@@ -231,16 +231,16 @@ impl BlurElement {
         // compute input_to_geo so that it crops the extended capture radius
         let geo_scale = {
             let Scale { x, y } = geo.size / extended_geo.size;
-            Mat3::from_scale(Vec2::new(x as f32, y as f32)).inverse()
+            Affine2::from_scale(Vec2::new(x as f32, y as f32)).inverse()
         };
         let geo_translation = {
             let offset = geo.loc - extended_geo.loc;
-            Mat3::from_translation(-Vec2::new(
+            Affine2::from_translation(-Vec2::new(
                 (offset.x / extended_geo.size.w) as f32,
                 (offset.y / extended_geo.size.h) as f32,
             ))
         };
-        let input_to_geo = geo_scale * geo_translation;
+        let input_to_geo = Mat3::from(geo_scale * geo_translation);
 
         let uniforms = vec![
             Uniform::new("geo_size", (geometry.size.w as f32, geometry.size.h as f32)),

--- a/src/backend/render/wayland/clipped_surface.rs
+++ b/src/backend/render/wayland/clipped_surface.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::{Borrow, BorrowMut};
 
-use glam::{Mat3, Vec2};
+use glam::{Affine2, Mat3, Vec2};
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 use smithay::{
     backend::renderer::{
@@ -63,18 +63,18 @@ where
         let view = elem.view();
 
         let transform = elem.transform();
-        let transform_matrix = Mat3::from_translation(Vec2::new(0.5, 0.5))
+        let transform_matrix = Affine2::from_translation(Vec2::new(0.5, 0.5))
             * transform.matrix()
-            * Mat3::from_translation(-Vec2::new(0.5, 0.5));
+            * Affine2::from_translation(-Vec2::new(0.5, 0.5));
 
         let geo_scale = {
             let Scale { x, y } = elem_geo.size.to_f64() / geo.size.to_f64();
-            Mat3::from_scale(Vec2::new(x as f32, y as f32))
+            Affine2::from_scale(Vec2::new(x as f32, y as f32))
         };
 
         let geo_translation = {
             let offset = (elem_geo.loc - geo.loc).to_f64();
-            Mat3::from_translation(Vec2::new(
+            Affine2::from_translation(Vec2::new(
                 (offset.x / elem_geo.size.w as f64) as f32,
                 (offset.y / elem_geo.size.h as f64) as f32,
             ))
@@ -82,16 +82,17 @@ where
 
         let buf_scale = {
             let Scale { x, y } = buf_size.to_f64() / view.src.size.to_f64();
-            Mat3::from_scale(Vec2::new(x as f32, y as f32))
+            Affine2::from_scale(Vec2::new(x as f32, y as f32))
         };
 
-        let buf_translation = Mat3::from_translation(Vec2::new(
+        let buf_translation = Affine2::from_translation(Vec2::new(
             (view.src.loc.x / buf_size.w as f64) as f32,
             (view.src.loc.y / buf_size.h as f64) as f32,
         ));
 
-        let input_to_geo =
-            transform_matrix * geo_scale * geo_translation * buf_scale * buf_translation;
+        let input_to_geo = Mat3::from(
+            transform_matrix * geo_scale * geo_translation * buf_scale * buf_translation,
+        );
 
         let uniforms = vec![
             Uniform::new("geo_size", (geometry.size.w as f32, geometry.size.h as f32)),


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Followup to https://github.com/Smithay/smithay/pull/2100, just uses Affine2 for matrix multiplication parts, before converting it to Mat3 for OpenGL.