### PR TITLE
fix: ensure X window focus on unmap/map

### DIFF
--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -212,6 +212,29 @@ impl Shell {
         state.common.shell.write().update_active();
     }
 
+    // We suppress Element(X) to Fullscreen(X) transition to avoid
+    // loss of focus by the X window when having a transition to fullscreen
+    // but in the case of X11 unmap/map the leave/enter needs to happen for the X11
+    // internal state to be focused on the window
+    pub fn set_focus_on_x11_map(
+        state: &mut State,
+        target: &KeyboardFocusTarget,
+        seat: &Seat<State>,
+        update_cursor: bool,
+    ) {
+        let need_reset = seat
+            .get_keyboard()
+            .and_then(|keyboard| keyboard.current_focus())
+            .and_then(|current| current.x11_surface())
+            .is_some_and(|current| Some(current) == target.x11_surface());
+
+        if need_reset {
+            update_focus_state(seat, None, state, None, false);
+        }
+
+        Shell::set_focus(state, Some(target), seat, None, update_cursor);
+    }
+
     pub fn append_focus_stack(&mut self, target: impl Into<FocusTarget>, seat: &Seat<State>) {
         let target = target.into();
         if target.is_minimized() {

--- a/src/shell/focus/target.rs
+++ b/src/shell/focus/target.rs
@@ -326,7 +326,7 @@ impl KeyboardFocusTarget {
         }
     }
 
-    fn x11_surface(&self) -> Option<X11Surface> {
+    pub fn x11_surface(&self) -> Option<X11Surface> {
         match self {
             KeyboardFocusTarget::Element(mapped) => mapped.active_window().x11_surface().cloned(),
             KeyboardFocusTarget::Fullscreen(surface) => surface.x11_surface().cloned(),

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -858,7 +858,7 @@ impl XwmHandler for State {
             if let Some(target) = res {
                 let seat = shell.seats.last_active().clone();
                 std::mem::drop(shell);
-                Shell::set_focus(self, Some(&target), &seat, None, false);
+                Shell::set_focus_on_x11_map(self, &target, &seat, false);
             }
         }
     }


### PR DESCRIPTION
This fixes some games where you have to alt-tab out and back in to get input focus.

There is an issue caused by basically two things:
- a race on whether refresh_focus runs between unmap/map
- the fact that we suppress(rightfully so) Element(W) to Fullscreen(W) focus changes

On unmap, the X server input is lost by the window, in cosmic-comp it removes it from the focus_stack.

Now 2 things can happen:
1) refresh_focus runs after the unmap but before the map, it finds that keyboard.current_focus() refers to something not in the focus_stack, it corrects the focus(ie another window gets it), then when the window maps, KeyboardTarget::enter is called => conn.set_input_focus corrects the X server internal focus. The game correctly has input.
2) refresh_focus doesn't run between the unmap and the map, Fullscreen(W) is put in the stack, when it maps and update focus, all it sees is a transition between Element(W) and Fullscreen(W) which is suppressed in KeyboardTarget::replace. From cosmic-comp's perspective the game has focus, from the X server's pov it lost focus when unmapping and never regained it.

So to fix it we force a transition(only in the case of map and if the mapped window had focus in the first place) by transitioning focus to None then back to the window.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

