### PR TITLE
fix: treat unlocking the session as user activity

### DIFF
--- a/src/wayland/handlers/session_lock.rs
+++ b/src/wayland/handlers/session_lock.rs
@@ -46,6 +46,11 @@ impl SessionLockHandler for State {
         let mut shell = self.common.shell.write();
         shell.session_lock = None;
 
+        let seats = shell.seats.iter().cloned().collect::<Vec<_>>();
+        for seat in &seats {
+            self.common.idle_notifier_state.notify_activity(seat);
+        }
+
         for output in shell.outputs() {
             self.backend.schedule_render(output);
         }


### PR DESCRIPTION
**Steps to reproduce** (needs an unlock method that produces no input event — a fingerprint reader here; a smartcard should behave the same)

1. Set "turn off screen after" to a short value.
2. Lock the session and wait until the screen turns off.
3. Unlock with the fingerprint reader, without touching mouse or keyboard.

The session unlocks, but the screen stays off until an input event arrives. Depending on how the timeouts line up, the session can also lock itself again a few seconds later.

**Cause**

`SessionLockHandler::unlock` (`src/wayland/handlers/session_lock.rs`) drops the lock and schedules a render, but never calls into `IdleNotifierState`. Every other path that means "the user is here" goes through `notify_activity`, which is driven by input events — and a fingerprint unlock produces none. The idle clock therefore keeps running for the whole time the session was locked, and is already expired the moment the session comes back.

**Fix**

Notify activity for every seat in `unlock()`, which resets the timers exactly as an input event would.

**Testing**

On Pop!_OS COSMIC with a Synaptics fingerprint reader: lock, wait for the screen to switch off, then unlock by finger only — the display comes back **13 ms** after `session unlocked` and stays on, and the session does not lock itself again. Verified from the journal, with no mouse or keyboard input involved.

To be precise about what was tested where: the runtime testing was done on a build of `091583a` (the version currently packaged for me), and the patch has been running on my daily system since 2026-08-14. Against current `master` I have only run `cargo check --release`, which is clean. `src/wayland/handlers/session_lock.rs` is unchanged between the two commits, so the code under test is byte-identical.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
