### PR TITLE
fix: reach adjacent displays instead of switching workspaces

### DIFF
--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -13,6 +13,8 @@ pub struct WorkspaceConfig {
     pub action_on_typing: Action,
     #[serde(default = "default_wraparound")]
     pub workspace_wraparound: bool,
+    #[serde(default)]
+    pub edge_navigation: EdgeNavigation,
 }
 
 fn default_wraparound() -> bool {
@@ -26,8 +28,16 @@ impl Default for WorkspaceConfig {
             workspace_layout: WorkspaceLayout::default(),
             action_on_typing: Action::default(),
             workspace_wraparound: default_wraparound(),
+            edge_navigation: EdgeNavigation::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EdgeNavigation {
+    #[default]
+    SwitchWorkspace,
+    LockedSpaces,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/cosmic-comp-config/src/workspace.rs
+++ b/cosmic-comp-config/src/workspace.rs
@@ -14,7 +14,9 @@ pub struct WorkspaceConfig {
     #[serde(default = "default_wraparound")]
     pub workspace_wraparound: bool,
     #[serde(default)]
-    pub edge_navigation: EdgeNavigation,
+    pub focus_edge_navigation: EdgeNavigation,
+    #[serde(default)]
+    pub move_edge_navigation: EdgeNavigation,
 }
 
 fn default_wraparound() -> bool {
@@ -28,7 +30,8 @@ impl Default for WorkspaceConfig {
             workspace_layout: WorkspaceLayout::default(),
             action_on_typing: Action::default(),
             workspace_wraparound: default_wraparound(),
-            edge_navigation: EdgeNavigation::default(),
+            focus_edge_navigation: EdgeNavigation::default(),
+            move_edge_navigation: EdgeNavigation::default(),
         }
     }
 }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -678,19 +678,6 @@ impl State {
                             &self.common.event_loop_handle,
                         );
 
-                        if is_move_action
-                            && propagate
-                            && let Some((_, prev_output, prev_idx)) =
-                                shell.previous_workspace_idx.take()
-                            && prev_output == focused_output
-                        {
-                            let _ = shell.activate(
-                                &focused_output,
-                                prev_idx,
-                                WorkspaceDelta::new_shortcut(),
-                                &mut workspace_guard,
-                            );
-                        }
                         res
                     };
 
@@ -880,23 +867,6 @@ impl State {
                     .move_current_element(direction, seat);
                 match res {
                     MoveResult::MoveFurther(_move_further) => {
-                        if let Some(last_mod_serial) = seat.last_modifier_change_for(backend_id) {
-                            let mut shell = self.common.shell.write();
-                            if !shell
-                                .previous_workspace_idx
-                                .as_ref()
-                                .is_some_and(|(serial, _, _)| *serial == last_mod_serial)
-                            {
-                                let current_output = seat.active_output();
-                                let workspace_idx = shell.workspaces.active_num(&current_output).1;
-                                shell.previous_workspace_idx = Some((
-                                    last_mod_serial,
-                                    current_output.downgrade(),
-                                    workspace_idx,
-                                ));
-                            }
-                        }
-
                         let action = match self.common.config.cosmic_conf.workspaces.edge_navigation
                         {
                             EdgeNavigation::LockedSpaces => Action::MoveToOutput(direction),

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use cosmic_comp_config::{
     TileBehavior,
-    workspace::{EdgeNavigation, WorkspaceLayout},
+    workspace::{EdgeNavigation, WorkspaceLayout, WorkspaceMode},
 };
 use cosmic_config::ConfigSet;
 use cosmic_settings_config::shortcuts;
@@ -360,6 +360,27 @@ impl State {
                     return;
                 };
 
+                let entry_output = if propagate
+                    && self.common.config.cosmic_conf.workspaces.workspace_mode
+                        == WorkspaceMode::Global
+                    && let Some(pressed) = pattern.inferred_direction()
+                {
+                    let entry_direction = match pressed {
+                        Direction::Left => Direction::Right,
+                        Direction::Right => Direction::Left,
+                        Direction::Up => Direction::Down,
+                        Direction::Down => Direction::Up,
+                    };
+                    let shell = self.common.shell.read();
+                    let mut output = focused_output.clone();
+                    while let Some(next) = shell.next_output(&output, entry_direction) {
+                        output = next.clone();
+                    }
+                    output
+                } else {
+                    focused_output.clone()
+                };
+
                 let res = {
                     let mut shell = self.common.shell.write();
                     shell
@@ -371,7 +392,7 @@ impl State {
                         .and_then(|workspace| {
                             shell.move_current(
                                 seat,
-                                (&focused_output, Some(workspace)),
+                                (&entry_output, Some(workspace)),
                                 matches!(x, Action::MoveToNextWorkspace),
                                 direction,
                                 &mut self.common.workspace_state.update(),
@@ -454,6 +475,27 @@ impl State {
                     return;
                 };
 
+                let entry_output = if propagate
+                    && self.common.config.cosmic_conf.workspaces.workspace_mode
+                        == WorkspaceMode::Global
+                    && let Some(pressed) = pattern.inferred_direction()
+                {
+                    let entry_direction = match pressed {
+                        Direction::Left => Direction::Right,
+                        Direction::Right => Direction::Left,
+                        Direction::Up => Direction::Down,
+                        Direction::Down => Direction::Up,
+                    };
+                    let shell = self.common.shell.read();
+                    let mut output = focused_output.clone();
+                    while let Some(next) = shell.next_output(&output, entry_direction) {
+                        output = next.clone();
+                    }
+                    output
+                } else {
+                    focused_output.clone()
+                };
+
                 let res = {
                     let mut shell = self.common.shell.write();
                     shell
@@ -465,7 +507,7 @@ impl State {
                         .and_then(|workspace| {
                             shell.move_current(
                                 seat,
-                                (&focused_output, Some(workspace)),
+                                (&entry_output, Some(workspace)),
                                 matches!(x, Action::MoveToPreviousWorkspace),
                                 direction,
                                 &mut self.common.workspace_state.update(),

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -809,7 +809,7 @@ impl State {
                                 .config
                                 .cosmic_conf
                                 .workspaces
-                                .edge_navigation
+                                .focus_edge_navigation
                             {
                                 EdgeNavigation::LockedSpaces => Action::SwitchOutput(direction),
                                 EdgeNavigation::SwitchWorkspace => {
@@ -867,7 +867,12 @@ impl State {
                     .move_current_element(direction, seat);
                 match res {
                     MoveResult::MoveFurther(_move_further) => {
-                        let action = match self.common.config.cosmic_conf.workspaces.edge_navigation
+                        let action = match self
+                            .common
+                            .config
+                            .cosmic_conf
+                            .workspaces
+                            .move_edge_navigation
                         {
                             EdgeNavigation::LockedSpaces => Action::MoveToOutput(direction),
                             EdgeNavigation::SwitchWorkspace => {

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -13,7 +13,10 @@ use crate::{
         handlers::xdg_activation::ActivationContext, protocols::workspace::WorkspaceUpdateGuard,
     },
 };
-use cosmic_comp_config::{TileBehavior, workspace::WorkspaceLayout};
+use cosmic_comp_config::{
+    TileBehavior,
+    workspace::{EdgeNavigation, WorkspaceLayout},
+};
 use cosmic_config::ConfigSet;
 use cosmic_settings_config::shortcuts;
 use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection};
@@ -772,19 +775,40 @@ impl State {
                                 }
                             }
 
-                            let action = match (
-                                direction,
-                                self.common.config.cosmic_conf.workspaces.workspace_layout,
-                            ) {
-                                (Direction::Left, WorkspaceLayout::Horizontal)
-                                | (Direction::Up, WorkspaceLayout::Vertical) => {
-                                    Action::PreviousWorkspace
+                            let action = match self
+                                .common
+                                .config
+                                .cosmic_conf
+                                .workspaces
+                                .edge_navigation
+                            {
+                                EdgeNavigation::LockedSpaces => Action::SwitchOutput(direction),
+                                EdgeNavigation::SwitchWorkspace => {
+                                    let output_in_direction_has_windows = {
+                                        let shell = self.common.shell.read();
+                                        let current_output = seat.active_output();
+                                        shell
+                                            .next_output(&current_output, direction)
+                                            .and_then(|output| shell.active_space(output))
+                                            .is_some_and(|workspace| !workspace.is_empty())
+                                    };
+
+                                    match (
+                                        direction,
+                                        self.common.config.cosmic_conf.workspaces.workspace_layout,
+                                        output_in_direction_has_windows,
+                                    ) {
+                                        (Direction::Left, WorkspaceLayout::Horizontal, false)
+                                        | (Direction::Up, WorkspaceLayout::Vertical, false) => {
+                                            Action::PreviousWorkspace
+                                        }
+                                        (Direction::Right, WorkspaceLayout::Horizontal, false)
+                                        | (Direction::Down, WorkspaceLayout::Vertical, false) => {
+                                            Action::NextWorkspace
+                                        }
+                                        _ => Action::SwitchOutput(direction),
+                                    }
                                 }
-                                (Direction::Right, WorkspaceLayout::Horizontal)
-                                | (Direction::Down, WorkspaceLayout::Vertical) => {
-                                    Action::NextWorkspace
-                                }
-                                _ => Action::SwitchOutput(direction),
                             };
 
                             self.handle_shortcut_action(
@@ -831,19 +855,35 @@ impl State {
                             }
                         }
 
-                        let action = match (
-                            direction,
-                            self.common.config.cosmic_conf.workspaces.workspace_layout,
-                        ) {
-                            (Direction::Left, WorkspaceLayout::Horizontal)
-                            | (Direction::Up, WorkspaceLayout::Vertical) => {
-                                Action::MoveToPreviousWorkspace
+                        let action = match self.common.config.cosmic_conf.workspaces.edge_navigation
+                        {
+                            EdgeNavigation::LockedSpaces => Action::MoveToOutput(direction),
+                            EdgeNavigation::SwitchWorkspace => {
+                                let output_exists_in_direction =
+                                    seat.focused_output().is_some_and(|output| {
+                                        self.common
+                                            .shell
+                                            .read()
+                                            .next_output(&output, direction)
+                                            .is_some()
+                                    });
+
+                                match (
+                                    direction,
+                                    self.common.config.cosmic_conf.workspaces.workspace_layout,
+                                    output_exists_in_direction,
+                                ) {
+                                    (Direction::Left, WorkspaceLayout::Horizontal, false)
+                                    | (Direction::Up, WorkspaceLayout::Vertical, false) => {
+                                        Action::MoveToPreviousWorkspace
+                                    }
+                                    (Direction::Right, WorkspaceLayout::Horizontal, false)
+                                    | (Direction::Down, WorkspaceLayout::Vertical, false) => {
+                                        Action::MoveToNextWorkspace
+                                    }
+                                    _ => Action::MoveToOutput(direction),
+                                }
                             }
-                            (Direction::Right, WorkspaceLayout::Horizontal)
-                            | (Direction::Down, WorkspaceLayout::Vertical) => {
-                                Action::MoveToNextWorkspace
-                            }
-                            _ => Action::MoveToOutput(direction),
                         };
 
                         self.handle_shortcut_action(


### PR DESCRIPTION
A few fixes for directional focus/move on stacked multi display setups (diff PR ([#2150](https://github.com/pop-os/cosmic-settings/pull/2150)) on cosmic-settings with the toggles).

Current focus behaviour is that: from window B or C, using super + down arrow (change focus) targeting window D (which is in another monitor) moves me to another workspace. The expected behaviour is that window D is focused.
Same kind of thing for moving windows. Attempting to move window B down and next to window D, moves window B in a new workspace and it lands on monitor A. The expected behaviour is that it moves next to window D.

<img width="916" height="791" alt="635990152-a399dba2-a111-468b-96d1-51a2d1e73aef" src="https://github.com/user-attachments/assets/7bbbecc4-0836-40be-ad36-86cd0daf69a9" />

The PR fixes the things listed above and a few nice to have things:

- moves that fall through, enter from the opposite edge, like a continuous strip effect. 
- added config for controlling which action (move or focus) result in a workspace change.

Related discussions:
[#2238](https://github.com/pop-os/cosmic-epoch/issues/2238)
https://github.com/pop-os/cosmic-epoch/discussions/1767


---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

