### PR TITLE
fix: preserve valid asymmetric surface padding

### DIFF
--- a/src/wayland/handlers/corner_radius.rs
+++ b/src/wayland/handlers/corner_radius.rs
@@ -3,7 +3,7 @@ use smithay::wayland::compositor::SurfaceData;
 
 use crate::wayland::protocols::corner_radius::{
     CacheableCorners, CacheablePadding, CornerRadiusData, CornerRadiusHandler, CornerRadiusState,
-    delegate_corner_radius,
+    Padding, delegate_corner_radius,
 };
 
 use crate::state::State;
@@ -50,13 +50,23 @@ pub fn surface_padding(states: &SurfaceData, size: Size<i32, Logical>) -> Option
 
     let padding = guard.current().0?;
 
+    Some(constrain_padding(padding, size))
+}
+
+fn constrain_padding(padding: Padding, size: Size<i32, Logical>) -> [i32; 4] {
+    let [top, bottom] = constrain_padding_axis(padding.top, padding.bottom, size.h);
+    let [right, left] = constrain_padding_axis(padding.right, padding.left, size.w);
+
+    [top, right, bottom, left]
+}
+
+fn constrain_padding_axis(first: i32, second: i32, length: i32) -> [i32; 2] {
     // guard against padding being too large
-    Some([
-        padding.top.min(size.h / 2),
-        padding.right.min(size.w / 2),
-        padding.bottom.min(size.h / 2),
-        padding.left.min(size.w / 2),
-    ])
+    if first.saturating_add(second) <= length {
+        [first, second]
+    } else {
+        [first.min(length / 2), second.min(length / 2)]
+    }
 }
 
 pub fn pad_rect(


### PR DESCRIPTION
This removes a blurred area below the applibrary when frosted glass is enabled by fixing a padding-clamp bug reproducible with a monitor with a 3840×2160 logical resolution at 100% scaling.


before:
<img width="3840" height="2160" alt="Screenshot_2026-08-28_22-04-08" src="https://github.com/user-attachments/assets/3b88a7eb-8f9a-4aa2-881c-62cf94cc85c8" />



after:
<img width="3840" height="2160" alt="Screenshot_2026-08-29_00-23-14" src="https://github.com/user-attachments/assets/e8913960-d64b-4f79-99ea-584f20c1bf8c" />




- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

