### PR TITLE
shortcuts: output-addressed workspace actions (issue #2120 Option B)

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -18,6 +18,7 @@ use cosmic_settings_config::shortcuts;
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection};
 use smithay::{
     input::{Seat, pointer::MotionEvent},
+    output::Output,
     utils::{Point, Serial},
 };
 #[cfg(not(feature = "debug"))]
@@ -33,6 +34,38 @@ fn propagate_by_default(action: &shortcuts::Action) -> bool {
         action,
         shortcuts::Action::Focus(_) | shortcuts::Action::Move(_)
     )
+}
+
+/// Resolve an output by exact connector name (e.g. "DP-1"), falling back to a
+/// case-insensitive substring match on the EDID model (e.g. "LS32A70").
+/// Ambiguous model matches are refused, as multiple identical monitors cannot
+/// be reliably distinguished by model.
+fn output_for_query<'a>(outputs: impl Iterator<Item = &'a Output>, query: &str) -> Option<Output> {
+    let query_lower = query.to_lowercase();
+    let mut model_match: Option<&Output> = None;
+    let mut ambiguous = false;
+    for output in outputs {
+        if output.name() == query {
+            return Some(output.clone());
+        }
+        if output
+            .physical_properties()
+            .model
+            .to_lowercase()
+            .contains(&query_lower)
+        {
+            if model_match.is_some() {
+                ambiguous = true;
+            } else {
+                model_match = Some(output);
+            }
+        }
+    }
+    if ambiguous {
+        warn!("output query {query:?} matches multiple outputs, ignoring");
+        return None;
+    }
+    model_match.cloned()
 }
 
 impl State {
@@ -522,16 +555,18 @@ impl State {
 
             Action::SwitchOutput(direction) => {
                 let current_output = seat.active_output();
-                let mut shell = self.common.shell.write();
-
-                let next_output = shell.next_output(&current_output, direction).cloned();
+                let next_output = self
+                    .common
+                    .shell
+                    .read()
+                    .next_output(&current_output, direction)
+                    .cloned();
 
                 if let Some(next_output) = next_output {
-                    let res = {
-                        let mut workspace_guard = self.common.workspace_state.update();
-                        if propagate
-                            && let Some((serial, prev_output, prev_idx)) =
-                                shell.previous_workspace_idx.take()
+                    if propagate {
+                        let mut shell = self.common.shell.write();
+                        if let Some((serial, prev_output, prev_idx)) =
+                            shell.previous_workspace_idx.take()
                             && seat.last_modifier_change().is_some_and(|s| s == serial)
                             && prev_output == current_output
                         {
@@ -539,49 +574,89 @@ impl State {
                                 &current_output,
                                 prev_idx,
                                 WorkspaceDelta::new_shortcut(),
-                                &mut workspace_guard,
+                                &mut self.common.workspace_state.update(),
                             );
                         }
+                    }
 
-                        let idx = shell.workspaces.active_num(&next_output).1;
-                        let res = shell.activate(
-                            &next_output,
-                            idx,
-                            WorkspaceDelta::new_shortcut(),
-                            &mut workspace_guard,
-                        );
-                        seat.set_active_output(&next_output);
-                        res
-                    };
+                    self.switch_to_output(&next_output, None, seat, serial, time);
+                }
+            }
 
-                    if let Ok(new_pos) = res {
-                        let workspace = shell.workspaces.active(&next_output).unwrap().1;
-                        let new_target = workspace
-                            .focus_stack
-                            .get(seat)
-                            .last()
-                            .cloned()
-                            .map(Into::<KeyboardFocusTarget>::into);
-                        std::mem::drop(shell);
+            Action::WorkspaceOnOutput(query, key_num) => {
+                let target_output = {
+                    let shell = self.common.shell.read();
+                    output_for_query(shell.outputs(), &query)
+                };
+                let workspace = match key_num {
+                    0 => 9,
+                    x => x - 1,
+                };
 
-                        let update_cursor = self.common.config.cosmic_conf.cursor_follows_focus;
-                        Shell::set_focus(self, new_target.as_ref(), seat, None, update_cursor);
+                if let Some(output) = target_output {
+                    self.switch_to_output(&output, Some(workspace as usize), seat, serial, time);
+                } else {
+                    warn!("WorkspaceOnOutput: no output matches {query:?}");
+                }
+            }
 
-                        if let Some(ptr) = seat.get_pointer() {
-                            // Update cursor position if `set_focus` didn't already
-                            if !update_cursor {
-                                ptr.motion(
-                                    self,
-                                    None,
-                                    &MotionEvent {
-                                        location: new_pos.to_f64().as_logical(),
-                                        serial,
-                                        time,
-                                    },
-                                );
-                            }
-                            ptr.frame(self);
+            x @ Action::MoveToWorkspaceOnOutput(..) | x @ Action::SendToWorkspaceOnOutput(..) => {
+                let (query, key_num, follow): (String, u8, bool) = match x {
+                    Action::MoveToWorkspaceOnOutput(query, n) => (query, n, true),
+                    Action::SendToWorkspaceOnOutput(query, n) => (query, n, false),
+                    _ => unreachable!(),
+                };
+                let target_output = {
+                    let shell = self.common.shell.read();
+                    output_for_query(shell.outputs(), &query)
+                };
+                let Some(target_output) = target_output else {
+                    warn!("Move/SendToWorkspaceOnOutput: no output matches {query:?}");
+                    return;
+                };
+                let workspace = match key_num {
+                    0 => 9,
+                    x => x - 1,
+                };
+                let mut shell = self.common.shell.write();
+                let res = {
+                    let mut workspace_guard = self.common.workspace_state.update();
+                    match shell.workspaces.ensure_pinned_workspaces(
+                        &target_output,
+                        workspace as usize + 1,
+                        &mut workspace_guard,
+                    ) {
+                        Ok(true) => shell.workspaces.persist(&self.common.config),
+                        Ok(false) => {}
+                        Err(err) => {
+                            error!(?err, "Failed to pin implicitly created workspaces");
+                            return;
                         }
+                    }
+                    shell.move_current(
+                        seat,
+                        (&target_output, Some(workspace as usize)),
+                        follow,
+                        None,
+                        &mut workspace_guard,
+                        &self.common.event_loop_handle,
+                    )
+                };
+
+                if follow && let Ok(Some((target, new_pos))) = res {
+                    std::mem::drop(shell);
+                    Shell::set_focus(self, Some(&target), seat, None, follow);
+                    if let Some(ptr) = seat.get_pointer() {
+                        ptr.motion(
+                            self,
+                            None,
+                            &MotionEvent {
+                                location: new_pos.to_f64().as_logical(),
+                                serial,
+                                time,
+                            },
+                        );
+                        ptr.frame(self);
                     }
                 }
             }
@@ -1038,6 +1113,87 @@ impl State {
 
             // Do nothing
             Action::Disable => (),
+        }
+    }
+
+    /// Activate `workspace_idx` (or the currently-active workspace) on `target`
+    /// and transfer keyboard focus + pointer there.
+    pub(crate) fn switch_to_output(
+        &mut self,
+        target: &Output,
+        workspace_idx: Option<usize>,
+        seat: &Seat<State>,
+        serial: Serial,
+        time: u32,
+    ) {
+        let current_output = seat.active_output();
+        if *target == current_output {
+            let already_active = workspace_idx
+                .map(|idx| self.common.shell.read().workspaces.active_num(target).1 == idx)
+                .unwrap_or(true);
+            // Returning here means the requested index is already active, so it exists and needs
+            // no implicit creation.
+            if already_active {
+                return;
+            }
+        }
+
+        let mut shell = self.common.shell.write();
+        let res = {
+            let mut workspace_guard = self.common.workspace_state.update();
+            if let Some(workspace_idx) = workspace_idx {
+                match shell.workspaces.ensure_pinned_workspaces(
+                    target,
+                    workspace_idx + 1,
+                    &mut workspace_guard,
+                ) {
+                    Ok(true) => shell.workspaces.persist(&self.common.config),
+                    Ok(false) => {}
+                    Err(err) => {
+                        error!(?err, "Failed to pin implicitly created workspaces");
+                        return;
+                    }
+                }
+            }
+            let idx = workspace_idx.unwrap_or_else(|| shell.workspaces.active_num(target).1);
+            let res = shell.activate(
+                target,
+                idx,
+                WorkspaceDelta::new_shortcut(),
+                &mut workspace_guard,
+            );
+            seat.set_active_output(target);
+            res
+        };
+
+        if let Ok(new_pos) = res {
+            let workspace = shell.workspaces.active(target).unwrap().1;
+            let new_target = workspace
+                .focus_stack
+                .get(seat)
+                .last()
+                .cloned()
+                .map(Into::<KeyboardFocusTarget>::into);
+            std::mem::drop(shell);
+
+            let update_cursor = self.common.config.cosmic_conf.cursor_follows_focus;
+            Shell::set_focus(self, new_target.as_ref(), seat, None, update_cursor);
+
+            if let Some(ptr) = seat.get_pointer() {
+                // Update cursor position if `set_focus` didn't already
+                if !update_cursor {
+                    ptr.motion(
+                        self,
+                        None,
+                        &MotionEvent {
+                            location: new_pos.to_f64().as_logical(),
+                            serial,
+                            time,
+                        },
+                    );
+                }
+                ptr.frame(self);
+            }
         }
     }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -83,7 +83,8 @@ use crate::{
                 toplevel_leave_output, toplevel_leave_workspace,
             },
             workspace::{
-                WorkspaceGroupHandle, WorkspaceHandle, WorkspaceState, WorkspaceUpdateGuard,
+                WorkspaceGroupHandle, WorkspaceHandle, WorkspaceIdAlreadySetError, WorkspaceState,
+                WorkspaceUpdateGuard,
             },
         },
     },
@@ -916,6 +917,41 @@ impl Workspaces {
             }
         }
         self.sets.insert(output.clone(), set);
+    }
+
+    pub fn ensure_pinned_workspaces(
+        &mut self,
+        output: &Output,
+        count: usize,
+        workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
+    ) -> Result<bool, WorkspaceIdAlreadySetError> {
+        let set = &mut self.sets[output];
+        let mut created = false;
+
+        while set.workspaces.len() < count {
+            set.add_empty_workspace(workspace_state);
+            let workspace_idx = set.workspaces.len() - 1;
+            let workspace = &mut set.workspaces[workspace_idx];
+            let id = random_workspace_id();
+            workspace.pinned = true;
+            workspace_state.set_id(&workspace.handle, &id)?;
+            workspace.id = Some(id);
+            workspace_state.add_workspace_state(&workspace.handle, WState::Pinned);
+            created = true;
+        }
+
+        if self.mode == WorkspaceMode::Global {
+            for (other_output, set) in self.sets.iter_mut() {
+                if other_output == output {
+                    continue;
+                }
+                while set.workspaces.len() < count {
+                    set.add_empty_workspace(workspace_state);
+                }
+            }
+        }
+
+        Ok(created)
     }
 
     pub fn remove_output<'a>(
@@ -5139,4 +5175,55 @@ pub fn check_grab_preconditions(
     }
 
     Some(start_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smithay::{
+        output::{PhysicalProperties, Subpixel},
+        reexports::wayland_server::Display,
+    };
+
+    #[test]
+    fn ensure_pinned_workspaces_creates_and_pins_missing_workspaces() {
+        let display = Display::<State>::new().unwrap();
+        let mut workspace_state =
+            crate::wayland::protocols::workspace::WorkspaceState::new(&display.handle(), |_| true);
+        let output = Output::new(
+            "test-output".into(),
+            PhysicalProperties {
+                size: (200, 150).into(),
+                subpixel: Subpixel::HorizontalRgb,
+                make: "test".into(),
+                model: "test".into(),
+                serial_number: "test".into(),
+            },
+        );
+        let mut workspaces = Workspaces {
+            sets: IndexMap::new(),
+            backup_set: None,
+            layout: WorkspaceLayout::Horizontal,
+            mode: WorkspaceMode::OutputBound,
+            autotile: false,
+            autotile_behavior: TileBehavior::Global,
+            theme: cosmic::theme::system_preference(),
+            appearance: AppearanceConfig::default(),
+            persisted_workspaces: Vec::new(),
+        };
+        workspaces.add_output(&output, &mut workspace_state.update());
+
+        let created = workspaces
+            .ensure_pinned_workspaces(&output, 3, &mut workspace_state.update())
+            .unwrap();
+
+        let workspaces = &workspaces.sets[&output].workspaces;
+        assert!(created);
+        assert_eq!(workspaces.len(), 3);
+        assert!(
+            workspaces[1..]
+                .iter()
+                .all(|workspace| workspace.pinned && workspace.id.is_some())
+        );
+    }
 }

--- a/src/wayland/handlers/workspace.rs
+++ b/src/wayland/handlers/workspace.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
-    shell::WorkspaceDelta,
     utils::prelude::*,
     wayland::protocols::workspace::{
         Request, State as WState, WorkspaceHandler, WorkspaceState, delegate_workspace,
     },
 };
 use cosmic_protocols::workspace::v2::server::zcosmic_workspace_handle_v2::TilingState;
-use smithay::reexports::wayland_server::DisplayHandle;
+use smithay::{reexports::wayland_server::DisplayHandle, utils::SERIAL_COUNTER};
 
 impl WorkspaceHandler for State {
     fn workspace_state(&self) -> &WorkspaceState<Self> {
@@ -22,22 +21,21 @@ impl WorkspaceHandler for State {
         for request in requests.into_iter() {
             match request {
                 Request::Activate(handle) => {
-                    let mut shell = self.common.shell.write();
-                    let maybe = shell.workspaces.iter().find_map(|(o, set)| {
-                        set.workspaces
-                            .iter()
-                            .position(|w| w.handle == handle)
-                            .map(|i| (o.clone(), i))
-                    });
+                    let maybe = {
+                        let shell = self.common.shell.read();
+                        shell.workspaces.iter().find_map(|(o, set)| {
+                            set.workspaces
+                                .iter()
+                                .position(|w| w.handle == handle)
+                                .map(|i| (o.clone(), i))
+                        })
+                    };
 
                     if let Some((output, idx)) = maybe {
-                        let _ = shell.activate(
-                            &output,
-                            idx,
-                            WorkspaceDelta::new_shortcut(),
-                            &mut self.common.workspace_state.update(),
-                        );
-                        // TODO: move cursor?
+                        let seat = self.common.shell.read().seats.last_active().clone();
+                        let serial = SERIAL_COUNTER.next_serial();
+                        let time = self.common.clock.now().as_millis();
+                        self.switch_to_output(&output, Some(idx), &seat, serial, time);
                     }
                 }
                 Request::SetTilingState { workspace, state } => {


### PR DESCRIPTION
Implements [Option B from cosmic-comp#2120](https://github.com/pop-os/cosmic-comp/issues/2120): direct workspace addressing on a chosen output for multi-monitor setups. [cosmic-epoch#2270](https://github.com/pop-os/cosmic-epoch/issues/2270) and [cosmic-comp#697](https://github.com/pop-os/cosmic-comp/issues/697) are related asks.

New RON actions:

```ron
WorkspaceOnOutput("DP-3", 2)
MoveToWorkspaceOnOutput("LS32A70", 4)
SendToWorkspaceOnOutput("O34", 1)
```

Output matching uses an exact connector name first, then a case-insensitive EDID-model substring. Ambiguous model matches are refused. Missing workspace indices are implicitly created and pinned so positional indices remain stable when empty unpinned workspaces are culled.

The ext-workspace-v1 Activate path now transfers keyboard focus and pointer location when activation crosses outputs.

Depends on [cosmic-settings-daemon#172](https://github.com/pop-os/cosmic-settings-daemon/pull/172) merging first, followed by a lockfile bump, so this remains draft.

Follow-ups: cosmic-settings UI integration for the actions and declarative per-output workspace counts.