### PR TITLE
Prevent crash when closing floating windows in a tiled workspace

### DIFF
--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -1315,7 +1315,7 @@ impl TilingLayout {
             .ok_or(NodeIdError::NodeIdNoLongerValid)?;
         let state = {
             let tree = &self.queue.trees.back().unwrap().0;
-            tree.get(&node_id).unwrap().parent().and_then(|parent_id| {
+            tree.get(&node_id)?.parent().and_then(|parent_id| {
                 let parent = tree.get(parent_id).unwrap();
                 let idx = parent
                     .children()


### PR DESCRIPTION
Use try propagation instead of unwrapping. This prevents a crash when closing closing stacked and floating windows in a tiled workspace. See #2697 for details on the crash. 

Fixes #2697

Pretty low-effort change which somehow prevents the crash. Since I wasn't able to get a stack trace, I'm not sure exactly why this fixes it, but seems like a safe enough change. 

No AI was used in identifying nor in fixing the bug.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

