### PR TITLE
image-copy: Fix panics on capture failure paths

### DIFF
--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -401,7 +401,8 @@ fn constraints_for_output(output: &Output, backend: &mut BackendData) -> Option<
             kms.target_node_for_output(output)
                 .or(*kms.primary_node.read().unwrap())
         })
-        .unwrap();
+        .inspect_err(|err| tracing::warn!(?err, "Couldn't use node for screencopy"))
+        .ok()?;
     Some(constraints_for_renderer(mode, renderer.as_mut()))
 }
 
@@ -423,7 +424,8 @@ fn constraints_for_toplevel(
 
             dma_node.or(*kms.primary_node.read().unwrap())
         })
-        .unwrap();
+        .inspect_err(|err| tracing::warn!(?err, "Couldn't use node for screencopy"))
+        .ok()?;
 
     Some(constraints_for_renderer(size, renderer.as_mut()))
 }

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -305,7 +305,7 @@ pub fn render_workspace_to_buffer(
         return;
     };
 
-    let mut output = workspace.output().clone();
+    let output = workspace.output().clone();
     let idx = shell.workspaces.idx_for_handle(&output, &handle).unwrap();
     std::mem::drop(shell);
 
@@ -317,7 +317,17 @@ pub fn render_workspace_to_buffer(
     let buffer_size = buffer_dimensions(&buffer).unwrap();
     if mode != Some(buffer_size) {
         let Some(constraints) = constraints_for_output(&output, &mut state.backend) else {
-            output.remove_session(session);
+            // Drop the workspace's owned Session so the client receives `stopped`.
+            if let Some(workspace) = state
+                .common
+                .shell
+                .write()
+                .workspaces
+                .space_for_handle_mut(&handle)
+            {
+                workspace.remove_session(session);
+            }
+            frame.fail(CaptureFailureReason::Stopped);
             return;
         };
         session.update_constraints(constraints);

--- a/src/wayland/handlers/image_copy_capture/user_data.rs
+++ b/src/wayland/handlers/image_copy_capture/user_data.rs
@@ -70,12 +70,9 @@ impl SessionHolder for Output {
     }
 
     fn remove_session(&mut self, session: &SessionRef) {
-        self.user_data()
-            .get::<ImageCopySessionsData>()
-            .unwrap()
-            .borrow_mut()
-            .sessions
-            .retain(|s| s != session);
+        if let Some(sessions) = self.user_data().get::<ImageCopySessionsData>() {
+            sessions.borrow_mut().sessions.retain(|s| s != session);
+        }
     }
 
     fn sessions(&self) -> Vec<SessionRef> {
@@ -103,12 +100,12 @@ impl SessionHolder for Output {
     }
 
     fn remove_cursor_session(&mut self, session: &CursorSessionRef) {
-        self.user_data()
-            .get::<ImageCopySessionsData>()
-            .unwrap()
-            .borrow_mut()
-            .cursor_sessions
-            .retain(|s| s != session);
+        if let Some(sessions) = self.user_data().get::<ImageCopySessionsData>() {
+            sessions
+                .borrow_mut()
+                .cursor_sessions
+                .retain(|s| s != session);
+        }
     }
 
     fn cursor_sessions(&self) -> Vec<CursorSessionRef> {
@@ -194,12 +191,9 @@ impl SessionHolder for CosmicSurface {
     }
 
     fn remove_session(&mut self, session: &SessionRef) {
-        self.user_data()
-            .get::<ImageCopySessionsData>()
-            .unwrap()
-            .borrow_mut()
-            .sessions
-            .retain(|s| s != session);
+        if let Some(sessions) = self.user_data().get::<ImageCopySessionsData>() {
+            sessions.borrow_mut().sessions.retain(|s| s != session);
+        }
     }
     fn sessions(&self) -> Vec<SessionRef> {
         self.user_data()
@@ -226,12 +220,12 @@ impl SessionHolder for CosmicSurface {
     }
 
     fn remove_cursor_session(&mut self, session: &CursorSessionRef) {
-        self.user_data()
-            .get::<ImageCopySessionsData>()
-            .unwrap()
-            .borrow_mut()
-            .cursor_sessions
-            .retain(|s| s != session);
+        if let Some(sessions) = self.user_data().get::<ImageCopySessionsData>() {
+            sessions
+                .borrow_mut()
+                .cursor_sessions
+                .retain(|s| s != session);
+        }
     }
 
     fn cursor_sessions(&self) -> Vec<CursorSessionRef> {


### PR DESCRIPTION
## Summary

Fixes two compositor-crash panics and a stuck-session bug in the
image-copy-capture failure handling.

**Workspace captures: session removed from the wrong holder.**
`render_workspace_to_buffer`'s constraints-failure path called
`output.remove_session()`, but workspace-scope sessions live in
`Workspace::image_copy`. If the output never hosted an output-scope capture,
the unguarded `ImageCopySessionsData` unwrap panicked — reachable by any
workspace screencast frame arriving while the output has no current mode
(e.g. it is being unplugged or disabled). Otherwise the `retain()` was a
silent no-op: the workspace's owned `Session` was never dropped, so the
client never received `stopped` and kept submitting frames to a dead
session, each failing as `unknown`. The session is now removed from the
workspace; dropping it stops the session and fails the frame as `stopped`.

**Unguarded holder unwraps.** `remove_session`/`remove_cursor_session` on
`Output` and `CosmicSurface` now tolerate a missing `ImageCopySessionsData`,
making removal idempotent (matching the existing `sessions()`/`remove_frame`
style).

**Renderer-creation failure during constraint negotiation.**
`constraints_for_output`/`constraints_for_toplevel` unwrapped
`offscreen_renderer()`, which can fail (e.g. after a GPU reset — a case the
render-path callers already handle gracefully since 9514b494). They now fail
the capture instead of panicking.

## Testing

The failure paths were verified against smithay's session/frame lifecycle:
dropping the workspace's owned `Session` fails its active frames as `stopped`
and sends `stopped`, and a `None` from the constraints functions produces a
stopped session at creation and is handled by the existing else-branches in
the render-path callers. Normal capture behaviour is unchanged — the diff
only touches failure paths.

## AI assistance

This work was developed with AI assistance (Claude Code); use of AI-generated
code is disclosed in the commit messages per the contribution guidelines. All
changes have been reviewed and are understood by the author.

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
