### PR TITLE
fix(corner_radius): only error on radius values the client submitted

### DIFF
--- a/src/wayland/protocols/corner_radius.rs
+++ b/src/wayland/protocols/corner_radius.rs
@@ -12,6 +12,7 @@ use smithay::reexports::wayland_server::New;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{HookId, Logical, Point, Rectangle};
 use smithay::wayland::compositor::Cacheable;
+use smithay::wayland::compositor::SurfaceData;
 use smithay::wayland::compositor::add_pre_commit_hook;
 use smithay::wayland::compositor::with_states;
 use smithay::wayland::shell::wlr_layer::WlrLayerShellHandler;
@@ -28,6 +29,49 @@ use wayland_backend::server::GlobalId;
 
 type ToplevelHookId = Mutex<Option<(HookId, Weak<CosmicCornerRadiusToplevelV1>)>>;
 type LayerHookId = Mutex<Option<(HookId, Weak<CosmicCornerRadiusLayerV1>)>>;
+
+/// Which of the double-buffered corner-radius values the client itself
+/// submitted since the surface was last committed.
+///
+/// The radius and padding hints are validated against the surface geometry in
+/// a pre-commit hook, which runs on *every* commit. Without this marker a
+/// client would be killed whenever a compositor-initiated resize (tiling,
+/// maximise, snapping, a resize animation) made a previously legal radius too
+/// large for the new geometry, even though the client never sent a new
+/// request and had no way to avoid it. Only state the client actually
+/// submitted may raise a protocol error.
+#[derive(Debug, Default, Clone, Copy)]
+struct Submitted {
+    corners: bool,
+    padding: bool,
+}
+
+type SubmittedState = Mutex<Submitted>;
+
+fn mark_corners_submitted(surface_data: &SurfaceData) {
+    let submitted = surface_data
+        .data_map
+        .get_or_insert_threadsafe(SubmittedState::default);
+    submitted.lock().unwrap().corners = true;
+}
+
+fn mark_padding_submitted(surface_data: &SurfaceData) {
+    let submitted = surface_data
+        .data_map
+        .get_or_insert_threadsafe(SubmittedState::default);
+    submitted.lock().unwrap().padding = true;
+}
+
+/// Reads and clears the markers. Called once per commit from the pre-commit
+/// hooks, so a value is only ever validated against the geometry it was
+/// submitted with.
+fn take_submitted(surface_data: &SurfaceData) -> Submitted {
+    let submitted = surface_data
+        .data_map
+        .get_or_insert_threadsafe(SubmittedState::default);
+    let mut guard = submitted.lock().unwrap();
+    std::mem::take(&mut *guard)
+}
 
 #[derive(Debug)]
 pub struct CornerRadiusState {
@@ -374,6 +418,7 @@ where
                     let mut cached = s.cached_state.get::<CacheableCorners>();
                     let pending = cached.pending();
                     *pending = CacheableCorners(guard.corners);
+                    mark_corners_submitted(s);
                 });
                 drop(guard);
 
@@ -505,6 +550,7 @@ where
                     let mut cached = s.cached_state.get::<CacheableCorners>();
                     let pending = cached.pending();
                     *pending = CacheableCorners(guard.corners);
+                    mark_corners_submitted(s);
                 });
                 drop(guard);
 
@@ -568,6 +614,7 @@ where
                     let mut cached = s.cached_state.get::<CacheablePadding>();
                     let pending = cached.pending();
                     *pending = CacheablePadding(guard.padding);
+                    mark_padding_submitted(s);
                 });
                 drop(guard);
 
@@ -609,6 +656,14 @@ where
 
 fn xdg_radius_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &WlSurface) {
     with_states(surface, |surface_data| {
+        // Only a radius the client submitted itself may be fatal. A radius
+        // that only became too large because the surface geometry shrank is
+        // clamped when rendering (see `surface_corners`), so there is nothing
+        // to protect against here and killing the client would be a bug.
+        if !take_submitted(surface_data).corners {
+            return;
+        }
+
         let corners = *surface_data
             .cached_state
             .get::<CacheableCorners>()
@@ -654,9 +709,32 @@ fn pad_rect(
     Some(rect)
 }
 
+fn post_layer_error(
+    surface_data: &SurfaceData,
+    error: cosmic_corner_radius_layer_v1::Error,
+    reason: &str,
+) {
+    if let Some(hook) = surface_data.data_map.get::<LayerHookId>() {
+        let hook_ref = hook.lock().unwrap();
+        if let Some((_, obj)) = hook_ref.as_ref()
+            && let Ok(obj) = obj.upgrade()
+        {
+            obj.post_error(error as u32, format!("{obj:?} {reason}"));
+        }
+    }
+}
+
 fn layer_radius_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &WlSurface) {
     let bbox = bbox_from_surface_tree(surface, Point::default());
     with_states(surface, |surface_data| {
+        // Only values the client submitted itself may be fatal. Values that
+        // only became too large because the surface was resized are clamped
+        // when rendering (see `surface_corners` / `surface_padding`).
+        let submitted = take_submitted(surface_data);
+        if !submitted.corners && !submitted.padding {
+            return;
+        }
+
         let corners = *surface_data
             .cached_state
             .get::<CacheableCorners>()
@@ -667,37 +745,39 @@ fn layer_radius_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &
             .pending();
         let empty = Padding::default();
         let Some(padded_box) = pad_rect(bbox, padding.0.as_ref().unwrap_or(&empty)) else {
-            if let Some(hook) = surface_data.data_map.get::<LayerHookId>() {
-                let hook_ref = hook.lock().unwrap();
-                if let Some((_, obj)) = hook_ref.as_ref()
-                    && let Ok(obj) = obj.upgrade()
-                {
-                    obj.post_error(
-                        cosmic_corner_radius_layer_v1::Error::PaddingTooLarge as u32,
-                        format!("{obj:?} padding too large"),
-                    );
-                }
+            if submitted.padding {
+                post_layer_error(
+                    surface_data,
+                    cosmic_corner_radius_layer_v1::Error::PaddingTooLarge,
+                    "padding too large",
+                );
             }
             return;
         };
 
-        if corners.0.as_ref().is_some_and(|corners| {
-            let half_min_dim = (padded_box.size.w.min(padded_box.size.h) / 2) as u32;
-            corners.top_right > half_min_dim
-                || corners.top_left > half_min_dim
-                || corners.bottom_right > half_min_dim
-                || corners.bottom_left > half_min_dim
-        }) && let Some(hook) = surface_data.data_map.get::<LayerHookId>()
+        // A surface that isn't mapped yet has no size to validate against;
+        // `bbox_from_surface_tree` reports an empty rectangle for it. Treating
+        // that as "every radius is too large" kills clients that set a radius
+        // before their first buffer, so skip it, the same way the xdg hook
+        // skips surfaces that have no window geometry yet.
+        if padded_box.size.w <= 0 || padded_box.size.h <= 0 {
+            return;
+        }
+
+        if submitted.corners
+            && corners.0.as_ref().is_some_and(|corners| {
+                let half_min_dim = (padded_box.size.w.min(padded_box.size.h) / 2) as u32;
+                corners.top_right > half_min_dim
+                    || corners.top_left > half_min_dim
+                    || corners.bottom_right > half_min_dim
+                    || corners.bottom_left > half_min_dim
+            })
         {
-            let hook_ref = hook.lock().unwrap();
-            if let Some((_, obj)) = hook_ref.as_ref()
-                && let Ok(obj) = obj.upgrade()
-            {
-                obj.post_error(
-                    cosmic_corner_radius_layer_v1::Error::RadiusTooLarge as u32,
-                    format!("{obj:?} corner radius too large"),
-                );
-            }
+            post_layer_error(
+                surface_data,
+                cosmic_corner_radius_layer_v1::Error::RadiusTooLarge,
+                "corner radius too large",
+            );
         }
     });
 }


### PR DESCRIPTION
### The Problem

`cosmic-comp` kills clients with a fatal Wayland protocol error over a purely cosmetic corner-radius hint, in two situations the client cannot avoid.

The radius and padding hints are validated in a **pre-commit hook**, which runs on *every* commit of the surface — not only on the commit that carries a new `set_radius`/`set_padding` request. As a result:

1. **A window that is resized smaller is killed.** A client sets a legal radius (say 20px on a 400x400 window). Later the compositor resizes it — tiling, maximising, snapping, a resize animation. The client acks the configure and commits its new, smaller window geometry. The hook re-validates the *old* radius against the *new* geometry, decides it is too large, and posts `radius_too_large`. The client never sent a new request and had no way to prevent this.

2. **A layer surface that is not mapped yet is killed.** `layer_radius_hook` validates against `bbox_from_surface_tree`, which reports an empty rectangle for a surface with no buffer. `half_min_dim` is then `0`, so *every* non-zero radius counts as too large. The xdg hook does not have this problem because it only validates when window geometry is set.

Because `post_error` tears down the whole connection, a single stale hint takes down everything that client owns.

### Impact

Not theoretical. On my machine (Pop!_OS 24.04, 4K display, `cosmic-comp` 693d1ad) these two errors account for **349,861 of the 392,958** Wayland protocol errors in the last 7 days of my journal — 89% of all of them.

**`cosmic-panel` stops drawing and never recovers (case 1).** The panel's Wayland connection is killed, but the process does not exit, so `cosmic-session` never respawns it. The panel and every applet stay alive and healthy and simply never render again. 345,220 lines of

```
Protocol error 1 on object cosmic_corner_radius_toplevel_v1@375
```

at a sustained ~20,000/minute for 15 minutes, stopping when `cosmic-panel` was killed by hand and respawned by the session. The panel-side "alive but not rendering, so it is never restarted" behaviour is pop-os/cosmic-panel#635; this is one of the triggers for it.

**`xdg-desktop-portal-cosmic` dies, taking the clipboard with it (case 2).** The portal's screenshot overlay is a layer surface built with `size_limits: Limits::NONE.min_height(1.0).min_width(1.0)` (`src/screenshot.rs`), so it can legitimately be 1x1 before it is configured. From my journal:

```
xdg-desktop-portal-cosmic[852701]: cosmic_corner_radius_layer_v1#1087: error 1: ... corner radius too large
xdg-desktop-portal-cosmic[852701]: SCTK failed to send Control::AboutToWait. TrySendError { kind: Disconnected }
xdg-desktop-portal-cosmic[852701]: Error: EventLoop(ExitFailure(1))
systemd[1638]: dbus-...portal.desktop.cosmic@1.service: Main process exited, code=exited, status=1/FAILURE
```

The portal owns the `wl_data_offer` for a screenshot, so when it dies the screenshot can no longer be pasted. This looks like a contributor to the recurring "screenshot sometimes can't be pasted" reports (e.g. pop-os/cosmic-screenshot#224).

### How to Reproduce

Minimal client, no special setup — full source: https://gist.github.com/zyads/d07ee40c32de6a162dbaae96fe5cbb28

1. Map a 400x400 `xdg_toplevel` with `set_window_geometry(0, 0, 400, 400)`.
2. `cosmic_corner_radius_toplevel_v1.set_radius(20, 20, 20, 20)` and commit. Accepted, correctly — 20 <= 400/2.
3. **Without touching the radius object again**, `set_window_geometry(0, 0, 400, 20)` and commit.

Result on current `main`:

```
step 1: mapped a 400x400 toplevel
step 2: set_radius(20,20,20,20) on a 400x400 window - accepted, as it should be
step 3: committing a smaller window geometry (400x20). Radius NOT touched.
RESULT: KILLED by the compositor
  protocol error: code=1 interface=cosmic_corner_radius_toplevel_v1 object=12
                  message="... corner radius too large"
```

Step 3 is exactly what every client does when it acks a compositor-initiated resize.

### The Fix

Only raise a protocol error for state the **client actually submitted in the commit being processed**.

- A small `Submitted { corners, padding }` marker is stored in the surface's `data_map`, set by `set_radius`/`set_padding`, and read-and-cleared once per commit by the hooks. A value is therefore only ever validated against the geometry it was submitted alongside.
- `layer_radius_hook` additionally skips surfaces whose padded box has no area, mirroring the xdg hook's existing "no window geometry yet" behaviour.

Genuinely bad clients — ones that submit an over-large radius for the geometry they are committing — still get the protocol error, so protocol conformance is unchanged for the case the error exists for.

Nothing is left unprotected: `surface_corners()` and `surface_padding()` in `src/wayland/handlers/corner_radius.rs` already clamp to `half_min_dim` when rendering, with the comment *"guard against corner radius being too large, potentially disconnecting the outline"*. The rendering path was always safe; the fatal error was redundant.

### Verification

Built and checked on Rust 1.93 / Ubuntu 24.04: `cargo fmt --all -- --check` clean and `cargo build --release` clean. `cargo clippy --all-features -- -D warnings` reports no lint from the changed file — the four it does report are pre-existing on `master` under 1.93's clippy (`needless_borrow` in `src/input/mod.rs`, `collapsible_if` in `src/wayland/handlers/xdg_shell/mod.rs`), both untouched here.

Behaviour, checked by running the reproducer against a **patched `cosmic-comp` running nested** (`COSMIC_BACKEND=winit`) and against an unpatched one:

| | unpatched | patched |
|---|---|---|
| shrink geometry, radius untouched | **killed**, `radius_too_large` | survives |
| `set_radius(300,…)` on a 400x400 window (`--conformance`) | rejected | **still rejected** |

So the false positive is gone and the error still fires for the case it exists for.

I did not run a patched compositor as my real session, so I have not directly watched the panel survive over a long session. The evidence for that half is the journal correlation above plus the reproducer.

### Note

I also noticed, but deliberately did **not** touch in this PR, that `GetCornerRadiusLayer` checks `ToplevelHookId` rather than `LayerHookId` when deciding whether a corner-radius object already exists for a layer surface (`corner_radius.rs`, `GetCornerRadiusLayer` arm). That looks like a copy-paste slip, but it is a separate issue and I did not want to mix it in. Happy to file it separately.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
