### PR TITLE
fix(a11y): make screen magnifier zoom optically linear

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -1101,7 +1101,13 @@ impl State {
         }
 
         if zoom_seat == *seat {
-            let new_level = (current_level + change).max(1.0);
+            let new_level = if change > 0.0 {
+                current_level * (1.0 + change)
+            } else {
+                current_level / (1.0 - change)
+            };
+            let new_level = if new_level < 1.01 { 1.0 } else { new_level };
+
             shell.trigger_zoom(
                 seat,
                 Some(&output),


### PR DESCRIPTION
Changed the magnifier zoom calculation from additive to multiplicative.

With the previous additive formula (current_level + change), the relative zoom steps became increasingly smaller at deeper levels, causing zooming to become increasingly arduous as zoom level increased.

By scaling multiplicatively,the perceived zoom steps remain equal in perception across zoom levels improving UX.

Added a small threshold to safely round down to 1.0 when zooming out to allow the magnifier to fully disable.

Tested on x86_64 Xubuntu 26.04 in Cosmic DE Epoch 1.4 (with patched cosmic-comp)

LLM disclosure:
Gemini Flash 3.5 was helpful in finding where the bothering code was located and and suggested this fix.
That being said, there are only a few lines, the logic is simple and every line is well understood and functionality well tested.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

