### PR TITLE
fix(kms): survive GPU resets instead of taking the whole session down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,6 +4819,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 [[package]]
 name = "smithay"
 version = "0.7.0"
+source = "git+https://github.com/gustavx404/smithay.git?rev=65150b53#65150b5366ad25ceac82a7147f8164b9b639016a"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,7 +4819,6 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/smithay/smithay.git?rev=5fb12b8#5fb12b87407b3680135c45d94214c5f1b1d0fbea"
 dependencies = [
  "aliasable",
  "appendlist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,4 +145,4 @@ lto = "fat"
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { git = "https://github.com/smithay/smithay.git", rev = "5fb12b8" }
+smithay = { path = "../smithay" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,4 +145,4 @@ lto = "fat"
 cosmic-protocols = { git = "https://github.com/pop-os//cosmic-protocols", branch = "main" }
 
 [patch.crates-io]
-smithay = { path = "../smithay" }
+smithay = { git = "https://github.com/gustavx404/smithay.git", rev = "65150b53" }

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -456,6 +456,17 @@ impl State {
                 Some(reusable),
             )?;
 
+            // NOTE: deliberately *not* treating `!device_fd().is_privileged()` as a failure
+            // here. On a libseat/logind session the compositor never acquires the master lock
+            // via `drmSetMaster` itself - logind owns the device and hands out an fd that is
+            // already usable for modesetting, so `DrmDeviceFd::new`'s acquisition attempt is
+            // expected to fail and `privileged` is `false` during completely healthy operation
+            // (verified live: every cosmic-comp start on this session logs "assuming
+            // unprivileged mode" and drives the display fine). Bailing on it turned every GPU
+            // context-loss recovery into an unconditional failure, which then exited the
+            // compositor and tore down the whole session - closing every client app and leaving
+            // a long black screen - instead of recovering in place.
+
             if let Some(guard) = syncobj_guard {
                 let import_device = new_device.drm.device().device_fd().clone();
                 if supports_syncobj_eventfd(&import_device) {

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -79,6 +79,14 @@ pub struct KmsState {
 
     pub syncobj_state: Option<DrmSyncobjState>,
     pub dmabuf_global: Option<DmabufGlobal>,
+
+    /// Physical DRM devices (keyed the same way as `drm_devices`) currently being reopened in
+    /// response to a lost GPU context (see `SurfaceCommand::ContextLost`). Prevents firing a
+    /// second, redundant `reopen_device()` for the same physical device if multiple outputs on
+    /// that GPU report context loss concurrently - `reopen_device()` already tears down and
+    /// rebuilds every output on the device, so a second concurrent call would just race the
+    /// first one over the same DRM/EGL state.
+    pub recovering_devices: HashSet<DrmNode>,
 }
 
 pub struct KmsGuard<'a> {
@@ -137,6 +145,7 @@ pub fn init_backend(
 
         syncobj_state: None,
         dmabuf_global: None,
+        recovering_devices: HashSet::new(),
     });
 
     // manually add already present gpus

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -28,7 +28,7 @@ use smithay::{
             gbm::{GbmAllocator, GbmBuffer},
         },
         drm::{
-            DrmDeviceFd, DrmEventMetadata, DrmEventTime, DrmNode, VrrSupport,
+            DrmDeviceFd, DrmEventMetadata, DrmEventTime, DrmNode, NodeType, VrrSupport,
             compositor::{
                 BlitFrameResultError, FrameError, FrameFlags, PrimaryPlaneElement,
                 RenderFrameResult,
@@ -51,7 +51,8 @@ use smithay::{
                 },
             },
             gles::{
-                GlesRenderbuffer, GlesRenderer, GlesTexture, Uniform, element::TextureShaderElement,
+                GlesError, GlesRenderbuffer, GlesRenderer, GlesTexture, Uniform,
+                element::TextureShaderElement,
             },
             glow::GlowRenderer,
             multigpu::{ApiDevice, Error as MultiError, GpuManager},
@@ -128,6 +129,14 @@ pub struct Surface {
     dpms: bool,
 }
 
+/// Cap on consecutive redraw failures before an output gives up retrying
+/// entirely, rather than retrying forever against a GPU/driver that never
+/// recovers (e.g. EGL context recreation failing deterministically after a
+/// GPU reset with VRAM loss). Bounds both the retry loop itself and, since
+/// no further redraw attempts are made once this is hit, the associated
+/// per-attempt log volume.
+const MAX_CONSECUTIVE_RENDER_FAILURES: u32 = 5;
+
 pub struct SurfaceThreadState {
     // rendering
     api: GpuManager<GbmGlowBackend<DrmDeviceFd>>,
@@ -142,6 +151,22 @@ pub struct SurfaceThreadState {
     timings: Timings,
     frame_callback_seq: usize,
     thread_sender: Sender<SurfaceCommand>,
+    /// Number of consecutive failed redraw attempts, used to back off retries
+    /// instead of hammering a broken GPU/driver in a tight loop.
+    consecutive_render_failures: u32,
+    /// Set once `consecutive_render_failures` exceeds `MAX_CONSECUTIVE_RENDER_FAILURES`,
+    /// so this output stops scheduling further redraws. A GPU/driver that fails every
+    /// retry (e.g. EGL context recreation impossible after VRAM loss) would otherwise
+    /// retry forever, which floods the log and clients reconnecting against a
+    /// never-rendering compositor without ever making progress.
+    render_permanently_failed: bool,
+    /// Set after this output has sent a `SurfaceCommand::ContextLost` for the current
+    /// loss event and is awaiting `reopen_device()` on the main thread. While set, further
+    /// context-lost redraw failures do NOT re-increment `consecutive_render_failures` or
+    /// re-send the recovery request: `reopen_device()` tears down and rebuilds this very
+    /// thread (`drop_and_join`), so any retries issued here before that happens would only
+    /// race the in-flight recovery and can spuriously trip the `give_up_and_exit` cap.
+    context_lost_reported: bool,
 
     output: Output,
     mirroring: Option<Output>,
@@ -227,6 +252,56 @@ pub enum ThreadCommand {
 pub enum SurfaceCommand {
     SendFrames(usize),
     RenderStates(RenderElementStates),
+    ContextLost(DrmNode),
+}
+
+/// Sentinel status used for `context_lost_status()`'s `EGL_CONTEXT_LOST` case, where no
+/// `glGetGraphicsResetStatus` code is available (the failure surfaced via `eglMakeCurrent`
+/// instead). Matches the raw `EGL_CONTEXT_LOST` enum value so it reads unambiguously in logs
+/// next to the `GL_*_CONTEXT_RESET` codes (0x8252-0x8254) `GlesError::ContextLost` carries.
+const EGL_CONTEXT_LOST_STATUS: u32 = 0x300e;
+
+/// Walks an error's `source()` chain looking for a `GlesError::ContextLost` (context loss
+/// detected via a GL reset-status query), or a `GlesError::ContextActivationError` wrapping
+/// `EGL_CONTEXT_LOST` (context loss surfaced via `eglMakeCurrent` failing instead) — either
+/// indicates the GPU was reset (e.g. VRAM lost) and the EGL context is dead.
+fn context_lost_status(err: &(dyn std::error::Error + 'static)) -> Option<u32> {
+    let mut source = Some(err);
+    while let Some(err) = source {
+        if let Some(gles_err) = err.downcast_ref::<GlesError>() {
+            match gles_err {
+                GlesError::ContextLost(status) => return Some(*status),
+                GlesError::ContextActivationError(make_current_err)
+                    if make_current_err.is_context_lost() =>
+                {
+                    return Some(EGL_CONTEXT_LOST_STATUS);
+                }
+                _ => {}
+            }
+        }
+        source = err.source();
+    }
+    None
+}
+
+/// How many times to retry reopening the DRM device after a GPU context loss before giving up
+/// and exiting the compositor (which closes every client app - see `give_up_and_exit`).
+const REOPEN_DEVICE_ATTEMPTS: u32 = 3;
+/// Base delay between reopen attempts, multiplied by the attempt number.
+const REOPEN_DEVICE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Gives up on recovering after repeated redraw failures and exits the whole compositor
+/// process, rather than leaving it running with a permanently-blank output.
+///
+/// `cosmic-session` already supervises and restarts `cosmic-comp` on any exit (observed:
+/// restarts within milliseconds). A fresh process re-establishes EGL/DRM state from scratch,
+/// which has proven far more reliable than in-process recovery: `recreate_node()` deterministically
+/// fails to reacquire an EGL context after a hard GPU reset with VRAM loss (`Unable to find
+/// matching egl device for ...`), so retrying it forever just wastes ~2s per attempt while the
+/// output stays dead anyway. Uses `std::process::exit` rather than `panic!`: a panic in a
+/// surface thread only unwinds that thread and would not bring down the rest of the compositor.
+fn give_up_and_exit() -> ! {
+    std::process::exit(1)
 }
 
 #[derive(Debug, Default)]
@@ -328,6 +403,92 @@ impl Surface {
                                 Some(feedback)
                             }
                         });
+                }
+                Event::Msg(SurfaceCommand::ContextLost(node)) => {
+                    // `update_egl()`-only recreation (the previous approach here) fails
+                    // deterministically after a hard GPU reset with VRAM loss ("Unable to
+                    // find matching egl device for ..."): it only rebuilds the EGL context,
+                    // not the underlying DRM device fd, and the latter is what's actually
+                    // unusable post-reset. `reopen_device()` is the primitive that already
+                    // solves this exact error for udev hotplug (`device_changed`'s retry
+                    // path below) - reuse it here instead of a second, narrower mechanism.
+                    if !state.backend.kms().recovering_devices.insert(dev_node) {
+                        // A recovery for this physical device (there may be several outputs
+                        // on it) is already in flight from another output's ContextLost
+                        // message; reopen_device() already rebuilds every output on the
+                        // device, so let that attempt finish rather than racing a second
+                        // concurrent teardown/rebuild over the same DRM/EGL state.
+                        trace!(?node, ?dev_node, "GPU context lost, recovery already in flight");
+                        return;
+                    }
+                    warn!(?node, ?dev_node, "GPU context lost, reopening DRM device");
+                    let path = dev_node
+                        .dev_path_with_type(NodeType::Primary)
+                        .or_else(|| dev_node.dev_path());
+                    let result = match path {
+                        Some(path) => {
+                            let dh = state.common.display_handle.clone();
+                            // Retry a couple of times before giving up: failing here exits the
+                            // compositor, which closes every client app, so a single transient
+                            // failure (the device still settling right after a reset) is worth
+                            // a second chance. Bounded and short so an actually-dead device
+                            // still gives up quickly instead of hanging on a black screen.
+                            let mut attempt = 1;
+                            loop {
+                                match state.reopen_device(dev_node.dev_id(), &path, &dh) {
+                                    Ok(outputs) => break Ok(outputs),
+                                    Err(err) if attempt < REOPEN_DEVICE_ATTEMPTS => {
+                                        warn!(
+                                            ?dev_node,
+                                            "Reopening DRM device failed (attempt {}/{}): {:#}",
+                                            attempt,
+                                            REOPEN_DEVICE_ATTEMPTS,
+                                            err
+                                        );
+                                        std::thread::sleep(REOPEN_DEVICE_RETRY_DELAY * attempt);
+                                        attempt += 1;
+                                    }
+                                    Err(err) => break Err(err),
+                                }
+                            }
+                        }
+                        None => Err(anyhow::anyhow!(
+                            "Could not determine device path for {}",
+                            dev_node
+                        )),
+                    };
+                    state.backend.kms().recovering_devices.remove(&dev_node);
+                    match result {
+                        Ok(_outputs) => {
+                            info!(?dev_node, "Recovered DRM device after GPU context loss");
+                            if let Err(err) = state.refresh_output_config() {
+                                warn!(
+                                    "Unable to refresh output config after device recovery: {}",
+                                    err
+                                );
+                            }
+                            state.common.refresh();
+                        }
+                        Err(err) => {
+                            // `reopen_device()` already retries master-lock acquisition
+                            // internally (see `DrmDeviceFd::new`'s bounded backoff); a failure
+                            // here means that retry budget is exhausted. There is no further
+                            // recovery path on this thread, and continuing to run leaves the
+                            // device silently unprivileged/broken (no modesetting, clients
+                            // failing to import textures, eventual wgpu/Vulkan panics in
+                            // clients) with nothing left to trigger a retry - previously
+                            // observed live as an indefinite broken-but-alive session. Exit so
+                            // cosmic-session's already-proven-fast respawn (~ms) takes over
+                            // with fresh DRM/EGL state instead.
+                            error!(
+                                ?dev_node,
+                                "Failed to reopen DRM device after GPU context loss: {:#}. \
+                                 Exiting so cosmic-session can restart the compositor cleanly.",
+                                err
+                            );
+                            give_up_and_exit();
+                        }
+                    }
                 }
                 Event::Closed => {}
             })
@@ -541,6 +702,9 @@ fn surface_thread(
         timings: Timings::new(None, None, false, target_node),
         frame_callback_seq: 0,
         thread_sender,
+        consecutive_render_failures: 0,
+        render_permanently_failed: false,
+        context_lost_reported: false,
 
         output,
         mirroring: None,
@@ -918,6 +1082,10 @@ impl SurfaceThreadState {
             return;
         };
 
+        if self.render_permanently_failed {
+            return;
+        };
+
         if let QueueState::WaitingForVBlank { .. } = &self.state {
             // We're waiting for VBlank, request a redraw afterwards.
             self.state = QueueState::WaitingForVBlank {
@@ -941,12 +1109,21 @@ impl SurfaceThreadState {
         let estimated_presentation = self.timings.next_presentation_time(&self.clock);
         let render_start = self.timings.next_render_time(&self.clock);
 
+        // Back off after repeated failures, so a persistently broken GPU/driver
+        // (e.g. a context that keeps failing to recover) doesn't spin retrying
+        // at zero delay, which pegs a CPU core and floods the log.
+        let failure_backoff = Duration::from_millis(
+            (self.consecutive_render_failures as u64 * 100).min(2000),
+        );
+
         let timer = if render_start.is_zero() {
-            trace!("Running late for frame.");
+            if failure_backoff.is_zero() {
+                trace!("Running late for frame.");
+            }
             // TODO triple buffering
-            Timer::immediate()
+            Timer::from_duration(failure_backoff)
         } else {
-            Timer::from_duration(render_start)
+            Timer::from_duration(render_start + failure_backoff)
         };
 
         let token = self
@@ -954,8 +1131,27 @@ impl SurfaceThreadState {
             .insert_source(timer, move |_time, _, state| {
                 if let Err(err) = state.redraw(estimated_presentation) {
                     let name = state.output.name();
-                    warn!(?name, "Failed to submit rendering: {:?}", err);
-                    state.queue_redraw(true);
+                    state.consecutive_render_failures =
+                        state.consecutive_render_failures.saturating_add(1);
+                    if state.consecutive_render_failures > MAX_CONSECUTIVE_RENDER_FAILURES {
+                        state.render_permanently_failed = true;
+                        error!(
+                            ?name,
+                            failures = state.consecutive_render_failures,
+                            "Giving up after {} consecutive redraw failures: {:#}. \
+                             Exiting so cosmic-session can restart the compositor cleanly.",
+                            state.consecutive_render_failures, err
+                        );
+                        give_up_and_exit();
+                    } else {
+                        warn!(
+                            ?name,
+                            failures = state.consecutive_render_failures,
+                            "Failed to submit rendering: {:#}",
+                            err
+                        );
+                        state.queue_redraw(true);
+                    }
                 }
                 TimeoutAction::Drop
             })
@@ -1377,6 +1573,8 @@ impl SurfaceThreadState {
                             self.send_dmabuf_feedback(states);
                         }
 
+                        self.consecutive_render_failures = 0;
+
                         if x.is_ok() {
                             if self.mirroring.is_none() {
                                 self.frame_callback_seq = self.frame_callback_seq.wrapping_add(1);
@@ -1404,7 +1602,53 @@ impl SurfaceThreadState {
             }
             Err(err) => {
                 compositor.reset_buffers();
-                anyhow::bail!("Rendering failed: {}", err);
+                if let Some(status) = context_lost_status(&err) {
+                    if self.context_lost_reported {
+                        // A recovery for this node is already in flight on the main
+                        // thread (`reopen_device` will `drop_and_join` this very thread).
+                        // Do not re-increment the failure counter or re-send the recovery
+                        // request: those redraw retries issued in the meantime would race
+                        // the in-flight teardown/rebuild and can spuriously trip the
+                        // `give_up_and_exit` cap while recovery is actually progressing.
+                        trace!(
+                            status,
+                            "GPU context lost on {} but recovery already in flight",
+                            self.output.name()
+                        );
+                        return Ok(());
+                    }
+
+                    self.context_lost_reported = true;
+                    self.consecutive_render_failures =
+                        self.consecutive_render_failures.saturating_add(1);
+                    if self.consecutive_render_failures > MAX_CONSECUTIVE_RENDER_FAILURES {
+                        self.render_permanently_failed = true;
+                        error!(
+                            status,
+                            failures = self.consecutive_render_failures,
+                            "Giving up on GPU context recreation after {} consecutive attempts. \
+                             Exiting so cosmic-session can restart the compositor cleanly.",
+                            self.consecutive_render_failures
+                        );
+                        give_up_and_exit();
+                    }
+                    warn!(
+                        status,
+                        failures = self.consecutive_render_failures,
+                        "GPU context lost while rendering, requesting renderer recreation"
+                    );
+                    let _ = self
+                        .thread_sender
+                        .send(SurfaceCommand::ContextLost(self.target_node));
+                    // Recreation happens asynchronously on the main thread; queue a
+                    // backed-off retry rather than leaving this output stalled forever.
+                    // `context_lost_reported` is left set so those retries don't re-count
+                    // the same loss event; `reopen_device` tears this thread down and
+                    // rebuilds it fresh, resetting the flag.
+                    self.queue_redraw(true);
+                    return Ok(());
+                }
+                anyhow::bail!("Rendering failed: {:#}", err);
             }
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -318,6 +318,18 @@ pub struct Common {
     pub workspace_state: WorkspaceState<State>,
     pub xwayland_scale: Option<f64>,
     pub xwayland_state: Option<XWaylandState>,
+    /// Render node the running Xwayland was launched with, remembered so an automatic
+    /// respawn after a crash can reuse it (see `XwmHandler::disconnected`).
+    pub xwayland_render_node: Option<DrmNode>,
+    /// Event-loop token of the current `XWayland` source, so a respawn can drop the old
+    /// (already `Disable`d, since smithay disables it once it emits `Ready`) source instead
+    /// of leaving one behind per restart.
+    pub xwayland_source_token: Option<RegistrationToken>,
+    /// Timestamps of recent automatic Xwayland respawns, used as a sliding window to stop
+    /// restarting an Xwayland that crashes immediately every time (see
+    /// `XWAYLAND_RESPAWN_LIMIT`/`XWAYLAND_RESPAWN_WINDOW`). A plain counter would instead
+    /// permanently give up on a long session that saw a few unrelated crashes hours apart.
+    pub xwayland_respawns: Vec<Instant>,
     pub xwayland_shell_state: XWaylandShellState,
     pub pointer_focus_state: Option<PointerFocusState>,
 
@@ -826,6 +838,9 @@ impl State {
                 a11y_state,
                 xwayland_scale: None,
                 xwayland_state: None,
+                xwayland_render_node: None,
+                xwayland_source_token: None,
+                xwayland_respawns: Vec::new(),
                 xwayland_shell_state,
                 pointer_focus_state: None,
                 dbus_state,

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -6,6 +6,18 @@ use std::process::Command;
 use tracing::{error, warn};
 
 pub fn ready(common: &Common) {
+    import_env(common);
+
+    if let Err(err) = notify(false, &[NotifyState::Ready]) {
+        error!(?err, "Failed to notify systemd");
+    }
+}
+
+/// Pushes the current `WAYLAND_DISPLAY`/`DISPLAY` into systemd's user environment.
+///
+/// Split out of [`ready`] so it can be re-run on its own when Xwayland is respawned onto a
+/// different display number - [`ready`] itself runs only once per session.
+pub fn import_env(common: &Common) {
     if booted() {
         match Command::new("systemctl")
             .args(["--user", "import-environment", "WAYLAND_DISPLAY", "DISPLAY"])
@@ -27,9 +39,5 @@ pub fn ready(common: &Common) {
             ),
             Err(err) => error!(?err, "Failed to run systemctl although booted with systemd",),
         };
-    }
-
-    if let Err(err) = notify(false, &[NotifyState::Ready]) {
-        error!(?err, "Failed to notify systemd");
     }
 }

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -4,7 +4,10 @@ use std::{
     os::unix::io::OwnedFd,
     process::Stdio,
     sync::mpsc::{self, Receiver, Sender},
+    time::{Duration, Instant},
 };
+
+use calloop::timer::{TimeoutAction, Timer};
 
 use crate::{
     backend::render::cursor::{Cursor, load_cursor_env, load_cursor_theme},
@@ -56,9 +59,20 @@ use smithay::{
         xwm::{Reorder, XwmId},
     },
 };
-use tracing::{error, trace, warn};
+use tracing::{error, info, trace, warn};
 use xcursor::parser::Image;
 use xkbcommon::xkb::Keysym;
+
+/// How many times Xwayland may be automatically respawned within
+/// `XWAYLAND_RESPAWN_WINDOW` before the compositor stops trying. Xwayland dying is
+/// normally recoverable (a GPU reset kills it outright, for example), but one that
+/// crashes immediately on every start would otherwise be restarted forever.
+const XWAYLAND_RESPAWN_LIMIT: usize = 3;
+/// Sliding window over which `XWAYLAND_RESPAWN_LIMIT` is counted.
+const XWAYLAND_RESPAWN_WINDOW: Duration = Duration::from_secs(60);
+/// Delay before respawning, so a crash-on-start Xwayland cannot spin the event loop, and
+/// so the dying server's resources are released before its replacement claims the socket.
+const XWAYLAND_RESPAWN_DELAY: Duration = Duration::from_millis(500);
 
 #[derive(Debug)]
 pub struct XWaylandState {
@@ -111,6 +125,9 @@ impl State {
             return;
         }
 
+        // Remembered so `XwmHandler::disconnected` can respawn on the same render node.
+        self.common.xwayland_render_node = render_node;
+
         let (xwayland, client) = match XWayland::spawn(
             &self.common.display_handle,
             None,
@@ -132,6 +149,10 @@ impl State {
                 return;
             }
         };
+
+        // Any launch after the first one is a restart of a crashed server (see
+        // `respawn_xwayland`); the Ready arm below needs to know to re-publish DISPLAY.
+        let is_respawn = !self.common.xwayland_respawns.is_empty();
 
         match self
             .common
@@ -176,6 +197,24 @@ impl State {
 
                     data.common.update_xwayland_settings();
                     data.common.update_xwayland_primary_output();
+
+                    // `notify_ready` is what publishes DISPLAY to the systemd/D-Bus
+                    // activation environments, but it only ever runs once per session
+                    // (`call_once`). A respawned Xwayland usually reclaims the same display
+                    // number, but it is not guaranteed to - and if it does not, both
+                    // environments would keep handing newly launched X11 apps the dead
+                    // server's number. Re-publish it on any respawn.
+                    if is_respawn && let crate::state::BackendData::Kms(_) = &data.backend {
+                        #[cfg(feature = "systemd")]
+                        crate::systemd::import_env(&data.common);
+                        if let Err(err) = crate::dbus::ready(&data.common) {
+                            error!(
+                                ?err,
+                                "Failed to update the D-Bus activation environment after \
+                                 restarting Xwayland"
+                            );
+                        }
+                    }
                 }
                 XWaylandEvent::Error => {
                     if let Some(mut xwayland_state) = data.common.xwayland_state.take() {
@@ -184,11 +223,65 @@ impl State {
                     data.notify_ready();
                 }
             }) {
-            Ok(_token) => {}
+            Ok(token) => {
+                self.common.xwayland_source_token = Some(token);
+            }
             Err(err) => {
                 error!(?err, "Failed to listen for Xwayland");
                 self.notify_ready();
             }
+        }
+    }
+
+    /// Tears down the state of an Xwayland that just died and schedules a replacement.
+    ///
+    /// Xwayland exiting at runtime is *not* reported via `XWaylandEvent::Error`: smithay's
+    /// `XWayland` event source returns `PostAction::Disable` as soon as it has emitted
+    /// `Ready`, so `Error` can only ever fire during startup. The sole runtime notification
+    /// is the X11 connection dropping, i.e. `XwmHandler::disconnected` - which is why this
+    /// hangs off that hook.
+    ///
+    /// Without this, a single Xwayland crash left the session with no X11 support at all:
+    /// every running X11 application was gone and no new one could start, for the rest of
+    /// the session. A GPU reset reliably causes exactly that, since the reset destroys
+    /// Xwayland's GL context and it aborts.
+    fn respawn_xwayland(&mut self) {
+        // The old source is already disabled (see above), but dropping its token keeps a
+        // dead source from being left behind on every restart.
+        if let Some(token) = self.common.xwayland_source_token.take() {
+            self.common.event_loop_handle.remove(token);
+        }
+        self.common.xwayland_state = None;
+
+        if !self.common.with_xwayland {
+            return;
+        }
+
+        let now = Instant::now();
+        self.common
+            .xwayland_respawns
+            .retain(|at| now.duration_since(*at) < XWAYLAND_RESPAWN_WINDOW);
+        if self.common.xwayland_respawns.len() >= XWAYLAND_RESPAWN_LIMIT {
+            error!(
+                "Xwayland died {} times within {:?}, not restarting it again. X11 \
+                 applications will not work for the rest of this session.",
+                self.common.xwayland_respawns.len(),
+                XWAYLAND_RESPAWN_WINDOW,
+            );
+            return;
+        }
+        self.common.xwayland_respawns.push(now);
+
+        let render_node = self.common.xwayland_render_node;
+        if let Err(err) = self.common.event_loop_handle.insert_source(
+            Timer::from_duration(XWAYLAND_RESPAWN_DELAY),
+            move |_, _, state| {
+                info!("Restarting Xwayland after it terminated");
+                state.launch_xwayland(render_node);
+                TimeoutAction::Drop
+            },
+        ) {
+            error!(?err, "Failed to schedule Xwayland restart");
         }
     }
 }
@@ -1292,7 +1385,11 @@ impl XwmHandler for State {
     }
 
     fn disconnected(&mut self, _xwm: XwmId) {
-        let xwayland_state = self.common.xwayland_state.as_mut().unwrap();
-        xwayland_state.xwm = None;
+        // Previously this only cleared `xwm` and kept `xwayland_state` alive, which left
+        // `launch_xwayland`'s `is_some()` guard permanently closed - so a dead Xwayland was
+        // never replaced. (It also `unwrap()`ed the state, which would panic if the X11
+        // connection ever dropped after the state had already been taken.)
+        warn!("Xwayland connection lost, restarting Xwayland");
+        self.respawn_xwayland();
     }
 }


### PR DESCRIPTION
Thanks for the work and the clear description.

On my end, I’ve switched to using `COSMIC_COMP_GPU_RESET_KILL_CLIENTS=1` as a workaround: it kills clients on GPU reset instead of trying to keep the session alive, which is enough for my current setup. Because of that, I’m not in a good position to continue testing this full recovery path, so I’m closing the PR to avoid blocking review or implying active validation from my side.

The changes still look useful for anyone pursuing true session-surviving GPU reset recovery; I hope they can be picked up in that context.