### PR TITLE
fix: Do not magnify cursor when there is an active grab.

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -338,6 +338,9 @@ impl State {
                     let current_output = seat.active_output();
 
                     if self.common.config.cosmic_conf.cursor_shake_to_find
+                        && seat
+                            .get_pointer()
+                            .is_some_and(|pointer| !pointer.is_grabbed())
                         && let Some(cursor_state) =
                             seat.user_data()
                                 .get::<crate::backend::render::cursor::CursorState>()


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

fixes #2789 

`Kwin` seems to have a similar check here: https://github.com/KDE/kwin/blob/5f2b2b20dabb764d6cdf38bd8d015181817d3916/src/plugins/shakecursor/shakecursor.cpp#L114-L121 , although not so familiar with that code.
Before:

https://github.com/user-attachments/assets/2e0fc566-3690-4a23-ac8f-fca66942b1c0




After:

https://github.com/user-attachments/assets/dbf8e830-36a2-4389-af6f-97c4e05af580



KDE:

https://github.com/user-attachments/assets/f9eb34c7-d446-4d9e-a8f2-44191ebcd51e

