### PR TITLE
fix: dbus: deadlock in a11y keyboard monitor

### DIFF
--- a/src/dbus/a11y_keyboard_monitor.rs
+++ b/src/dbus/a11y_keyboard_monitor.rs
@@ -150,9 +150,10 @@ impl A11yKeyboardMonitorState {
     }
 
     pub fn key_event(&self, modifiers: &ModifiersState, keysym: &KeysymHandle, state: KeyState) {
+        let has_key_grab = self.has_key_grab(modifiers, keysym.modified_sym());
         let clients = self.clients.lock().unwrap();
         for (unique_name, client) in clients.0.iter() {
-            if !client.watched && !self.has_key_grab(modifiers, keysym.modified_sym()) {
+            if !client.watched && !has_key_grab {
                 continue;
             }
 


### PR DESCRIPTION
## Problem

`A11yKeyboardMonitorState::key_event` calls `self.has_key_grab()` inside `self.clients` guard loop.

A "well-behaved" a11y client calls `WatchKeyboard` before `SetKeyGrabs`.

In the existing code, with such "well-behaved" clients,`!client.watched` short-circuits the call to `self.has_key_grab()` and thus prevents a double-lock.

If `WatchKeyboard` is not called first (poorly written client, no error or warning to the client developer other than this freeze, and **if** they test it on COSMIC), the `!client.watched` check does not short-circuit, and `self.has_key_grab()` is called **inside the existing guard**, which then tries to lock `self.clients` again, causing the deadlock.

This causes the compositor to freeze, requiring a hard reboot.

## Fix

This commit moves the `self.has_key_grab()` before the guard to prevent a double lock.

## Background

I discovered this bug/freeze while writing my `say-selection` screen reader to work with the new a11y KeyboardMonitor DBus API (**thanks COSMIC!**).

While prototyping, I failed to call `WatchKeyboard` before `SetKeyGrabs` and discovered this deadlock when COSMIC froze and I had to hard-reset.

I used AI to research the root cause, but chose the fix approach and wrote the code myself.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

