### PR TITLE
fix: reconcile focus-follows-cursor after workspace switch

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -183,24 +183,31 @@ impl State {
                     0 => 9,
                     x => x - 1,
                 };
-                let _ = self.common.shell.write().activate(
+                let res = self.common.shell.write().activate(
                     &current_output,
                     workspace as usize,
                     WorkspaceDelta::new_shortcut(),
                     &mut self.common.workspace_state.update(),
                 );
+                if res.is_ok() {
+                    self.reconcile_focus_to_pointer(seat);
+                }
             }
 
             Action::LastWorkspace => {
                 let current_output = seat.active_output();
                 let mut shell = self.common.shell.write();
                 let workspace = shell.workspaces.len(&current_output).saturating_sub(1);
-                let _ = shell.activate(
+                let res = shell.activate(
                     &current_output,
                     workspace,
                     WorkspaceDelta::new_shortcut(),
                     &mut self.common.workspace_state.update(),
                 );
+                drop(shell);
+                if res.is_ok() {
+                    self.reconcile_focus_to_pointer(seat);
+                }
             }
 
             Action::NextWorkspace => {
@@ -239,6 +246,8 @@ impl State {
                         direction,
                         true,
                     )
+                } else if next.is_ok() {
+                    self.reconcile_focus_to_pointer(seat);
                 }
             }
 
@@ -278,6 +287,8 @@ impl State {
                         direction,
                         true,
                     )
+                } else if previous.is_ok() {
+                    self.reconcile_focus_to_pointer(seat);
                 };
             }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2073,6 +2073,56 @@ impl State {
         }
     }
 
+    /// Reconcile keyboard focus to the window under the pointer on the active workspace.
+    ///
+    /// Does nothing unless focus-follows-cursor is enabled and the pointer is
+    /// ungrabbed, and never clears focus when the pointer is over empty space.
+    pub fn reconcile_focus_to_pointer(&mut self, seat: &Seat<State>) {
+        if !self.common.config.cosmic_conf.focus_follows_cursor {
+            return;
+        }
+
+        let Some(ptr) = seat.get_pointer() else {
+            return;
+        };
+        if ptr.is_grabbed() {
+            return;
+        }
+
+        let position = ptr.current_location().as_global();
+        let target = {
+            let shell = self.common.shell.read();
+            let Some(output) = shell
+                .outputs()
+                .find(|output| output.geometry().to_f64().contains(position))
+                .cloned()
+            else {
+                return;
+            };
+            shell
+                .active_space(&output)
+                .and_then(|workspace| workspace.toplevel_element_under(position, seat))
+        };
+
+        let Some(target) = target else {
+            return;
+        };
+
+        if let Some(pointer_focus_state) = self.common.pointer_focus_state.take() {
+            self.common
+                .event_loop_handle
+                .remove(pointer_focus_state.token);
+        }
+
+        Shell::set_focus(
+            self,
+            Some(&target),
+            seat,
+            Some(SERIAL_COUNTER.next_serial()),
+            false,
+        );
+    }
+
     #[profiling::function]
     pub fn element_under(
         global_pos: Point<f64, Global>,


### PR DESCRIPTION
With "focus follows cursor" enabled, switching workspaces left keyboard focus on the newly-active workspace's previously-active window instead of the window under the pointer. Neither holding the pointer still nor moving it within that window corrected it — only a click did.

Focus-follows-cursor is implemented solely as an edge-triggered pointer motion handler that compares the element under the old vs. new pointer position. A workspace switch moves focus without any pointer motion, so the handler never runs, and the switch actions only call `Shell::activate()`. A click works because the button handler is level-triggered.

This adds `State::reconcile_focus_to_pointer()`, invoked from the four workspace-switch actions (`Workspace`, `LastWorkspace`, `NextWorkspace`, `PreviousWorkspace`) on success. When focus-follows-cursor is enabled and the pointer is ungrabbed, it focuses the window under the pointer on the destination workspace, and leaves focus untouched when the pointer is over empty space. `MoveToWorkspace`/`SendToWorkspace` are deliberately left alone — the moved window should follow and stay focused.

Fixes: pop-os/cosmic-epoch#3650

Tested on real hardware (Pop!_OS 24.04, COSMIC, Wayland, ThinkPad T490) and in continuous daily use since 2026-07-15.

<details>
<summary>Why it queries the destination workspace directly, how this relates to #1366 and #2396, and the test runs</summary>

It queries the destination workspace's layout directly via `Workspace::toplevel_element_under` rather than `State::element_under`: the switch animation is still in progress when the action handler runs, and `element_under` honours the animation offset, so it would resolve the pointer to the *outgoing* workspace's window, which `Common::refresh_focus` then reverts. The full reasoning is in the commit message.

**Related issues**

- #1366 asks for exactly this behaviour: *"the window under the cursor at the time of switching focus should become the focused window."* That is what this implements. The second option offered there — warping the cursor to the last focused window — is not implemented; a plain workspace switch performs no cursor warp.
- #2396 is **not** claimed to be fixed by this. It reports dead pointer hover after a switch plus clicks landing on the wrong workspace, and its reporter states that toggling focus-follows-cursor made no difference. This change only runs when `focus_follows_cursor` is enabled and touches neither pointer-motion delivery nor click routing.

**Test runs**, with the patched build installed as `/usr/bin/cosmic-comp`:

- Pointer held still over the left tile, switching to a workspace whose last-focused window is the right tile → focus lands on the window under the pointer.
- Hover the right tile, switch away, move the pointer left, switch back → focus lands on the left tile.
- `Super+Ctrl+Up`/`Down` (`NextWorkspace`/`PreviousWorkspace`) → focus follows the pointer.
- Pointer over empty space → focus is left untouched.
- Verified with `cursor_follows_focus` both disabled and enabled; a plain workspace switch performs no cursor warp.

**On the base, precisely.** That runtime testing was done on a build of `bb584aa`, the commit the installed package is built from. For this PR the change was rebased onto `master` (`f97a852`), where it applies cleanly and `cargo check --release` completes without warnings; the runtime checks above were not repeated on that newer base.

</details>

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
