### PR TITLE
fix(shell): take presentation feedback from fullscreen surfaces

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -5024,6 +5024,20 @@ impl Shell {
         let mut output_presentation_feedback = OutputPresentationFeedback::new(output);
 
         if let Some(active) = self.active_space(output) {
+            for fs in active.get_fullscreen_surfaces() {
+                fs.surface.take_presentation_feedback(
+                    &mut output_presentation_feedback,
+                    surface_primary_scanout_output,
+                    |surface, _| {
+                        surface_presentation_feedback_flags_from_states(
+                            surface,
+                            None,
+                            render_element_states,
+                        )
+                    },
+                );
+            }
+
             active.mapped().for_each(|mapped| {
                 mapped.active_window().take_presentation_feedback(
                     &mut output_presentation_feedback,


### PR DESCRIPTION
Looks like we don't collect presentation feedback for fullscreen surfaces, and send `discarded` to the client. This has been an issue since adedb705 I think. The latest version of chrome cares about that now, after 1.5s cancels the fullscreen. There may be a cleaner solution to this. But this works.

Fixes #2677 
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

