### PR TITLE
fix(corner_radius): check LayerHookId for layer surfaces

### DIFF
--- a/src/wayland/protocols/corner_radius.rs
+++ b/src/wayland/protocols/corner_radius.rs
@@ -190,7 +190,7 @@ where
                     let radius_exists = with_states(surface.wl_surface(), |surface_data| {
                         let hook_id = surface_data
                             .data_map
-                            .get_or_insert_threadsafe(|| ToplevelHookId::new(None));
+                            .get_or_insert_threadsafe(|| LayerHookId::new(None));
                         let guard = hook_id.lock().unwrap();
                         guard.as_ref().map(|(_, t)| t.upgrade().is_ok())
                     });


### PR DESCRIPTION
Fixes #2651, as offered there.

`GetCornerRadiusLayer` looked up the existing hook via `ToplevelHookId`:

```rust
.get_or_insert_threadsafe(|| ToplevelHookId::new(None));
```

while inserting into `LayerHookId` a few lines later:

```rust
.get_or_insert_threadsafe(|| LayerHookId::new(None));
```

Both are `Mutex<Option<(HookId, Weak<..>)>>` so it compiles, but they are distinct `data_map` slots. The "does this surface already have a corner-radius object?" check for a layer surface was reading the toplevel slot, so it could not see a layer object that was already there, and it created a toplevel entry on a layer surface as a side effect.

Every other read of the layer hook already uses `LayerHookId` (the `CornerRadiusSurface::Layer` arms further down, and the destructor path).

One line. Verified `cargo check` clean on a fresh Ubuntu 24.04 container against `master`.

While I was in there: the `post_error` message in that same arm says `CosmicCornerRadiusToplevelV1 object already exists for the surface` on a layer surface, which looks like part of the same copy-paste. I left it out to keep this to the one line, happy to add it if you want.

---
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
