### PR TITLE
fix screenshot tool sometimes crashing

### DIFF
--- a/src/wayland/protocols/corner_radius.rs
+++ b/src/wayland/protocols/corner_radius.rs
@@ -5,16 +5,15 @@ use cosmic_protocols::corner_radius::v1::server::cosmic_corner_radius_toplevel_v
 use cosmic_protocols::corner_radius::v1::server::{
     cosmic_corner_radius_manager_v1, cosmic_corner_radius_toplevel_v1,
 };
-use smithay::desktop::utils::bbox_from_surface_tree;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_popup::XdgPopup;
 use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::server::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
 use smithay::reexports::wayland_server::New;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::utils::{HookId, Logical, Point, Rectangle};
+use smithay::utils::{HookId, Logical, Rectangle};
 use smithay::wayland::compositor::Cacheable;
 use smithay::wayland::compositor::add_pre_commit_hook;
 use smithay::wayland::compositor::with_states;
-use smithay::wayland::shell::wlr_layer::WlrLayerShellHandler;
+use smithay::wayland::shell::wlr_layer::{LayerSurfaceAttributes, WlrLayerShellHandler};
 use smithay::wayland::shell::xdg::{SurfaceCachedState, XdgShellSurfaceUserData};
 use smithay::{
     reexports::{
@@ -655,7 +654,6 @@ fn pad_rect(
 }
 
 fn layer_radius_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &WlSurface) {
-    let bbox = bbox_from_surface_tree(surface, Point::default());
     with_states(surface, |surface_data| {
         let corners = *surface_data
             .cached_state
@@ -665,8 +663,34 @@ fn layer_radius_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &
             .cached_state
             .get::<CacheablePadding>()
             .pending();
+
+        //  The radius and padding is relative to the size of `zwlr_layer_surface_v1` (according to
+        //  the protocol). That is the configure the client acked.
+        //
+        // `last_acked` is the becomes current as part of this commit,
+        // so it is staged consistently with the pending radius/padding above.
+        //
+        // Until the client acks a configure there is no defined size, and nothing to check.
+        let Some(size) = surface_data
+            .data_map
+            .get::<Mutex<LayerSurfaceAttributes>>()
+            .and_then(|attrs| {
+                attrs
+                    .lock()
+                    .unwrap()
+                    .last_acked
+                    .as_ref()
+                    .and_then(|configure| configure.state.size)
+            })
+        else {
+            return;
+        };
+
         let empty = Padding::default();
-        let Some(padded_box) = pad_rect(bbox, padding.0.as_ref().unwrap_or(&empty)) else {
+        let Some(padded_box) = pad_rect(
+            Rectangle::from_size(size),
+            padding.0.as_ref().unwrap_or(&empty),
+        ) else {
             if let Some(hook) = surface_data.data_map.get::<LayerHookId>() {
                 let hook_ref = hook.lock().unwrap();
                 if let Some((_, obj)) = hook_ref.as_ref()


### PR DESCRIPTION
Fixes https://github.com/pop-os/xdg-desktop-portal-cosmic/issues/348

The layer radius hook validated the *pending* corner radius against `bbox_from_surface_tree()`, the *currently committed* buffer bounding box. This made any non-zero radius fatal for a layer surface that had not yet committed its first buffer.

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

