### PR TITLE
Fix pointer constraints in all (?) cases

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -30,7 +30,10 @@ use smithay::{
         winit::event_loop::pump_events::PumpStatus,
     },
     utils::Transform,
-    wayland::{dmabuf::DmabufFeedbackBuilder, presentation::Refresh},
+    wayland::{
+        dmabuf::DmabufFeedbackBuilder, presentation::Refresh,
+        relative_pointer::RelativePointerManagerState,
+    },
 };
 use std::{borrow::BorrowMut, cell::RefCell, time::Duration};
 use tracing::{error, info, warn};
@@ -242,6 +245,11 @@ pub fn init_backend(
         }
         state.common.refresh();
     }
+
+    // Create relative pointer global.
+    // Without it Xwayland disables pointer warp emulation entirely, so games
+    // relying on relative motion get none when running nested.
+    RelativePointerManagerState::new::<State>(dh);
 
     if state.common.with_xwayland {
         state.launch_xwayland(None);

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -37,7 +37,10 @@ use smithay::{
         wayland_server::DisplayHandle,
     },
     utils::{DeviceFd, Transform},
-    wayland::{dmabuf::DmabufFeedbackBuilder, presentation::Refresh},
+    wayland::{
+        dmabuf::DmabufFeedbackBuilder, presentation::Refresh,
+        relative_pointer::RelativePointerManagerState,
+    },
 };
 use std::{borrow::BorrowMut, cell::RefCell, os::unix::io::OwnedFd, time::Duration};
 use tracing::{debug, error, info, warn};
@@ -386,6 +389,11 @@ pub fn init_backend(
         }
         state.common.refresh();
     }
+
+    // Create relative pointer global.
+    // Without it Xwayland disables pointer warp emulation entirely, so games
+    // relying on relative motion get none when running nested.
+    RelativePointerManagerState::new::<State>(dh);
 
     if state.common.with_xwayland {
         state.launch_xwayland(None);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -611,28 +611,7 @@ impl State {
                     if let Some((under, surface_location)) = new_under
                         .and_then(|(target, loc)| Some((target.wl_surface()?.into_owned(), loc)))
                     {
-                        let shell = self.common.shell.read();
-                        let is_focused = seat
-                            .get_keyboard()
-                            .and_then(|k| k.current_focus())
-                            .is_some_and(|f| f.has_surface(&shell, &under));
-
-                        if is_focused {
-                            with_pointer_constraint(&under, &ptr, |constraint| match constraint {
-                                Some(constraint) if !constraint.is_active() => {
-                                    let region = match &*constraint {
-                                        PointerConstraint::Locked(locked) => locked.region(),
-                                        PointerConstraint::Confined(confined) => confined.region(),
-                                    };
-                                    let point =
-                                        (ptr.current_location() - surface_location).to_i32_floor();
-                                    if region.is_none_or(|region| region.contains(point)) {
-                                        constraint.activate();
-                                    }
-                                }
-                                _ => {}
-                            });
-                        }
+                        self.maybe_activate_pointer_constraint(&seat, &under, surface_location);
                     }
 
                     let mut shell = self.common.shell.write();

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -374,11 +374,27 @@ fn update_focus_state(
             && let Some(surface) = old_target.wl_surface()
             && let Some(pointer) = seat.get_pointer()
         {
-            with_pointer_constraint(&surface, &pointer, |constraint| {
-                if let Some(constraint) = constraint {
-                    constraint.deactivate();
-                }
+            // Constraints are oneshot in the common case (Xwayland), so only
+            // deactivate if the surface actually lost focus eligibility. An
+            // `Element` to `Fullscreen` transition of the same window — a game
+            // entering fullscreen — must not destroy its active constraint.
+            let shell = state.common.shell.read(); // Grabs a read lock on the shell
+            let still_eligible = target.is_some_and(|new_target| {
+                new_target.has_surface(&shell, &surface)
+                    || state
+                        .common
+                        .xwayland_constraint_focus_override(new_target, &surface)
             });
+            drop(shell); // Drops the read lock on the shell as early as possible
+
+            if !still_eligible {
+                // Sirface is not eligible for constraints anymore, let's deactivate it
+                with_pointer_constraint(&surface, &pointer, |constraint| {
+                    if let Some(constraint) = constraint {
+                        constraint.deactivate();
+                    }
+                });
+            }
         }
 
         if should_update_cursor
@@ -762,6 +778,10 @@ fn update_pointer_focus(state: &mut State, seat: &Seat<State>) {
         drop(shell);
 
         if pointer.current_focus().as_ref() != under.as_ref().map(|(target, _)| target) {
+            let entered = under
+                .as_ref()
+                .and_then(|(target, loc)| Some((target.wl_surface()?.into_owned(), *loc)));
+
             pointer.motion(
                 state,
                 under,
@@ -771,6 +791,10 @@ fn update_pointer_focus(state: &mut State, seat: &Seat<State>) {
                     time: state.common.clock.now().as_millis(),
                 },
             );
+
+            if let Some((surface, location)) = entered {
+                state.maybe_activate_pointer_constraint(seat, &surface, location);
+            }
         }
     }
 }

--- a/src/wayland/handlers/pointer_constraints.rs
+++ b/src/wayland/handlers/pointer_constraints.rs
@@ -1,14 +1,72 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{shell::CosmicSurface, state::State, utils::prelude::*};
+use ron::de::Position;
 use smithay::{
-    input::pointer::PointerHandle,
+    input::{Seat, pointer::PointerHandle},
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     utils::{Logical, Point},
-    wayland::{pointer_constraints::PointerConstraintsHandler, seat::WaylandFocus},
+    wayland::{
+        pointer_constraints::{PointerConstraint, PointerConstraintsHandler},
+        seat::WaylandFocus,
+    },
 };
 
 pub use smithay::wayland::pointer_constraints::{PointerConstraintRef, with_pointer_constraint};
+
+impl State {
+    /// Activate the pointer constraint of `surface`, if any, now that the
+    /// pointer is over it at `surface_location`.
+    ///
+    /// Constraints are deactivated whenever the surface loses pointer focus,
+    /// which happens for reasons entirely outside the client's control (a
+    /// window resize moving the pointer out, for example). Every path that
+    /// gives a surface pointer focus back therefore has to offer the
+    /// constraint another chance to activate, or a game stays without
+    /// relative motion until the user happens to move the mouse.
+    pub fn maybe_activate_pointer_constraint(
+        &self,
+        seat: &Seat<State>,
+        surface: &WlSurface,
+        surface_location: Point<f64, Logical>,
+    ) {
+        let Some(pointer) = seat.get_pointer() else {
+            return;
+        };
+
+        let shell = self.common.shell.read(); // Grabs a read lock on the shell
+        let is_focused = seat
+            .get_keyboard()
+            .and_then(|k| k.current_focus())
+            .is_some_and(|f| {
+                f.has_surface(&shell, surface)
+                    || self.common.xwayland_constraint_focus_override(&f, surface)
+            });
+        drop(shell); // Drop the shell lock as early as possible
+
+        if !is_focused {
+            // No point in activating a constraint for a surface that's not focused.
+            return;
+        }
+
+        with_pointer_constraint(surface, &pointer, |constraint| {
+            let Some(constraint) = constraint else {
+                return;
+            };
+            if constraint.is_active() {
+                return;
+            }
+            let region = match &*constraint {
+                PointerConstraint::Locked(locked) => locked.region(),
+                PointerConstraint::Confined(confined) => confined.region(),
+            };
+            let point = (pointer.current_location() - surface_location).to_i32_floor();
+            if region.is_none_or(|region| region.contains(point)) {
+                constraint.activate();
+            }
+        });
+    }
+}
 
 impl PointerConstraintsHandler for State {
     fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
@@ -21,58 +79,41 @@ impl PointerConstraintsHandler for State {
             .find(|s| s.get_pointer().as_ref() == Some(pointer))
             .cloned();
 
-        let (is_under, is_focused, surface_location) = if let Some(seat) = seat {
-            seat.set_pointer_constraint_hint(None);
-            let current_output = seat.active_output();
-            let position = seat.get_pointer().unwrap().current_location().as_global();
-            let shell = self.common.shell.read();
-            let under = State::surface_under(position, &current_output, &shell);
-            let mut surface_location = None;
+        let Some(seat) = seat else {
+            // The seat is None, so we can't get the pointer. We can't set the constraint.
+            return;
+        };
+        seat.set_pointer_constraint_hint(None);
 
-            let is_under = if let Some((target, target_loc)) = under
-                && let Some(under_surface) = target.wl_surface()
-            {
-                if *under_surface == *surface {
-                    surface_location = Some(target_loc);
-                    true
-                } else {
-                    CosmicSurface::surface_tree_offset(surface, &under_surface).is_some_and(
-                        |offset| {
-                            surface_location = Some(target_loc - offset.to_f64().as_global());
-                            true
-                        },
-                    )
-                }
-            } else {
-                false
-            };
-
-            let is_focused = seat
-                .get_keyboard()
-                .and_then(|k| k.current_focus())
-                .is_some_and(|f| f.has_surface(&shell, surface));
-
-            (is_under, is_focused, surface_location)
+        let current_output = seat.active_output();
+        let pointer = seat.get_pointer();
+        let position;
+        if let Some(pointer) = pointer {
+            position = pointer.current_location().as_global();
         } else {
-            (false, false, None)
+            // The pointer is None, so we can't get its location. So we can't set the constraint.
+            return;
+        }
+        let shell = self.common.shell.read(); // Grabs a read lock on the shell
+        let under = State::surface_under(position, &current_output, &shell);
+        drop(shell); // Drops the read lock on the shell as soon as possible
+
+        // Only the surface actually under the pointer may hold it captive.
+        let surface_location = if let Some((target, target_loc)) = under
+            && let Some(under_surface) = target.wl_surface()
+        {
+            if *under_surface == *surface {
+                Some(target_loc)
+            } else {
+                CosmicSurface::surface_tree_offset(surface, &under_surface)
+                    .map(|offset| target_loc - offset.to_f64().as_global())
+            }
+        } else {
+            None
         };
 
-        if is_focused && is_under {
-            with_pointer_constraint(surface, pointer, |constraint| {
-                if let Some(constraint) = constraint {
-                    if let Some(region) = constraint.region() {
-                        if let Some(surface_location) = surface_location
-                            && let position = pointer.current_location()
-                            && let point = (position - surface_location.as_logical()).to_i32_floor()
-                            && region.contains(point)
-                        {
-                            constraint.activate();
-                        }
-                    } else {
-                        constraint.activate();
-                    }
-                }
-            });
+        if let Some(surface_location) = surface_location {
+            self.maybe_activate_pointer_constraint(&seat, surface, surface_location.as_logical());
         }
     }
 

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -33,7 +33,10 @@ use smithay::{
     },
     desktop::space::SpaceElement,
     input::{keyboard::ModifiersState, pointer::CursorIcon},
-    reexports::{wayland_server::Client, x11rb::protocol::xproto::Window as X11Window},
+    reexports::{
+        wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
+        x11rb::protocol::xproto::Window as X11Window,
+    },
     utils::{
         Buffer as BufferCoords, Logical, Point, Rectangle, SERIAL_COUNTER, Serial, Size, Transform,
     },
@@ -290,6 +293,31 @@ impl XWaylandState {
 }
 
 impl Common {
+    /// Whether `surface` should be considered keyboard-focused for the purpose
+    /// of activating pointer constraints, even though it is not part of the
+    /// focused element's surface tree.
+    ///
+    /// X11 clients share a single input domain: Xwayland routes keyboard input
+    /// to the right window internally (following X input focus), independent of
+    /// which of its surfaces holds the Wayland keyboard focus. Games commonly
+    /// grab the pointer on a different X window than the focused one — e.g. an
+    /// override-redirect fullscreen window, which can never take our keyboard
+    /// focus. Refusing to activate the constraint in that case leaves such
+    /// games without any relative pointer motion.
+    pub fn xwayland_constraint_focus_override(
+        &self,
+        focus: &KeyboardFocusTarget,
+        surface: &WlSurface,
+    ) -> bool {
+        self.xwayland_state
+            .as_ref()
+            .and_then(|xstate| Some((&xstate.client, xstate.xwm.as_ref()?)))
+            .is_some_and(|(x_client, xwm)| {
+                focus.is_xwm(xwm.id())
+                    && surface.client().is_some_and(|client| client == *x_client)
+            })
+    }
+
     pub fn has_x_keyboard_focus(&self, xwmid: XwmId) -> bool {
         let keyboard = self
             .shell


### PR DESCRIPTION
This is a bit of a tricky PR for me. I've been struggling since the partial (to me at least) fix introduced in https://github.com/pop-os/cosmic-comp/pull/2357 (Thanks @skygrango !) seemed to work fine "sometimes", but I still could reproduce the Helldivers 2 "mouse is stuck" bug somewhat often.

So I took it onto myself to, before attempting this branch, try to come up with a reproducer test. I have produced such a reproducer test in a separate repo (the reproducer test did leverage AI, to hook into the Wayland protocol and analyse what is going on). The reproducer code is: https://github.com/chrisglass/pointer-lock-test

Armed with a reliable reproducer, this is my attempt to solve the issue once and for all. 
Most of the issues stem from mouse window constraints, that get set/unset slightly differently in the existing code, and depend largely on where in the tree the surface was at the particular moment the change of e.g. fullscreen happened.

One thing I am unsure of (honestly): initializing RelativePointerManagerState *seemed* to help, but now removing the lines doesn't make the tests fail, and I can't reproduce the failure/success manually. I didn't measure any noticeable impact... but decided to keep it since I am almost sure it caused a failure before. I've played around with it for so long and the reproducer is so unreliable manually that I am honestly unsure now.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

