### PR TITLE
feat(xkb): remember and restore keyboard layout per window

### DIFF
--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -162,6 +162,10 @@ pub struct XkbConfig {
     pub repeat_delay: u32,
     #[serde(default = "default_repeat_rate")]
     pub repeat_rate: u32,
+    /// Remember and restore the active layout on a per-window basis, instead of
+    /// sharing a single active layout across all windows.
+    #[serde(default)]
+    pub per_window_layout: bool,
 }
 
 impl Default for XkbConfig {
@@ -174,6 +178,7 @@ impl Default for XkbConfig {
             options: None,
             repeat_delay: default_repeat_delay(),
             repeat_rate: default_repeat_rate(),
+            per_window_layout: false,
         }
     }
 }

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 use indexmap::IndexSet;
 use smithay::{
     desktop::{PopupUngrabStrategy, layer_map_for_output},
-    input::{Seat, pointer::MotionEvent},
+    input::{Seat, keyboard::Layout, pointer::MotionEvent},
     output::Output,
     reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface},
     utils::{IsAlive, Point, SERIAL_COUNTER, Serial},
@@ -18,7 +18,7 @@ use smithay::{
         shell::wlr_layer::{KeyboardInteractivity, Layer},
     },
 };
-use std::{borrow::Cow, hash::Hash, mem, sync::Mutex};
+use std::{borrow::Cow, cell::Cell, hash::Hash, mem, sync::Mutex};
 
 use tracing::{debug, trace};
 
@@ -356,6 +356,16 @@ impl Shell {
     }
 }
 
+/// The window (if any) a keyboard focus target should remember/restore a
+/// per-window xkb layout for.
+fn xkb_layout_surface(target: &KeyboardFocusTarget) -> Option<CosmicSurface> {
+    match target {
+        KeyboardFocusTarget::Element(mapped) => Some(mapped.active_window()),
+        KeyboardFocusTarget::Fullscreen(surface) => Some(surface.clone()),
+        _ => None,
+    }
+}
+
 /// Internal, used to ensure that ActiveFocus, KeyboardFocusTarget, and FocusedOutput are all in sync
 #[profiling::function]
 fn update_focus_state(
@@ -369,6 +379,29 @@ fn update_focus_state(
     if let Some(keyboard) = seat.get_keyboard() {
         // remove constraint when target changed
         let old_focus = keyboard.current_focus();
+
+        if state.common.config.cosmic_conf.xkb_config.per_window_layout
+            && let Some(old_surface) = old_focus.as_ref().and_then(xkb_layout_surface)
+        {
+            let active_layout = keyboard.with_xkb_state(state, |context| {
+                context.xkb().lock().unwrap().active_layout()
+            });
+            old_surface
+                .user_data()
+                .insert_if_missing(|| Cell::new(Layout::default()));
+            old_surface
+                .user_data()
+                .get::<Cell<Layout>>()
+                .unwrap()
+                .set(active_layout);
+            debug!(
+                app_id = %old_surface.app_id(),
+                title = %old_surface.title(),
+                group = active_layout.0,
+                "xkb: stored per-window layout"
+            );
+        }
+
         if let Some(old_target) = old_focus
             && target != Some(&old_target)
             && let Some(surface) = old_target.wl_surface()
@@ -439,6 +472,21 @@ fn update_focus_state(
             .xwayland_notify_focus_change(target.cloned(), serial);
         ActiveFocus::set(seat, target.cloned());
         keyboard.set_focus(state, target.cloned(), serial);
+
+        if state.common.config.cosmic_conf.xkb_config.per_window_layout
+            && let Some(new_surface) = target.and_then(xkb_layout_surface)
+            && let Some(stored_layout) = new_surface.user_data().get::<Cell<Layout>>()
+        {
+            let stored_layout = stored_layout.get();
+            debug!(
+                app_id = %new_surface.app_id(),
+                title = %new_surface.title(),
+                group = stored_layout.0,
+                "xkb: restoring per-window layout"
+            );
+            keyboard.with_xkb_state(state, |mut context| context.set_layout(stored_layout));
+        }
+
         std::mem::drop(keyboard);
 
         //update the focused output or set it to the active output


### PR DESCRIPTION
Adds an opt-in `per_window_layout` flag to `XkbConfig`. When enabled, the active xkb layout group is saved for the window losing keyboard focus and restored for the window gaining it, so each window keeps its own layout instead of sharing one global layout across the whole session — matching GNOME's "Use different sources for different windows".

**Behavior**
- Off by default, no behavior change unless explicitly enabled.
- A window that has never had focus before (or was just mapped) simply inherits whichever layout is currently active — no jarring reset to layout 0.
- Only applies to actual windows (`Element`/`Fullscreen` focus targets). Popups, layer-shell surfaces (panel/dock), the window-group focus target, and the lock screen are intentionally excluded, so opening a context menu or tooltip never touches the layout.
- The existing `zcosmic_keyboard_layout_v1` protocol and panel indicator need no changes — they already broadcast whatever the seat's active layout is, which this PR keeps in sync with the focused window.

**Testing**
Manually tested on real hardware (KMS session on a spare VT, and now daily-driven in a real session) with 2 layouts (en/ru) and Alt+Shift switching: opening/switching between multiple windows correctly saves and restores each window's own layout.

Closes pop-os/cosmic-epoch#3092.
Related: pop-os/cosmic-settings#1038 (UI toggle) — companion PR for the settings checkbox will follow once this lands, since it needs this field to exist in a published `cosmic-comp-config` revision.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.