### PR TITLE
fix(kms): retry busy drm devices during startup

### DIFF
--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -52,7 +52,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::Path,
     sync::{Arc, RwLock, atomic::AtomicBool},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 mod device;
@@ -64,6 +64,9 @@ pub(crate) use surface::Surface;
 pub use surface::Timings;
 
 use super::render::{CLEAR_COLOR, CursorMode, output_elements};
+
+const DEVICE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const DEVICE_BUSY_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug)]
 pub struct KmsState {
@@ -140,12 +143,43 @@ pub fn init_backend(
     });
 
     // manually add already present gpus
+    //
+    // Taking a device fails with EBUSY while the compositor we replace is still shutting
+    // down. Coming up with no device at all is fatal, so retry for a bounded time.
+    let mut pending = udev_dispatcher
+        .as_source_ref()
+        .device_list()
+        .map(|(dev, path)| (dev, path.to_owned()))
+        .collect::<Vec<_>>();
+
     let mut outputs = Vec::new();
-    for (dev, path) in udev_dispatcher.as_source_ref().device_list() {
-        match state.device_added(dev, path, dh) {
-            Ok(added) => outputs.extend(added),
-            Err(err) => warn!("Failed to add device {}: {:?}", path.display(), err),
+    let deadline = Instant::now() + DEVICE_BUSY_TIMEOUT;
+    loop {
+        let mut errors = Vec::new();
+        pending.retain(|(dev, path)| match state.device_added(*dev, path, dh) {
+            Ok(added) => {
+                outputs.extend(added);
+                false
+            }
+            Err(err) => {
+                errors.push((path.clone(), err));
+                true
+            }
+        });
+
+        // never delay startup once some device came up, a secondary gpu may keep failing
+        if pending.is_empty() || !outputs.is_empty() || Instant::now() >= deadline {
+            for (path, err) in errors {
+                warn!("Failed to add device {}: {:?}", path.display(), err);
+            }
+            break;
         }
+
+        info!(
+            "No drm device available yet, retrying in {:?}",
+            DEVICE_BUSY_RETRY_INTERVAL
+        );
+        std::thread::sleep(DEVICE_BUSY_RETRY_INTERVAL);
     }
 
     if let Err(err) = state.select_primary_gpu(dh) {


### PR DESCRIPTION
#2382 introduced a regression, which causes devices like my Framework 13 with an Ryzen 5 7640U to login into a black screen from cosmic-greeter.

On a greeter to session handoff the outgoing compositor can still hold the dri card when the incoming cosmic-comp starts, so the device open fails with EBUSY and the session dies with "Backend initialized without output" and a black screen. This retries failed devices for up to 5s at 100ms intervals in `init_backend()`, but only while no device came up at all, so a failing secondary GPU never delays startup.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

