### PR TITLE
Add synthetic panel-fit fallback modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "cosmic-settings-config",
  "cosmic-settings-daemon-config",
  "cosmic-text",
+ "drm-ffi 0.9.0",
  "egui",
  "egui_plot",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = ["cosmic-comp-config"]
 
 [dependencies]
 anyhow = { version = "1.0.102", features = ["backtrace"] }
+drm-ffi = "0.9.0"
 bitflags = "2.11.0"
 calloop = { version = "0.14.4", features = ["executor", "stream"] }
 cosmic-comp-config = { path = "cosmic-comp-config", features = [

--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     backend::{
-        kms::render::gles::GbmGlowBackend,
+        kms::{
+            fallback_modes::{KmsMode, ModeSource, fallback_modes},
+            render::gles::GbmGlowBackend,
+        },
         render::{CLEAR_COLOR, CursorMode, GlMultiRenderer, init_shaders, output_elements},
     },
     config::{CompTransformDef, EdidProduct, ScreenFilter},
@@ -34,7 +37,7 @@ use smithay::{
     output::{Mode as OutputMode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::{
         calloop::{LoopHandle, RegistrationToken},
-        drm::control::{Device as ControlDevice, ModeTypeFlags, connector, crtc},
+        drm::control::{Device as ControlDevice, ModeTypeFlags, connector, crtc, property},
         gbm::BufferObjectFlags as GbmBufferFlags,
         rustix::fs::{Dev as dev_t, OFlags},
         wayland_server::DisplayHandle,
@@ -60,6 +63,103 @@ use std::{
 };
 
 use super::{drm_helpers, surface::Surface};
+
+/// Complete DRM modes advertised for one connector. Driver modes and generated
+/// panel-fit modes share this registry so a protocol selection is always
+/// resolved to the exact timing submitted to KMS.
+#[derive(Debug, Default)]
+pub(crate) struct ConnectorModes(pub Vec<KmsMode>);
+
+impl ConnectorModes {
+    pub(crate) fn resolve(&self, size: (i32, i32), refresh: Option<u32>) -> Option<KmsMode> {
+        self.0
+            .iter()
+            .copied()
+            .filter(|entry| {
+                let (width, height) = entry.mode.size();
+                (width as i32, height as i32) == size
+            })
+            .min_by_key(|entry| {
+                refresh
+                    .unwrap_or_default()
+                    .abs_diff(drm_helpers::calculate_refresh_rate(entry.mode))
+            })
+    }
+}
+
+fn connector_has_tile(device: &impl ControlDevice, connector: connector::Handle) -> bool {
+    drm_helpers::get_property_val(device, connector, "TILE")
+        .ok()
+        .is_some_and(|(_, value)| value != 0)
+}
+
+fn connector_supports_scaling(device: &impl ControlDevice, connector: connector::Handle) -> bool {
+    let Ok(prop) = drm_helpers::get_prop(device, connector, "scaling mode") else {
+        return false;
+    };
+    let Ok(info) = device.get_property(prop) else {
+        return false;
+    };
+    match info.value_type() {
+        property::ValueType::Enum(values) => values
+            .values()
+            .1
+            .iter()
+            .any(|value| value.name().to_str().ok() == Some("Full aspect")),
+        _ => false,
+    }
+}
+
+fn connector_modes(device: &impl ControlDevice, info: &connector::Info) -> Vec<KmsMode> {
+    let real_modes = info
+        .modes()
+        .iter()
+        .copied()
+        .map(|mode| KmsMode {
+            preferred: mode.mode_type().contains(ModeTypeFlags::PREFERRED),
+            mode,
+            source: ModeSource::Driver,
+        })
+        .collect::<Vec<_>>();
+    let edp_has_mixed_sizes = info.interface() == connector::Interface::EmbeddedDisplayPort
+        && real_modes.first().is_some_and(|first| {
+            real_modes
+                .iter()
+                .any(|mode| mode.mode.size() != first.mode.size())
+        });
+    let mut modes = real_modes.clone();
+    if !edp_has_mixed_sizes {
+        modes.extend(fallback_modes(
+            &real_modes,
+            connector_supports_scaling(device, info.handle()),
+            connector_has_tile(device, info.handle()),
+        ));
+    }
+    modes
+}
+
+/// Set aspect-preserving panel fitting before a synthetic modeset. We only do
+/// this when the connector explicitly exposes that enum value; otherwise the
+/// generated mode was never advertised.
+pub(crate) fn set_fallback_scaling(
+    device: &impl ControlDevice,
+    connector: connector::Handle,
+) -> Result<()> {
+    let prop = drm_helpers::get_prop(device, connector, "scaling mode")?;
+    let info = device.get_property(prop)?;
+    let property::ValueType::Enum(values) = info.value_type() else {
+        anyhow::bail!("scaling mode property is not an enum");
+    };
+    let value = values
+        .values()
+        .1
+        .iter()
+        .find(|value| value.name().to_str().ok() == Some("Full aspect"))
+        .ok_or_else(|| anyhow::anyhow!("scaling mode lacks Full aspect"))?
+        .value();
+    device.set_property(connector, prop, value)?;
+    Ok(())
+}
 
 #[derive(Debug)]
 pub struct EGLInternals {
@@ -1257,16 +1357,26 @@ fn populate_modes(
         refresh: refresh_rate as i32,
     };
 
+    let connector_modes = connector_modes(drm, &conn_info);
     let mut modes = Vec::new();
-    for mode in conn_info.modes() {
-        let refresh_rate = drm_helpers::calculate_refresh_rate(*mode);
+    for entry in &connector_modes {
+        let refresh_rate = drm_helpers::calculate_refresh_rate(entry.mode);
         let mode = OutputMode {
-            size: (mode.size().0 as i32, mode.size().1 as i32).into(),
+            size: (entry.mode.size().0 as i32, entry.mode.size().1 as i32).into(),
             refresh: refresh_rate as i32,
         };
         modes.push(mode);
         output.add_mode(mode);
     }
+    output
+        .user_data()
+        .insert_if_missing(|| RefCell::new(ConnectorModes::default()));
+    output
+        .user_data()
+        .get::<RefCell<ConnectorModes>>()
+        .unwrap()
+        .borrow_mut()
+        .0 = connector_modes;
     for mode in output
         .modes()
         .into_iter()
@@ -1383,7 +1493,17 @@ pub fn scale_from_dpi(dpi: f64, step_size: u32, shorter_px: u16) -> f64 {
 
 #[cfg(test)]
 mod test {
-    use super::{calculate_scale, connector::Interface};
+    use super::{ConnectorModes, calculate_scale, connector::Interface};
+    use crate::backend::kms::fallback_modes::fallback_catalog;
+
+    #[test]
+    fn persisted_synthetic_mode_resolves_after_reconstruction() {
+        let mode = fallback_catalog()
+            .find(|entry| entry.mode.size() == (1920, 1200))
+            .unwrap();
+        let registry = ConnectorModes(vec![mode]);
+        assert!(registry.resolve((1920, 1200), Some(59_950)).is_some());
+    }
 
     #[test]
     fn test_scale() {

--- a/src/backend/kms/fallback_modes.rs
+++ b/src/backend/kms/fallback_modes.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Conservative CVT reduced-blanking fallback modes for panel-fit connectors.
+
+use smithay::reexports::drm::control::{Mode, ModeFlags, ModeTypeFlags};
+
+use crate::backend::kms::drm_helpers::calculate_refresh_rate;
+
+pub const SYNC_TOLERANCE_MHZ: u32 = 1;
+pub const REFRESH_MATCH_TOLERANCE_MHZ: u32 = 100;
+
+const COMMON_RESOLUTIONS: &[(u16, u16)] = &[
+    // 4:3
+    (800, 600),
+    (1024, 768),
+    (1152, 864),
+    (1280, 960),
+    (1400, 1050),
+    (1440, 1080),
+    (1600, 1200),
+    (1920, 1440),
+    (2048, 1536),
+    // 16:10
+    (1280, 800),
+    (1440, 900),
+    (1680, 1050),
+    (1920, 1200),
+    (2560, 1600),
+    // 16:9
+    (1280, 720),
+    (1366, 768),
+    (1600, 900),
+    (1920, 1080),
+    (2048, 1152),
+    (2560, 1440),
+    (2880, 1620),
+    (3200, 1800),
+    (3840, 2160),
+    (4096, 2304),
+    (5120, 2880),
+];
+const COMMON_REFRESH_RATES: &[u32] = &[60, 90, 120, 144, 165, 240];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModeSource {
+    Driver,
+    FallbackLandscape,
+    FallbackPortrait,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KmsMode {
+    pub mode: Mode,
+    pub source: ModeSource,
+    pub preferred: bool,
+}
+
+impl KmsMode {
+    pub fn is_fallback(self) -> bool {
+        !matches!(self.source, ModeSource::Driver)
+    }
+}
+
+/// Build CVT-RB v1 timings. This is the reduced-blanking timing family used by
+/// Mutter for refresh rates divisible by 60; it is suitable for panel fitting,
+/// not a claim that arbitrary external displays accept CVT timings.
+fn cvt_rb_mode(width: u16, height: u16, refresh_hz: u32) -> Mode {
+    debug_assert_eq!(refresh_hz % 60, 0);
+    let hdisplay = width / 8 * 8;
+    let htotal = hdisplay + 160;
+    let vfront_porch: u16 = 3;
+    let vsync: u16 = 6;
+    // CVT-RB requires at least 460 us vertical blanking. Clock is rounded
+    // down to the 250 kHz granularity used by cvt.
+    let h_period_ns = (1_000_000_000u64 / refresh_hz as u64 - 460_000)
+        / (height as u64 + vfront_porch as u64 + vsync as u64);
+    let vblank = (460_000u64 / h_period_ns + 1) as u16;
+    let vtotal = height + vblank;
+    let clock = ((htotal as u64 * vtotal as u64 * refresh_hz as u64 / 1_000) / 250 * 250) as u32;
+
+    let mut raw = drm_ffi::drm_mode_modeinfo {
+        clock,
+        hdisplay,
+        hsync_start: hdisplay + 48,
+        hsync_end: hdisplay + 80,
+        htotal,
+        hskew: 0,
+        vdisplay: height,
+        vsync_start: height + vfront_porch,
+        vsync_end: height + vfront_porch + vsync,
+        vtotal,
+        vscan: 0,
+        vrefresh: 0,
+        flags: (ModeFlags::PHSYNC | ModeFlags::NVSYNC).bits(),
+        type_: ModeTypeFlags::empty().bits(),
+        name: [0; 32],
+    };
+    let name = format!("{width}x{height}R");
+    for (dst, src) in raw.name.iter_mut().zip(name.bytes()) {
+        *dst = src as i8;
+    }
+    raw.into()
+}
+
+pub fn fallback_catalog() -> impl Iterator<Item = KmsMode> {
+    COMMON_RESOLUTIONS.iter().flat_map(|&(width, height)| {
+        COMMON_REFRESH_RATES
+            .iter()
+            .copied()
+            .filter(|refresh| refresh % 60 == 0)
+            .flat_map(move |refresh| {
+                let landscape = KmsMode {
+                    mode: cvt_rb_mode(width, height, refresh),
+                    source: ModeSource::FallbackLandscape,
+                    preferred: false,
+                };
+                let portrait = KmsMode {
+                    mode: cvt_rb_mode(height, width, refresh),
+                    source: ModeSource::FallbackPortrait,
+                    preferred: false,
+                };
+                [landscape, portrait]
+            })
+    })
+}
+
+pub fn fallback_modes(
+    real_modes: &[KmsMode],
+    scaling_supported: bool,
+    tiled: bool,
+) -> Vec<KmsMode> {
+    if real_modes.is_empty() || !scaling_supported || tiled {
+        return Vec::new();
+    }
+
+    let (max_width, max_height, max_refresh, max_clock) = real_modes.iter().fold(
+        (0u16, 0u16, 60_000u32, 0u32),
+        |(width, height, refresh, clock), mode| {
+            (
+                width.max(mode.mode.size().0),
+                height.max(mode.mode.size().1),
+                refresh.max(calculate_refresh_rate(mode.mode)),
+                clock.max(mode.mode.clock()),
+            )
+        },
+    );
+    let landscape = max_width > max_height;
+
+    fallback_catalog()
+        .filter(|candidate| matches!(candidate.source, ModeSource::FallbackLandscape) == landscape)
+        .filter(|candidate| {
+            let (width, height) = candidate.mode.size();
+            let refresh = calculate_refresh_rate(candidate.mode);
+            width <= max_width
+                && height <= max_height
+                && refresh <= max_refresh + SYNC_TOLERANCE_MHZ
+                && candidate.mode.clock() <= max_clock
+        })
+        .filter(|candidate| {
+            let (width, height) = candidate.mode.size();
+            let refresh = calculate_refresh_rate(candidate.mode);
+            !real_modes.iter().any(|real| {
+                real.mode.size() == (width, height)
+                    && refresh.abs_diff(calculate_refresh_rate(real.mode)) < SYNC_TOLERANCE_MHZ
+            })
+        })
+        .filter(|candidate| {
+            let refresh = calculate_refresh_rate(candidate.mode);
+            real_modes.iter().any(|real| {
+                refresh.abs_diff(calculate_refresh_rate(real.mode)) < REFRESH_MATCH_TOLERANCE_MHZ
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn driver(width: u16, height: u16, refresh: u32) -> KmsMode {
+        let mode = cvt_rb_mode(width, height, refresh);
+        // Native modes are represented by their complete driver timings in
+        // production; CVT is sufficient for exercising pure filtering here.
+        KmsMode {
+            mode,
+            source: ModeSource::Driver,
+            preferred: true,
+        }
+    }
+
+    #[test]
+    fn target_timing_matches_cvt_rb() {
+        let mode = cvt_rb_mode(1920, 1200, 60);
+        assert_eq!(mode.size(), (1920, 1200));
+        assert_eq!(mode.clock(), 154_000);
+        assert_eq!(mode.hsync(), (1968, 2000, 2080));
+        assert_eq!(mode.vsync(), (1203, 1209, 1235));
+        assert!(mode.flags().contains(ModeFlags::PHSYNC | ModeFlags::NVSYNC));
+        assert_eq!(calculate_refresh_rate(mode), 59_950);
+    }
+
+    #[test]
+    fn panel_4k_16_10_gets_1920_1200() {
+        let modes = fallback_modes(&[driver(3840, 2400, 60)], true, false);
+        assert!(
+            modes.iter().any(|mode| mode.mode.size() == (1920, 1200)
+                && calculate_refresh_rate(mode.mode) == 59_950)
+        );
+    }
+
+    #[test]
+    fn capability_and_tile_guards_work() {
+        let real = [driver(3840, 2400, 60)];
+        assert!(fallback_modes(&real, false, false).is_empty());
+        assert!(fallback_modes(&real, true, true).is_empty());
+    }
+
+    #[test]
+    fn real_modes_are_not_duplicated_and_native_stays_preferred() {
+        let real = [driver(3840, 2400, 60), driver(1920, 1200, 60)];
+        let fallbacks = fallback_modes(&real, true, false);
+        assert!(
+            !fallbacks
+                .iter()
+                .any(|mode| mode.mode.size() == (1920, 1200))
+        );
+        assert!(real[0].preferred);
+        assert!(fallbacks.iter().all(|mode| !mode.preferred));
+    }
+
+    #[test]
+    fn limits_and_refresh_matching_are_enforced() {
+        let modes = fallback_modes(&[driver(1920, 1200, 60)], true, false);
+        assert!(
+            modes
+                .iter()
+                .all(|mode| mode.mode.size().0 <= 1920 && mode.mode.size().1 <= 1200)
+        );
+        assert!(modes.iter().all(|mode| mode.mode.clock() <= 154_000));
+        assert!(
+            !modes
+                .iter()
+                .any(|mode| calculate_refresh_rate(mode.mode) > 60_000)
+        );
+    }
+
+    #[test]
+    fn portrait_catalog_is_selected() {
+        let modes = fallback_modes(&[driver(2400, 3840, 60)], true, false);
+        assert!(
+            modes
+                .iter()
+                .all(|mode| matches!(mode.source, ModeSource::FallbackPortrait))
+        );
+        assert!(modes.iter().any(|mode| mode.mode.size() == (1200, 1920)));
+    }
+}

--- a/src/backend/kms/mod.rs
+++ b/src/backend/kms/mod.rs
@@ -42,7 +42,7 @@ use smithay::{
         wayland_protocols::wp::linux_dmabuf::zv1::server::zwp_linux_dmabuf_feedback_v1::TrancheFlags,
         wayland_server::{Client, DisplayHandle},
     },
-    utils::{Clock, DevPath, Monotonic, Size},
+    utils::{Clock, DevPath, Monotonic},
     wayland::{
         dmabuf::{DmabufFeedbackBuilder, DmabufGlobal},
         drm_syncobj::{DrmSyncobjState, supports_syncobj_eventfd},
@@ -61,6 +61,7 @@ use std::{
 
 mod device;
 mod drm_helpers;
+mod fallback_modes;
 pub mod render;
 mod surface;
 use device::*;
@@ -1036,21 +1037,25 @@ impl KmsGuard<'_> {
 
                 let drm = &mut device.drm;
                 let conn = surface.connector;
-                let conn_info = drm.device().get_connector(conn, false)?;
-                let mode = conn_info
-                    .modes()
-                    .iter()
-                    // match the size
-                    .filter(|mode| {
-                        let (x, y) = mode.size();
-                        Size::from((x as i32, y as i32)) == output_config.mode_size()
+                let mode = surface
+                    .output
+                    .user_data()
+                    .get::<std::cell::RefCell<ConnectorModes>>()
+                    .and_then(|modes| {
+                        modes.borrow().resolve(
+                            (output_config.mode_size().w, output_config.mode_size().h),
+                            output_config.0.mode.1,
+                        )
                     })
-                    // and then select the closest refresh rate (e.g. to match 59.98 as 60)
-                    .min_by_key(|mode| {
-                        let refresh_rate = drm_helpers::calculate_refresh_rate(**mode);
-                        (output_config.0.mode.1.unwrap() as i32 - refresh_rate as i32).abs()
-                    })
-                    .ok_or(anyhow::anyhow!("Unable to find matching mode"))?;
+                    .ok_or(anyhow::anyhow!("Unable to find matching advertised mode"))?;
+
+                // A fallback timing is only advertised when this property and
+                // its Full aspect enum are available. Set it before Smithay
+                // creates the MODE_ID blob so the atomic modeset uses panel
+                // fitting rather than plane scaling.
+                if !test_only && mode.is_fallback() {
+                    set_fallback_scaling(drm.device(), conn)?;
+                }
 
                 if !test_only {
                     if !surface.is_active() {
@@ -1109,7 +1114,7 @@ impl KmsGuard<'_> {
                             let compositor = drm
                                 .initialize_output(
                                     *crtc,
-                                    *mode,
+                                    mode.mode,
                                     &[conn],
                                     &surface.output,
                                     Some(planes.clone()),
@@ -1217,7 +1222,7 @@ impl KmsGuard<'_> {
                             elements.add_output(crtc, CLEAR_COLOR, output_elements);
                         }
 
-                        drm.use_mode(&surface.crtc, *mode, &mut renderer, &elements)
+                        drm.use_mode(&surface.crtc, mode.mode, &mut renderer, &elements)
                             .context("Failed to apply new mode")?;
                     }
                 }


### PR DESCRIPTION
### A word of Warning/an Apology

Vibe-coded PR ahead. In preparing this, the AI used the Mutter source code (also GPL-3) as a reference.

I'm submitting it because it may solve a real issue for someone else, and it works for me. The code itself may be iffy. For example, it seems odd that it has to "reach around" smithay's KMS interaction code by going directly to `drm-ffi`. Buyer beware, OK to close if you don't like it; it'll still be discoverable. If you do close it, I will likely come back with a bug report requesting the same feature.

### What is being fixed here

I have a high-resolution laptop panel (3840x2400). As part of my work, I need to share my full screen on which an inking app runs. Both the screen sharing and the note taking app bog down and become too slow to be usable at the full panel resolution. Half-resolution meanwhile (1920x1200) is no problem. My panel does not offer a native 1920x1200 mode, but it does support upscaling. Gnome offers a synthetic mode along those lines. Cosmic settings only provides the full panel resolution.

I made this by having an AI investigate what Mutter does and cloning the relevant behavior in cosmic-comp. I'm using it now, and it seems to do what I need.

### Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- **MAYBE** I understand these changes in full and will be able to respond to review comments.
- **I THINK** My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

