### PR TITLE
fix(kms): recover from DRM master handoff failure

### DIFF
--- a/data/cosmic-comp.service
+++ b/data/cosmic-comp.service
@@ -8,5 +8,6 @@ Before=cosmic-session.target
 [Service]
 Type=notify
 ExecStart=/usr/bin/cosmic-comp
-Restart=never
+Restart=on-failure
+RestartSec=1s
 ExecStopPost=/usr/bin/systemctl --user unset-environment DISPLAY WAYLAND_DISPLAY

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -34,6 +34,7 @@ use smithay::{
     output::{Mode as OutputMode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::{
         calloop::{LoopHandle, RegistrationToken},
+        drm::Device as _,
         drm::control::{Device as ControlDevice, ModeTypeFlags, connector, crtc},
         gbm::BufferObjectFlags as GbmBufferFlags,
         rustix::fs::{Dev as dev_t, OFlags},
@@ -685,6 +686,14 @@ pub struct OutputChanges {
 }
 
 impl Device {
+    pub(super) fn has_drm_master(&self) -> bool {
+        self.drm
+            .device()
+            .device_fd()
+            .authenticated()
+            .unwrap_or(false)
+    }
+
     fn new(
         dev: dev_t,
         path: impl AsRef<Path>,

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -59,7 +59,31 @@ use device::*;
 pub(crate) use surface::Surface;
 pub use surface::Timings;
 
+fn primary_master_failure_requires_retry(is_primary: bool, acquired: bool) -> bool {
+    is_primary && !acquired
+}
+
 use super::render::{CLEAR_COLOR, CursorMode, output_elements};
+
+#[cfg(test)]
+mod tests {
+    use super::primary_master_failure_requires_retry;
+
+    #[test]
+    fn primary_master_failure_is_retryable() {
+        assert!(primary_master_failure_requires_retry(true, false));
+    }
+
+    #[test]
+    fn secondary_master_failure_does_not_block_startup() {
+        assert!(!primary_master_failure_requires_retry(false, false));
+    }
+
+    #[test]
+    fn acquired_primary_master_does_not_require_retry() {
+        assert!(!primary_master_failure_requires_retry(true, true));
+    }
+}
 
 #[derive(Debug)]
 pub struct KmsState {
@@ -144,6 +168,24 @@ pub fn init_backend(
 
     if let Err(err) = state.backend.kms().select_primary_gpu(dh) {
         warn!("Failed to determine primary gpu: {}", err);
+    }
+
+    let primary_node = *state.backend.kms().primary_node.read().unwrap();
+    if let Some(primary_node) = primary_node {
+        let primary_device = state
+            .backend
+            .kms()
+            .drm_devices
+            .values()
+            .find(|device| device.inner.render_node == primary_node)
+            .context("Primary render device is not available")?;
+
+        if primary_master_failure_requires_retry(true, primary_device.has_drm_master()) {
+            anyhow::bail!(
+                "Unable to acquire DRM master for primary device {}; retrying compositor startup",
+                primary_device.inner.dev_node
+            );
+        }
     }
 
     if let Err(err) = state.refresh_output_config() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2529,7 +2529,7 @@ pub fn update_output_image_copy_cursor_position(
     position: Point<f64, Global>,
 ) {
     let output_geometry = output.geometry();
-    for session in cursor_sessions_for_output(&shell, &output) {
+    for session in cursor_sessions_for_output(shell, output) {
         if let Some(cursor_geometry) = seat.cursor_geometry(
             (position - output_geometry.loc.to_f64())
                 .as_logical()

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -333,17 +333,15 @@ impl XdgShellHandler for State {
                     if let Some(ref grab) = grab {
                         if grab.has_ended() {
                             should_ungrab = true;
-                        } else if let Some(target) = grab.current_grab() {
-                            if let Some(wl_surface) = target.wl_surface() {
-                                if wl_surface.as_ref() == surface.wl_surface()
-                                    || smithay::desktop::PopupManager::popups_for_surface(
-                                        surface.wl_surface(),
-                                    )
-                                    .any(|(p, _)| p.wl_surface() == wl_surface.as_ref())
-                                {
-                                    should_ungrab = true;
-                                }
-                            }
+                        } else if let Some(target) = grab.current_grab()
+                            && let Some(wl_surface) = target.wl_surface()
+                            && (wl_surface.as_ref() == surface.wl_surface()
+                                || smithay::desktop::PopupManager::popups_for_surface(
+                                    surface.wl_surface(),
+                                )
+                                .any(|(p, _)| p.wl_surface() == wl_surface.as_ref()))
+                        {
+                            should_ungrab = true;
                         }
                     }
                     if should_ungrab {


### PR DESCRIPTION
Closes #2635

## Summary

- Detect missing DRM authentication on the primary KMS device before compositor readiness.
- Abort startup so systemd retries the session handoff with a fresh DRM descriptor.
- Preserve secondary/render-only device behavior.
- Fix existing Clippy warnings required by CI.

## Root cause

When the greeter still owns DRM master during startup, Smithay can initialize the device as unprivileged. cosmic-comp previously continued startup and announced readiness, leaving the graphical session on a black screen.

## Validation

- `cargo +stable fmt --all -- --check`
- `cargo +stable clippy --all-features -- -D warnings`
- `cargo +stable check --all-targets`
- `cargo +stable check --no-default-features`
- `cargo +stable check --features debug`
- `cargo +stable check --features profile-with-tracy`
- `cargo +stable check --features profile-with-tracy-gpu`
- `cargo +stable test --all-features`
- `git diff --check`

All automated checks passed.

Hardware validation on the affected Dell Latitude 3520 has not been performed yet because reproducing the DRM handoff can make the graphical session unavailable.

## Contributor declarations

- AI-assisted code was disclosed in the commit message, as required by the repository template.
- I understand the changes and will respond to review comments.
- The commit includes a DCO sign-off with `git commit -s`.
