### PR TITLE
fix: workaround for Chromium apps breaking below 1.0 scaling

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -956,8 +956,11 @@ impl Common {
                 );
                 if let Some(output) = primary_scanout_output {
                     with_fractional_scale(states, |fraction_scale| {
-                        fraction_scale
-                            .set_preferred_scale(output.current_scale().fractional_scale());
+                        // The 1.0 clamp is a workaround for Chromium
+                        // TODO: remove if Chromium ever gets fixed
+                        fraction_scale.set_preferred_scale(
+                            output.current_scale().fractional_scale().max(1.0),
+                        );
                     });
                 }
             }

--- a/src/wayland/handlers/fractional_scale.rs
+++ b/src/wayland/handlers/fractional_scale.rs
@@ -49,7 +49,10 @@ impl FractionalScaleHandler for State {
 
         with_states(&surface, |states| {
             with_fractional_scale(states, |fractional_scale| {
-                fractional_scale.set_preferred_scale(output.current_scale().fractional_scale());
+                // The 1.0 clamp is a workaround for Chromium
+                // TODO: remove if Chromium ever gets fixed
+                fractional_scale
+                    .set_preferred_scale(output.current_scale().fractional_scale().max(1.0));
             });
         });
     }


### PR DESCRIPTION
This is a fix for chromium apps running under Wayland breaking below 1.0 scaling(ie at 50% and 75%).
Note that I called the commit a fix but it is really a workaround for an issue that is not ours.
Chromium apps under Wayland seem to break when under 100%.
Other applications like Firefox using Wayland seem to work fine under those scales.

I suspect this has something to do with this clamp in Chromium but I couldn't find the exact logic chain that breaks:
https://chromium.googlesource.com/chromium/src/+/refs/heads/main/ui/ozone/platform/wayland/common/wayland_util.cc#329

For scales >= 100% this doesn't change anything.
For scales < 100%, scaling will still works but the surface buffer will be bigger(up to 4x for 50% compared to what it should be) and the surface will be downscaled when rendered(extra GPU work). This is obviously not ideal but I think the tradeoff of running Chromium apps until it gets fixed is worth it.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

