### PR TITLE
feat: allow XWayland window to start minimized

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -254,6 +254,7 @@ pub struct PendingWindow {
     pub surface: CosmicSurface,
     pub seat: Seat<State>,
     pub fullscreen: Option<Output>,
+    pub minimized: bool,
     pub maximized: bool,
     pub sticky: bool,
 }
@@ -2828,6 +2829,7 @@ impl Shell {
             surface: window,
             seat,
             fullscreen: output,
+            minimized: should_be_minimized,
             maximized: should_be_maximized,
             sticky: mut should_be_sticky,
         } = self.pending_windows.remove(pos);
@@ -2911,6 +2913,7 @@ impl Shell {
         if let Some(FocusTarget::Window(focused)) = maybe_focused
             && let Some(stack) = focused.stack_ref()
             && !is_dialog
+            && !should_be_minimized
             && !should_be_maximized
             && !(workspace.is_tiled(&focused.active_window()) && floating_exception)
         {
@@ -2960,8 +2963,13 @@ impl Shell {
             self.maximize_request(&mapped, &seat, false, loop_handle);
         }
 
-        let new_target = if (workspace_output == seat.active_output()
-            && active_handle == workspace_handle)
+        if should_be_minimized {
+            self.minimize_request(&window);
+        }
+
+        let new_target = if should_be_minimized {
+            None
+        } else if (workspace_output == seat.active_output() && active_handle == workspace_handle)
             || should_be_sticky
         {
             // TODO: enforce focus stealing prevention by also checking the same rules as for the else case.
@@ -3085,6 +3093,7 @@ impl Shell {
                     surface,
                     seat: seat.clone(),
                     fullscreen: None,
+                    minimized: false,
                     maximized: false,
                     sticky: false,
                 });

--- a/src/wayland/handlers/xdg_shell/mod.rs
+++ b/src/wayland/handlers/xdg_shell/mod.rs
@@ -50,6 +50,7 @@ impl XdgShellHandler for State {
                 surface,
                 seat,
                 fullscreen: None,
+                minimized: false,
                 maximized: false,
                 sticky: false,
             })

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -808,6 +808,7 @@ impl XwmHandler for State {
             );
         }
         let fullscreen = window.is_fullscreen().then(|| seat.active_output());
+        let minimized = window.is_hidden();
         let maximized = window.is_maximized();
         if let Some(pending) = shell
             .pending_windows
@@ -816,6 +817,7 @@ impl XwmHandler for State {
         {
             pending.seat = seat;
             pending.fullscreen = fullscreen;
+            pending.minimized = minimized;
             pending.maximized = maximized;
         } else {
             let surface = CosmicSurface::from(window);
@@ -823,6 +825,7 @@ impl XwmHandler for State {
                 surface,
                 seat,
                 fullscreen,
+                minimized,
                 maximized,
                 sticky: false,
             })


### PR DESCRIPTION
This is part of a fix for XCOM2 not starting in fullscreen.

This adds support for XWayland windows to map minimized.
This needs the companion PR https://github.com/Smithay/smithay/pull/2113 to be merged.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

