### PR TITLE
fix: clamp out-of-bounds cursor position hints instead of dropping them

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2377,30 +2377,29 @@ impl State {
                 let pos_in_element = location + surface_offset.to_f64();
                 let window_size = geometry.size.to_f64();
 
-                let is_legal = |p: Point<f64, Logical>| {
-                    let in_window =
-                        p.x >= 0.0 && p.y >= 0.0 && p.x < window_size.w && p.y < window_size.h;
-                    if !in_window {
-                        return false;
-                    }
+                // Clamp marginal out-of-bounds hints instead of dropping them:
+                // a dropped hint desyncs the client's tracked pointer position
+                let clamped = Point::<f64, Logical>::new(
+                    pos_in_element.x.clamp(0.0, window_size.w.next_down()),
+                    pos_in_element.y.clamp(0.0, window_size.h.next_down()),
+                );
 
-                    with_pointer_constraint(surface, pointer, |constraint| {
-                        if let Some(constraint) = constraint
-                            && let Some(region) = constraint.region()
-                        {
-                            let point_in_surface = (p - surface_offset.to_f64()).to_i32_floor();
-                            return region.contains(point_in_surface);
-                        }
-                        true
-                    })
-                };
+                let region_ok = with_pointer_constraint(surface, pointer, |constraint| {
+                    if let Some(constraint) = constraint
+                        && let Some(region) = constraint.region()
+                    {
+                        let point_in_surface = (clamped - surface_offset.to_f64()).to_i32_floor();
+                        return region.contains(point_in_surface);
+                    }
+                    true
+                });
 
                 let workspace_origin = output.geometry().loc.to_f64();
                 let origin = geometry.loc.to_f64();
 
-                if is_legal(pos_in_element) {
-                    let x = workspace_origin.x + origin.x + pos_in_element.x;
-                    let y = workspace_origin.y + origin.y + pos_in_element.y;
+                if region_ok {
+                    let x = workspace_origin.x + origin.x + clamped.x;
+                    let y = workspace_origin.y + origin.y + clamped.y;
                     Some((Point::<_, Global>::new(x, y), output.clone()))
                 } else {
                     None


### PR DESCRIPTION
## What

`apply_cursor_hint` silently discarded cursor position hints even fractionally outside the window bounds (`is_legal` returned false, the caller produced `None`): no `relative_motion`, no `motion`, no `frame`. The client believes its hint was applied, so every drop desyncs the compositor's pointer position from the client's. This restores the pre-296b6be behavior of always producing a correction.

## How

Clamp the hint into `[0, size.next_down()]` — the boundary pattern from #2568 — so a marginal out-of-range hint still produces a best-effort correction. Hints violating an active constraint region are still rejected.

Suspected contributor to the Proton/Xwayland mouselook clamp in #1692, where Xwayland's warp emulator sends a position hint on every motion tick while locked (not confirmed end-to-end with a game).

## Testing

Nested harness (Xvfb + winit backend, output scale 2.0): client locks the pointer, submits an out-of-bounds hint, unlocks. Before: hint dropped, no motion event delivered. After: hint clamped to `(w.next_down(), y)` and motion delivered at the clamped position.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
