### PR TITLE
Fix live adaptive-sync configuration changes

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -524,8 +524,6 @@ impl LockedBackend<'_> {
             )))
             .filter(|x| *x != output.current_location());
             output.change_current_state(mode, transform, scale.map(Scale::Fractional), location);
-
-            output.set_adaptive_sync(final_config.0.vrr);
         }
 
         match self {
@@ -540,6 +538,20 @@ impl LockedBackend<'_> {
             LockedBackend::Winit(state) => state.apply_config_for_outputs(test_only),
             LockedBackend::X11(state) => state.apply_config_for_outputs(test_only),
         }?;
+
+        // The KMS backend compares the requested VRR mode with the value stored on
+        // the output before sending `UseAdaptiveSync` to its surface thread.  Do
+        // not update that value until after the backend has made that comparison,
+        // otherwise a live VRR change is mistaken for a no-op and only takes
+        // effect after the compositor recreates the surface.
+        for output in &all_outputs {
+            let final_config = output
+                .user_data()
+                .get::<RefCell<OutputConfig>>()
+                .unwrap()
+                .borrow();
+            output.set_adaptive_sync(final_config.vrr);
+        }
 
         let mut shell_ref = shell.write();
         for output in &all_outputs {


### PR DESCRIPTION
## Summary

Apply the public adaptive-sync output state after backend configuration succeeds.

On the KMS backend, publishing it first caused the backend to compare the requested mode with the already-updated value. It then skipped the `UseAdaptiveSync` command, leaving the rendering surface thread in its previous VRR mode until the compositor restarted.

## Testing

- `cargo check -p cosmic-comp`
- On an AMD GPU with a VRR-capable DisplayPort monitor, changed adaptive sync from Automatic to Off and back while logged in.
- Verified the DRM `VRR_ENABLED` property now follows the new setting immediately; no logout/login is required.

- [x] I have disclosed use of AI assistance in the commit message and reviewed the change.
- [x] I understand these changes and can respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the Developer Certificate of Origin and certify my contribution under its conditions.