### PR TITLE
backend/kms: fix primary GPU selection on hybrid laptops where the dGPU enumerates first

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -227,42 +227,114 @@ fn determine_boot_gpu(seat: String) -> Option<DrmNode> {
     primary_node.and_then(|x| x.node_with_type(NodeType::Render).and_then(Result::ok))
 }
 
+/// Returns true, if the device exposes any internal panel connector
+/// (eDP/LVDS/DSI).
+///
+/// We deliberately scan all connectors reported by the device instead of only
+/// active surfaces: an internal panel might not have a surface (yet) - e.g.
+/// the lid is closed at boot, the internal output is disabled in the output
+/// configuration, or no CRTC could be assigned - but its presence still
+/// identifies this device as the GPU wired to the internal panel.
+fn has_builtin_display(dev: &Device) -> bool {
+    let drm_device = dev.drm.device();
+    drm_device
+        .resource_handles()
+        .ok()
+        .into_iter()
+        .flat_map(|res| res.connectors().to_vec())
+        .any(|conn| {
+            drm_device
+                .get_connector(conn, false)
+                .ok()
+                .is_some_and(|conn_info| {
+                    matches!(
+                        conn_info.interface(),
+                        Interface::EmbeddedDisplayPort | Interface::LVDS | Interface::DSI
+                    )
+                })
+        })
+}
+
 fn determine_primary_gpu(
     drm_devices: &IndexMap<DrmNode, Device>,
     seat: String,
 ) -> Result<Option<DrmNode>> {
-    if let Some(device) = dev_var("COSMIC_RENDER_DEVICE")
-        && let Some(node) = drm_devices.values().find_map(|dev| {
+    // Support full device paths (e.g. `/dev/dri/renderD128`) in
+    // COSMIC_RENDER_DEVICE. `dev_var` resolves bare node names relative to
+    // `/dev/dri/` internally, so absolute paths would silently fail to match.
+    if let Ok(value) = std::env::var("COSMIC_RENDER_DEVICE") {
+        if value.starts_with('/') {
+            match DrmNode::from_path(&value) {
+                Ok(node) => {
+                    let node = node
+                        .node_with_type(NodeType::Render)
+                        .and_then(Result::ok)
+                        .unwrap_or(node);
+                    if let Some(found) = drm_devices.values().find_map(|dev| {
+                        (dev.inner.render_node == node).then_some(dev.inner.render_node)
+                    }) {
+                        debug!("Selecting {} as primary gpu: COSMIC_RENDER_DEVICE", found);
+                        return Ok(Some(found));
+                    } else {
+                        warn!(
+                            "COSMIC_RENDER_DEVICE={} does not match any usable render device, \
+                             falling back to automatic selection",
+                            value
+                        );
+                    }
+                }
+                Err(err) => warn!(
+                    ?err,
+                    "COSMIC_RENDER_DEVICE={} is not a valid DRM device path, \
+                     falling back to automatic selection",
+                    value
+                ),
+            }
+        }
+    }
+
+    if let Some(device) = dev_var("COSMIC_RENDER_DEVICE") {
+        if let Some(node) = drm_devices.values().find_map(|dev| {
             device
                 .matches(&dev.inner.render_node)
                 .then_some(dev.inner.render_node)
-        })
-    {
-        return Ok(Some(node));
+        }) {
+            debug!("Selecting {} as primary gpu: COSMIC_RENDER_DEVICE", node);
+            return Ok(Some(node));
+        } else {
+            warn!(
+                "COSMIC_RENDER_DEVICE is set, but does not match any usable render device, \
+                 falling back to automatic selection"
+            );
+        }
     }
 
-    // try to find builtin display
-    for dev in drm_devices.values() {
-        if dev.inner.surfaces.values().any(|s| {
-            if let Ok(conn_info) = dev.drm.device().get_connector(s.connector, false) {
-                let i = conn_info.interface();
-                i == Interface::EmbeddedDisplayPort || i == Interface::LVDS || i == Interface::DSI
-            } else {
-                false
-            }
-        }) {
-            return Ok(Some(dev.inner.render_node));
-        }
+    // try to find a device with a builtin display (eDP/LVDS/DSI).
+    //
+    // This mirrors the behaviour mutter and kwin adopted for hybrid laptops,
+    // where the dGPU may enumerate before the iGPU on the PCI bus and/or be
+    // flagged as boot_vga (e.g. ASUS laptops with NVIDIA dGPU + AMD iGPU).
+    if let Some(dev) = drm_devices
+        .values()
+        .find(|dev| !dev.inner.is_software && has_builtin_display(dev))
+    {
+        debug!(
+            "Selecting {} as primary gpu: device has builtin display",
+            dev.inner.render_node
+        );
+        return Ok(Some(dev.inner.render_node));
     }
 
     // else try to find the boot gpu
     let boot = determine_boot_gpu(seat);
-    if let Some(boot) = boot
-        && drm_devices
+    if let Some(boot) = boot {
+        if drm_devices
             .values()
             .any(|dev| dev.inner.render_node == boot)
-    {
-        return Ok(Some(boot));
+        {
+            debug!("Selecting {} as primary gpu: boot gpu", boot);
+            return Ok(Some(boot));
+        }
     }
 
     // else just take the first


### PR DESCRIPTION
**NOTE THIS IS GENERATED BY FABLE/AI**

Im raising this as a draft only to hopefully help shed some light on the issue that is plaguing me on my ProArt P16 POP24 - I Understand the AI stance, and im not a rust dev, nor know much about compositors. However, im hoping that this may help someone?

See:
https://github.com/pop-os/cosmic-comp/issues/2149

## Problem

On hybrid laptops where the discrete GPU sits at a lower PCI address than the
integrated GPU and/or is flagged as `boot_vga` (e.g. ASUS GA605W / ProArt P16:
NVIDIA RTX 4070 Max-Q at `65:00.0`, AMD Radeon 880M/890M behind it — see #913
and https://gitlab.freedesktop.org/drm/amd/-/issues/3673), cosmic-comp can
select the NVIDIA dGPU as the primary render device. This prevents the dGPU
from ever entering runtime suspend (pop-os/cosmic-epoch#2994) and forces the
multi-GPU copy path for the whole session.

`determine_primary_gpu()` already prefers a device with a builtin display, but
the check iterates `dev.inner.surfaces` — only connectors that already have an
active CRTC/surface. If the internal panel has no surface at selection time
(lid closed at boot, internal output disabled in config, no free CRTC, or
surface init failure), the rule silently misses and selection falls through to
the boot GPU — the dGPU on this hardware. Mutter and KWin both solved this
class of bug by keying off the internal panel connector rather than
boot_vga/PCI order; this PR closes the remaining gap to that behaviour.

Separately, `COSMIC_RENDER_DEVICE=/dev/dri/renderD128` — the most natural
value to try, and the form circulating in #913 as the recommended workaround —
silently fails because `dev_var` resolves bare names relative to `/dev/dri/`
(#2232), with no visible warning.

## Changes

**Commit 1 — detect builtin displays via connectors, not active surfaces**
- New `has_builtin_display()` scans all connectors reported by the DRM device
  (`resource_handles()`) for `EmbeddedDisplayPort | LVDS | DSI`, skipping
  software devices.
- Connection state is deliberately not required: a lid-closed eDP may probe as
  disconnected on some firmware, while desktop GPUs essentially never expose
  these interfaces — presence alone is the robust signal (and matches the
  intent of the existing code, which also didn't check state).
- Adds `debug!` logging of which rule selected the primary GPU
  (`COSMIC_RENDER_DEVICE` / builtin display / boot gpu), so wrong selections
  are diagnosable from `journalctl _COMM=cosmic-comp`.

**Commit 2 — accept absolute paths in `COSMIC_RENDER_DEVICE`, warn on no match**
- Absolute paths are resolved via `DrmNode::from_path` and normalized to the
  render node before matching; bare-name handling via `dev_var` is unchanged.
- A `warn!` fires whenever the variable is set but doesn't resolve to a usable
  device, instead of silently falling back.

## Testing

Hardware: ASUS ProArt P16 (Ryzen AI 9 HX 370 / Radeon 890M iGPU + RTX 4070
dGPU, no MUX; NVIDIA is `boot_vga=1` on kernels without the vgaarb fix),
Pop!_OS 24.04, COSMIC session.

- [ ] No env var set: journal shows the AMD render node selected via
  "device has builtin display"; `fuser -v /dev/dri/render*` shows cosmic-comp
  on the AMD node; NVIDIA `power/runtime_status` reaches `suspended` at idle.
- [ ] Lid closed at boot with external display attached: AMD node still
  selected (previously fell through to boot GPU).
- [ ] `COSMIC_RENDER_DEVICE=/dev/dri/renderD128`: honored.
- [ ] `COSMIC_RENDER_DEVICE=renderD128`: still honored (unchanged).
- [ ] `COSMIC_RENDER_DEVICE=/dev/dri/renderD999`: prominent warning, automatic
  selection proceeds.

## Out of scope

- Re-evaluating the primary GPU on later udev events when one is already set
  (`init_udev` only re-selects when `primary_node` is `None`) — changing that
  invalidates live renderers and deserves its own discussion.
- The amdgpu UTCL2 page-fault crash on Radeon 890M (#2149) is a Mesa/kernel
  bug on gfx115x and isn't fixed by compositor changes — but selecting the
  correct single GPU avoids the multi-GPU import path that currently
  exercises it, which is why `COSMIC_RENDER_DEVICE=renderD128` has been
  reported as stabilizing these systems in #913.

Closes #913
Closes #2232



- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [ ] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

