### PR TITLE
fix: clamp pointer edge after applying the output offset

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -393,10 +393,12 @@ impl State {
                     // - output_geometry.size so that we don't send leave events to a fullscreen app
                     // - logical size so that the position doesn't end up outside the actual size of the output
                     // See https://github.com/pop-os/cosmic-comp/pull/2568
-                    let max_x = output_geometry_loc.x
-                        + logical.w.min(output_geometry.size.w as f64).next_down();
-                    let max_y = output_geometry_loc.y
-                        + logical.h.min(output_geometry.size.h as f64).next_down();
+                    let max_x = (output_geometry_loc.x
+                        + logical.w.min(output_geometry.size.w as f64))
+                    .next_down();
+                    let max_y = (output_geometry_loc.y
+                        + logical.h.min(output_geometry.size.h as f64))
+                    .next_down();
                     position.x = position.x.clamp(output_geometry_loc.x, max_x);
                     position.y = position.y.clamp(output_geometry_loc.y, max_y);
 


### PR DESCRIPTION
When testing https://github.com/pop-os/cosmic-comp/pull/2442 with `lan-mouse` I noticed if I set the host PC on the right, then it's very tricky to move the cursor between machines, but if I put it on the left, the cursor smoothly moves between machines.

After some digging I noticed that when I move the cursor all the way to the right edge, the cursor ends up exactly on 7949.0 which is my output's exclusive right bound. A pointer parked there is outside every surface.

`lan-mouse` create a 1px wide surface on the right edge, the current calculation allows the cursor to be on 7949.0 instead of 7948.9999999. Which means I have to wiggle the mouse very slowly around the right edge for it be on that 1px surface, send the mouse-enter event and transition to my other machine.

This PR fixes that. The cursor stays within bounds and smoothly moves between machines.

I thought this should be a separate PR since it's fixing a bug in a recently merged PR https://github.com/pop-os/cosmic-comp/pull/2568. If you'd prefer I can close this PR and add this as part of https://github.com/pop-os/cosmic-comp/pull/2442 to allow testing it with `lan-mouse`.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

