### PR TITLE
RFC: implement commit-timing-v1 and fifo-v1

### DIFF
--- a/src/backend/kms/device.rs
+++ b/src/backend/kms/device.rs
@@ -373,6 +373,7 @@ impl State {
 
         for output in outputs_removed {
             self.common.remove_output(&output);
+            output.signal_fifo(self);
         }
 
         self.backend.kms().refresh_used_devices()?;

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -72,11 +72,10 @@ use smithay::{
             linux_dmabuf::zv1::server::zwp_linux_dmabuf_feedback_v1,
             presentation_time::server::wp_presentation_feedback,
         },
-        wayland_server::{Client, protocol::wl_surface::WlSurface},
+        wayland_server::protocol::wl_surface::WlSurface,
     },
     utils::{Clock, Monotonic, Physical, Point, Rectangle, Transform},
     wayland::{
-        compositor::CompositorHandler,
         dmabuf::{DmabufFeedbackBuilder, get_dmabuf},
         image_copy_capture::{
             CaptureFailureReason, Frame as ScreencopyFrame, SessionRef as ScreencopySessionRef,
@@ -87,7 +86,6 @@ use smithay::{
     },
 };
 use tracing::{error, info, trace, warn};
-use wayland_backend::server::ClientId;
 
 use std::{
     borrow::{Borrow, BorrowMut},
@@ -227,7 +225,7 @@ pub enum ThreadCommand {
 
 #[derive(Debug)]
 pub enum SurfaceCommand {
-    BlockerCleared(HashMap<ClientId, Client>),
+    SignalFIFO,
     SendFrames(usize),
     RenderStates(RenderElementStates),
 }
@@ -282,13 +280,8 @@ impl Surface {
         let output_clone = output.clone();
         let thread_token = evlh
             .insert_source(rx2, move |command, _, state| match command {
-                Event::Msg(SurfaceCommand::BlockerCleared(signaled_clients)) => {
-                    let dh = &state.common.display_handle.clone();
-                    for (_id, client) in signaled_clients {
-                        state
-                            .client_compositor_state(&client)
-                            .blocker_cleared(state, dh);
-                    }
+                Event::Msg(SurfaceCommand::SignalFIFO) => {
+                    output_clone.signal_fifo(state);
                 }
                 Event::Msg(SurfaceCommand::SendFrames(sequence)) => {
                     if output_clone.mirroring().is_some() {
@@ -1386,11 +1379,7 @@ impl SurfaceThreadState {
                             // If postprocessing, use states from first render
                             let states = pre_postprocess_data.states.unwrap_or(frame_result.states);
                             self.send_dmabuf_feedback(states);
-
-                            let shell = self.shell.read();
-                            let signaled_clients = shell.signal_fifos(&self.output);
-                            drop(shell);
-                            self.send_blocker_cleared_callbacks(signaled_clients);
+                            self.send_signal_fifo_callbacks();
                         }
 
                         if x.is_ok() {
@@ -1478,11 +1467,9 @@ impl SurfaceThreadState {
         self.postprocess_textures.clear();
     }
 
-    fn send_blocker_cleared_callbacks(&mut self, signaled_clients: HashMap<ClientId, Client>) {
+    fn send_signal_fifo_callbacks(&mut self) {
         if self.mirroring.is_none() {
-            let _ = self
-                .thread_sender
-                .send(SurfaceCommand::BlockerCleared(signaled_clients));
+            let _ = self.thread_sender.send(SurfaceCommand::SignalFIFO);
         }
     }
 

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
-    backend::render::{
-        CLEAR_COLOR, CursorMode, GlMultiError, GlMultiRenderer, PostprocessOutputConfig,
-        PostprocessShader, PostprocessState,
-        element::{CosmicElement, DamageElement},
-        init_shaders, output_elements,
+    backend::{
+        kms::surface::timings::SAMPLE_TIME_WINDOW,
+        render::{
+            CLEAR_COLOR, CursorMode, GlMultiError, GlMultiRenderer, PostprocessOutputConfig,
+            PostprocessShader, PostprocessState,
+            element::{CosmicElement, DamageElement},
+            init_shaders, output_elements,
+        },
     },
     config::ScreenFilter,
     shell::Shell,
@@ -866,6 +869,8 @@ impl SurfaceThreadState {
             feedback.presented(clock, refresh, sequence as u64, flags);
 
             self.timings.presented(clock);
+            self.output
+                .set_avg_frametime(self.timings.avg_frametime(SAMPLE_TIME_WINDOW));
 
             while let Ok(pending_image_copy_data) = frames.recv() {
                 pending_image_copy_data.send_success_when_ready(

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -72,10 +72,11 @@ use smithay::{
             linux_dmabuf::zv1::server::zwp_linux_dmabuf_feedback_v1,
             presentation_time::server::wp_presentation_feedback,
         },
-        wayland_server::protocol::wl_surface::WlSurface,
+        wayland_server::{Client, protocol::wl_surface::WlSurface},
     },
     utils::{Clock, Monotonic, Physical, Point, Rectangle, Transform},
     wayland::{
+        compositor::CompositorHandler,
         dmabuf::{DmabufFeedbackBuilder, get_dmabuf},
         image_copy_capture::{
             CaptureFailureReason, Frame as ScreencopyFrame, SessionRef as ScreencopySessionRef,
@@ -86,6 +87,7 @@ use smithay::{
     },
 };
 use tracing::{error, info, trace, warn};
+use wayland_backend::server::ClientId;
 
 use std::{
     borrow::{Borrow, BorrowMut},
@@ -225,6 +227,7 @@ pub enum ThreadCommand {
 
 #[derive(Debug)]
 pub enum SurfaceCommand {
+    BlockerCleared(HashMap<ClientId, Client>),
     SendFrames(usize),
     RenderStates(RenderElementStates),
 }
@@ -279,6 +282,14 @@ impl Surface {
         let output_clone = output.clone();
         let thread_token = evlh
             .insert_source(rx2, move |command, _, state| match command {
+                Event::Msg(SurfaceCommand::BlockerCleared(signaled_clients)) => {
+                    let dh = &state.common.display_handle.clone();
+                    for (_id, client) in signaled_clients {
+                        state
+                            .client_compositor_state(&client)
+                            .blocker_cleared(state, dh);
+                    }
+                }
                 Event::Msg(SurfaceCommand::SendFrames(sequence)) => {
                     if output_clone.mirroring().is_some() {
                         return;
@@ -1061,13 +1072,6 @@ impl SurfaceThreadState {
             vrr = has_active_fullscreen;
         }
 
-        // TODO commit timing `signal_until`
-        {
-            let shell = self.shell.read();
-            // XXX correct way to set time?
-            shell.signal_commit_timing(&self.output, self.clock.now() + estimated_presentation);
-        }
-
         let mut elements = output_elements(
             Some(&render_node),
             &mut renderer,
@@ -1384,7 +1388,9 @@ impl SurfaceThreadState {
                             self.send_dmabuf_feedback(states);
 
                             let shell = self.shell.read();
-                            shell.signal_fifos(&self.output);
+                            let signaled_clients = shell.signal_fifos(&self.output);
+                            drop(shell);
+                            self.send_blocker_cleared_callbacks(signaled_clients);
                         }
 
                         if x.is_ok() {
@@ -1470,6 +1476,14 @@ impl SurfaceThreadState {
     fn update_screen_filter(&mut self, filter_config: ScreenFilter) {
         self.screen_filter = filter_config;
         self.postprocess_textures.clear();
+    }
+
+    fn send_blocker_cleared_callbacks(&mut self, signaled_clients: HashMap<ClientId, Client>) {
+        if self.mirroring.is_none() {
+            let _ = self
+                .thread_sender
+                .send(SurfaceCommand::BlockerCleared(signaled_clients));
+        }
     }
 
     fn send_frame_callbacks(&mut self) {

--- a/src/backend/kms/surface/mod.rs
+++ b/src/backend/kms/surface/mod.rs
@@ -1061,6 +1061,13 @@ impl SurfaceThreadState {
             vrr = has_active_fullscreen;
         }
 
+        // TODO commit timing `signal_until`
+        {
+            let shell = self.shell.read();
+            // XXX correct way to set time?
+            shell.signal_commit_timing(&self.output, self.clock.now() + estimated_presentation);
+        }
+
         let mut elements = output_elements(
             Some(&render_node),
             &mut renderer,
@@ -1375,6 +1382,9 @@ impl SurfaceThreadState {
                             // If postprocessing, use states from first render
                             let states = pre_postprocess_data.states.unwrap_or(frame_result.states);
                             self.send_dmabuf_feedback(states);
+
+                            let shell = self.shell.read();
+                            shell.signal_fifos(&self.output);
                         }
 
                         if x.is_ok() {

--- a/src/backend/kms/surface/timings.rs
+++ b/src/backend/kms/surface/timings.rs
@@ -7,7 +7,7 @@ use smithay::{
 use tracing::{debug, error};
 
 const BASE_SAFETY_MARGIN: Duration = Duration::from_millis(3);
-const SAMPLE_TIME_WINDOW: usize = 5;
+pub const SAMPLE_TIME_WINDOW: usize = 5;
 
 pub struct Timings {
     refresh_interval_ns: Option<NonZeroU64>,

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4,7 +4,8 @@ use grabs::{MenuAlignment, SeatMoveGrabState};
 use indexmap::IndexMap;
 use layout::TilingExceptions;
 use std::{
-    collections::HashMap,
+    cell::RefCell,
+    collections::{HashMap, HashSet},
     sync::{Mutex, atomic::Ordering},
     thread,
     time::{Duration, Instant},
@@ -55,11 +56,10 @@ use smithay::{
     output::{Output, WeakOutput},
     reexports::{
         wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1,
-        wayland_server::{Client, protocol::wl_surface::WlSurface},
+        wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
     },
-    utils::{IsAlive, Logical, Monotonic, Point, Rectangle, Serial, Size, Time},
+    utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
     wayland::{
-        commit_timing::CommitTimerBarrierStateUserData,
         compositor::{SurfaceAttributes, SurfaceData, get_parent, with_states},
         fifo::FifoBarrierCachedState,
         seat::WaylandFocus,
@@ -272,6 +272,37 @@ pub struct PendingLayer {
     pub surface: LayerSurface,
     pub seat: Seat<State>,
     pub output: Output,
+}
+
+pub enum OutputSurface<'a> {
+    Window(&'a CosmicSurface, Option<&'a Workspace>, bool, bool),
+    Layer(&'a LayerSurface, usize),
+    Surface(&'a WlSurface),
+    Cursor(&'a WlSurface),
+    Session(&'a WlSurface),
+}
+
+impl<'a> OutputSurface<'a> {
+    pub fn with_surfaces<F>(&self, processor: F)
+    where
+        F: FnMut(&WlSurface, &SurfaceData),
+    {
+        match self {
+            OutputSurface::Session(s) => with_surfaces_surface_tree(s, processor),
+            OutputSurface::Cursor(s) => with_surfaces_surface_tree(s, processor),
+            OutputSurface::Window(w, _space, _active, _is_fullscreen) => w.with_surfaces(processor),
+            OutputSurface::Layer(l, _namespace) => l.with_surfaces(processor),
+            OutputSurface::Surface(s) => with_surfaces_surface_tree(s, processor),
+        }
+    }
+}
+
+thread_local! {
+    static OUTPUT_SURFACE_SET: RefCell<(HashSet<CosmicSurface>, HashSet<WlSurface>)> =
+        RefCell::new((
+            HashSet::with_capacity(128),
+            HashSet::with_capacity(128),
+        ));
 }
 
 #[derive(Debug)]
@@ -2147,190 +2178,188 @@ impl Shell {
             })
     }
 
-    pub fn signal_commit_timing(&self, output: &Output, until: Time<Monotonic>) {
-        let processor = |_surface: &WlSurface, states: &SurfaceData| {
-            if let Some(mut commit_timer_state) = states
-                .data_map
-                .get::<CommitTimerBarrierStateUserData>()
-                .map(|commit_timer| commit_timer.lock().unwrap())
-            {
-                commit_timer_state.signal_until(until);
-            }
-        };
-
-        if let Some(session_lock) = self.session_lock.as_ref() {
-            if let Some(lock_surface) = session_lock.surfaces.get(output) {
-                with_surfaces_surface_tree(lock_surface.wl_surface(), processor);
-            }
-        }
-
-        self.workspaces
-            .sets
-            .get(output)
-            .unwrap()
-            .sticky_layer
-            .mapped()
-            .for_each(|mapped| {
-                for (window, _) in mapped.windows() {
-                    window.0.with_surfaces(processor);
-                }
-            });
-
-        for workspace in self.workspaces.spaces_for_output(output) {
-            for seat in self.seats.iter() {
-                if let Some(window) = workspace.get_fullscreen(seat) {
-                    window.surface.0.with_surfaces(processor);
-                }
-            }
-            workspace.mapped().for_each(|mapped| {
-                for (window, _) in mapped.windows() {
-                    window.0.with_surfaces(processor);
-                }
-            });
-            workspace.minimized_windows.iter().for_each(|m| {
-                for window in m.windows() {
-                    window.0.with_surfaces(processor);
-                }
-            });
-        }
-
-        let map = smithay::desktop::layer_map_for_output(output);
-        for layer_surface in map.layers() {
-            layer_surface.with_surfaces(processor);
-        }
-
-        self.override_redirect_windows.iter().for_each(|or| {
-            // Find output the override redirect window overlaps the most with
-            let or_geo = or.geometry().as_global();
-            let max_intersect_output = self
-                .outputs()
-                .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
-                .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
-                .map(|(o, _)| o);
-            if max_intersect_output == Some(output) {
-                if let Some(wl_surface) = or.wl_surface() {
-                    with_surfaces_surface_tree(&wl_surface, processor);
-                }
-            }
-        });
-
-        for seat in self
-            .seats
-            .iter()
-            .filter(|seat| &seat.active_output() == output)
-        {
-            let cursor_status = seat.cursor_image_status();
-
-            if let CursorImageStatus::Surface(wl_surface) = cursor_status {
-                with_surfaces_surface_tree(&wl_surface, processor);
-            }
-
-            if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
-                if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
-                    for (window, _) in grab_state.element().windows() {
-                        window.0.with_surfaces(processor);
+    pub fn for_each_surface_on_output(
+        &self,
+        output: &Output,
+        mut f: impl FnMut(OutputSurface<'_>),
+    ) {
+        OUTPUT_SURFACE_SET.with(|output_surface_set| {
+            let mut output_surface_set = output_surface_set.borrow_mut();
+            let (window_set, surface_set) = &mut *output_surface_set;
+            window_set.clear();
+            surface_set.clear();
+            if let Some(session_lock) = self.session_lock.as_ref() {
+                if let Some(lock_surface) = session_lock.surfaces.get(output) {
+                    if surface_set.insert(lock_surface.wl_surface().clone()) {
+                        f(OutputSurface::Session(lock_surface.wl_surface()));
                     }
                 }
             }
 
-            if let Some(icon) = get_dnd_icon(seat) {
-                with_surfaces_surface_tree(&icon.surface, processor);
+            for seat in self
+                .seats
+                .iter()
+                .filter(|seat| &seat.active_output() == output)
+            {
+                let cursor_status = seat.cursor_image_status();
+
+                if let CursorImageStatus::Surface(wl_surface) = cursor_status {
+                    if surface_set.insert(wl_surface.clone()) {
+                        f(OutputSurface::Cursor(&wl_surface));
+                    }
+                }
+
+                if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
+                    if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
+                        for (window, _) in grab_state.element().windows() {
+                            if window_set.insert(window.clone()) {
+                                f(OutputSurface::Window(&window, None, true, false));
+                            }
+                        }
+                    }
+                }
+
+                if let Some(icon) = get_dnd_icon(seat) {
+                    if surface_set.insert(icon.surface.clone()) {
+                        f(OutputSurface::Cursor(&icon.surface));
+                    }
+                }
+
+                if let Some(active) = self.active_space(output) {
+                    if let Some(window) = active.get_fullscreen(seat) {
+                        if window_set.insert(window.surface.clone()) {
+                            f(OutputSurface::Window(
+                                &window.surface,
+                                Some(active),
+                                true,
+                                true,
+                            ));
+                        }
+                    }
+
+                    for space in self
+                        .workspaces
+                        .spaces_for_output(output)
+                        .filter(|w| w.handle != active.handle)
+                    {
+                        if let Some(window) = space.get_fullscreen(seat) {
+                            if window_set.insert(window.surface.clone()) {
+                                f(OutputSurface::Window(
+                                    &window.surface,
+                                    Some(active),
+                                    false,
+                                    true,
+                                ));
+                            }
+                        }
+                    }
+                }
             }
-        }
+
+            self.workspaces
+                .sets
+                .get(output)
+                .unwrap()
+                .sticky_layer
+                .mapped()
+                .for_each(|mapped| {
+                    for (window, _) in mapped.windows() {
+                        if window_set.insert(window.clone()) {
+                            f(OutputSurface::Window(&window, None, true, false));
+                        }
+                    }
+                });
+
+            if let Some(active) = self.active_space(output) {
+                active.mapped().for_each(|mapped| {
+                    for (window, _) in mapped.windows() {
+                        if window_set.insert(window.clone()) {
+                            f(OutputSurface::Window(&window, Some(active), true, false));
+                        }
+                    }
+                });
+
+                // other (throttled) windows
+                active.minimized_windows.iter().for_each(|m| {
+                    for window in m.windows() {
+                        if window_set.insert(window.clone()) {
+                            f(OutputSurface::Window(&window, Some(active), false, false));
+                        }
+                    }
+                });
+
+                for space in self
+                    .workspaces
+                    .spaces_for_output(output)
+                    .filter(|w| w.handle != active.handle)
+                {
+                    space.mapped().for_each(|mapped| {
+                        for (window, _) in mapped.windows() {
+                            if window_set.insert(window.clone()) {
+                                f(OutputSurface::Window(&window, Some(active), false, false));
+                            }
+                        }
+                    });
+                    space.minimized_windows.iter().for_each(|m| {
+                        for window in m.windows() {
+                            if window_set.insert(window.clone()) {
+                                f(OutputSurface::Window(&window, Some(active), false, false));
+                            }
+                        }
+                    })
+                }
+            }
+
+            {
+                let map = smithay::desktop::layer_map_for_output(output);
+                let namespace = self.workspaces.active_num(output).1;
+                for layer_surface in map.layers() {
+                    if surface_set.insert(layer_surface.wl_surface().clone()) {
+                        f(OutputSurface::Layer(layer_surface, namespace));
+                    }
+                }
+            }
+
+            self.override_redirect_windows.iter().for_each(|or| {
+                // Find output the override redirect window overlaps the most with
+                let or_geo = or.geometry().as_global();
+                let max_intersect_output = self
+                    .outputs()
+                    .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
+                    .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
+                    .map(|(o, _)| o);
+                if max_intersect_output == Some(output) {
+                    if let Some(wl_surface) = or.wl_surface() {
+                        if surface_set.insert(wl_surface.clone()) {
+                            f(OutputSurface::Surface(&wl_surface));
+                        }
+                    }
+                }
+            });
+        });
     }
 
-    pub fn signal_fifos(&self, output: &Output) {
-        fn processor(_surface: &WlSurface, states: &SurfaceData) {
-            let fifo_barrier = states
-                .cached_state
-                .get::<FifoBarrierCachedState>()
-                .current()
-                .barrier
-                .take();
-            if let Some(fifo_barrier) = fifo_barrier {
-                fifo_barrier.signal();
-            }
-        }
+    pub fn signal_fifos(&self, output: &Output) -> HashMap<ClientId, Client> {
+        let mut clients: HashMap<ClientId, Client> = HashMap::new();
+        self.for_each_surface_on_output(output, |toplevel| {
+            toplevel.with_surfaces(|surface: &WlSurface, states: &SurfaceData| -> _ {
+                let fifo_barrier = &states
+                    .cached_state
+                    .get::<FifoBarrierCachedState>()
+                    .current()
+                    .barrier
+                    .take();
 
-        if let Some(session_lock) = self.session_lock.as_ref() {
-            if let Some(lock_surface) = session_lock.surfaces.get(output) {
-                with_surfaces_surface_tree(lock_surface.wl_surface(), processor);
-            }
-        }
-
-        self.workspaces
-            .sets
-            .get(output)
-            .unwrap()
-            .sticky_layer
-            .mapped()
-            .for_each(|mapped| {
-                for (window, _) in mapped.windows() {
-                    window.0.with_surfaces(processor);
+                if let Some(fifo_barrier) = fifo_barrier
+                    && let Some(client) = surface.client()
+                {
+                    fifo_barrier.signal();
+                    clients.insert(client.id(), client);
                 }
-            });
-
-        for workspace in self.workspaces.spaces_for_output(output) {
-            for seat in self.seats.iter() {
-                if let Some(window) = workspace.get_fullscreen(seat) {
-                    window.surface.0.with_surfaces(processor);
-                }
-            }
-            workspace.mapped().for_each(|mapped| {
-                for (window, _) in mapped.windows() {
-                    window.0.with_surfaces(processor);
-                }
-            });
-            workspace.minimized_windows.iter().for_each(|m| {
-                for window in m.windows() {
-                    window.0.with_surfaces(processor);
-                }
-            });
-        }
-
-        let map = smithay::desktop::layer_map_for_output(output);
-        for layer_surface in map.layers() {
-            layer_surface.with_surfaces(processor);
-        }
-
-        self.override_redirect_windows.iter().for_each(|or| {
-            // Find output the override redirect window overlaps the most with
-            let or_geo = or.geometry().as_global();
-            let max_intersect_output = self
-                .outputs()
-                .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
-                .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
-                .map(|(o, _)| o);
-            if max_intersect_output == Some(output) {
-                if let Some(wl_surface) = or.wl_surface() {
-                    with_surfaces_surface_tree(&wl_surface, processor);
-                }
-            }
+            })
         });
 
-        for seat in self
-            .seats
-            .iter()
-            .filter(|seat| &seat.active_output() == output)
-        {
-            let cursor_status = seat.cursor_image_status();
-
-            if let CursorImageStatus::Surface(wl_surface) = cursor_status {
-                with_surfaces_surface_tree(&wl_surface, processor);
-            }
-
-            if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
-                if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
-                    for (window, _) in grab_state.element().windows() {
-                        window.0.with_surfaces(processor);
-                    }
-                }
-            }
-
-            if let Some(icon) = get_dnd_icon(seat) {
-                with_surfaces_surface_tree(&icon.surface, processor);
-            }
-        }
+        clients
     }
 
     pub fn workspace_for_surface(&self, surface: &WlSurface) -> Option<(WorkspaceHandle, Output)> {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1542,7 +1542,6 @@ impl Common {
         output
             .user_data()
             .insert_if_missing_threadsafe(|| OutputId(next_output_id()));
-        output.init_fifo();
 
         if let Some(state) = shell.zoom_state.as_ref() {
             output.user_data().insert_if_missing_threadsafe(|| {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4,8 +4,7 @@ use grabs::{MenuAlignment, SeatMoveGrabState};
 use indexmap::IndexMap;
 use layout::TilingExceptions;
 use std::{
-    cell::RefCell,
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{Mutex, atomic::Ordering},
     thread,
     time::{Duration, Instant},
@@ -43,7 +42,6 @@ use smithay::{
         utils::{
             OutputPresentationFeedback, surface_presentation_feedback_flags_from_states,
             surface_primary_scanout_output, take_presentation_feedback_surface_tree,
-            with_surfaces_surface_tree,
         },
     },
     input::{
@@ -56,12 +54,11 @@ use smithay::{
     output::{Output, WeakOutput},
     reexports::{
         wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1,
-        wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
+        wayland_server::{Client, protocol::wl_surface::WlSurface},
     },
     utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
     wayland::{
-        compositor::{SurfaceAttributes, SurfaceData, get_parent, with_states},
-        fifo::FifoBarrierCachedState,
+        compositor::{SurfaceAttributes, get_parent, with_states},
         seat::WaylandFocus,
         session_lock::LockSurface,
         shell::{
@@ -272,37 +269,6 @@ pub struct PendingLayer {
     pub surface: LayerSurface,
     pub seat: Seat<State>,
     pub output: Output,
-}
-
-pub enum OutputSurface<'a> {
-    Window(&'a CosmicSurface, Option<&'a Workspace>, bool, bool),
-    Layer(&'a LayerSurface, usize),
-    Surface(&'a WlSurface),
-    Cursor(&'a WlSurface),
-    Session(&'a WlSurface),
-}
-
-impl<'a> OutputSurface<'a> {
-    pub fn with_surfaces<F>(&self, processor: F)
-    where
-        F: FnMut(&WlSurface, &SurfaceData),
-    {
-        match self {
-            OutputSurface::Session(s) => with_surfaces_surface_tree(s, processor),
-            OutputSurface::Cursor(s) => with_surfaces_surface_tree(s, processor),
-            OutputSurface::Window(w, _space, _active, _is_fullscreen) => w.with_surfaces(processor),
-            OutputSurface::Layer(l, _namespace) => l.with_surfaces(processor),
-            OutputSurface::Surface(s) => with_surfaces_surface_tree(s, processor),
-        }
-    }
-}
-
-thread_local! {
-    static OUTPUT_SURFACE_SET: RefCell<(HashSet<CosmicSurface>, HashSet<WlSurface>)> =
-        RefCell::new((
-            HashSet::with_capacity(128),
-            HashSet::with_capacity(128),
-        ));
 }
 
 #[derive(Debug)]
@@ -1576,6 +1542,7 @@ impl Common {
         output
             .user_data()
             .insert_if_missing_threadsafe(|| OutputId(next_output_id()));
+        output.init_fifo();
 
         if let Some(state) = shell.zoom_state.as_ref() {
             output.user_data().insert_if_missing_threadsafe(|| {
@@ -2176,190 +2143,6 @@ impl Shell {
                         })
                 })
             })
-    }
-
-    pub fn for_each_surface_on_output(
-        &self,
-        output: &Output,
-        mut f: impl FnMut(OutputSurface<'_>),
-    ) {
-        OUTPUT_SURFACE_SET.with(|output_surface_set| {
-            let mut output_surface_set = output_surface_set.borrow_mut();
-            let (window_set, surface_set) = &mut *output_surface_set;
-            window_set.clear();
-            surface_set.clear();
-            if let Some(session_lock) = self.session_lock.as_ref() {
-                if let Some(lock_surface) = session_lock.surfaces.get(output) {
-                    if surface_set.insert(lock_surface.wl_surface().clone()) {
-                        f(OutputSurface::Session(lock_surface.wl_surface()));
-                    }
-                }
-            }
-
-            for seat in self
-                .seats
-                .iter()
-                .filter(|seat| &seat.active_output() == output)
-            {
-                let cursor_status = seat.cursor_image_status();
-
-                if let CursorImageStatus::Surface(wl_surface) = cursor_status {
-                    if surface_set.insert(wl_surface.clone()) {
-                        f(OutputSurface::Cursor(&wl_surface));
-                    }
-                }
-
-                if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
-                    if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
-                        for (window, _) in grab_state.element().windows() {
-                            if window_set.insert(window.clone()) {
-                                f(OutputSurface::Window(&window, None, true, false));
-                            }
-                        }
-                    }
-                }
-
-                if let Some(icon) = get_dnd_icon(seat) {
-                    if surface_set.insert(icon.surface.clone()) {
-                        f(OutputSurface::Cursor(&icon.surface));
-                    }
-                }
-
-                if let Some(active) = self.active_space(output) {
-                    if let Some(window) = active.get_fullscreen(seat) {
-                        if window_set.insert(window.surface.clone()) {
-                            f(OutputSurface::Window(
-                                &window.surface,
-                                Some(active),
-                                true,
-                                true,
-                            ));
-                        }
-                    }
-
-                    for space in self
-                        .workspaces
-                        .spaces_for_output(output)
-                        .filter(|w| w.handle != active.handle)
-                    {
-                        if let Some(window) = space.get_fullscreen(seat) {
-                            if window_set.insert(window.surface.clone()) {
-                                f(OutputSurface::Window(
-                                    &window.surface,
-                                    Some(active),
-                                    false,
-                                    true,
-                                ));
-                            }
-                        }
-                    }
-                }
-            }
-
-            self.workspaces
-                .sets
-                .get(output)
-                .unwrap()
-                .sticky_layer
-                .mapped()
-                .for_each(|mapped| {
-                    for (window, _) in mapped.windows() {
-                        if window_set.insert(window.clone()) {
-                            f(OutputSurface::Window(&window, None, true, false));
-                        }
-                    }
-                });
-
-            if let Some(active) = self.active_space(output) {
-                active.mapped().for_each(|mapped| {
-                    for (window, _) in mapped.windows() {
-                        if window_set.insert(window.clone()) {
-                            f(OutputSurface::Window(&window, Some(active), true, false));
-                        }
-                    }
-                });
-
-                // other (throttled) windows
-                active.minimized_windows.iter().for_each(|m| {
-                    for window in m.windows() {
-                        if window_set.insert(window.clone()) {
-                            f(OutputSurface::Window(&window, Some(active), false, false));
-                        }
-                    }
-                });
-
-                for space in self
-                    .workspaces
-                    .spaces_for_output(output)
-                    .filter(|w| w.handle != active.handle)
-                {
-                    space.mapped().for_each(|mapped| {
-                        for (window, _) in mapped.windows() {
-                            if window_set.insert(window.clone()) {
-                                f(OutputSurface::Window(&window, Some(active), false, false));
-                            }
-                        }
-                    });
-                    space.minimized_windows.iter().for_each(|m| {
-                        for window in m.windows() {
-                            if window_set.insert(window.clone()) {
-                                f(OutputSurface::Window(&window, Some(active), false, false));
-                            }
-                        }
-                    })
-                }
-            }
-
-            {
-                let map = smithay::desktop::layer_map_for_output(output);
-                let namespace = self.workspaces.active_num(output).1;
-                for layer_surface in map.layers() {
-                    if surface_set.insert(layer_surface.wl_surface().clone()) {
-                        f(OutputSurface::Layer(layer_surface, namespace));
-                    }
-                }
-            }
-
-            self.override_redirect_windows.iter().for_each(|or| {
-                // Find output the override redirect window overlaps the most with
-                let or_geo = or.geometry().as_global();
-                let max_intersect_output = self
-                    .outputs()
-                    .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
-                    .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
-                    .map(|(o, _)| o);
-                if max_intersect_output == Some(output) {
-                    if let Some(wl_surface) = or.wl_surface() {
-                        if surface_set.insert(wl_surface.clone()) {
-                            f(OutputSurface::Surface(&wl_surface));
-                        }
-                    }
-                }
-            });
-        });
-    }
-
-    pub fn signal_fifos(&self, output: &Output) -> HashMap<ClientId, Client> {
-        let mut clients: HashMap<ClientId, Client> = HashMap::new();
-        self.for_each_surface_on_output(output, |toplevel| {
-            toplevel.with_surfaces(|surface: &WlSurface, states: &SurfaceData| -> _ {
-                let fifo_barrier = &states
-                    .cached_state
-                    .get::<FifoBarrierCachedState>()
-                    .current()
-                    .barrier
-                    .take();
-
-                if let Some(fifo_barrier) = fifo_barrier
-                    && let Some(client) = surface.client()
-                {
-                    fifo_barrier.signal();
-                    clients.insert(client.id(), client);
-                }
-            })
-        });
-
-        clients
     }
 
     pub fn workspace_for_surface(&self, surface: &WlSurface) -> Option<(WorkspaceHandle, Output)> {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -42,6 +42,7 @@ use smithay::{
         utils::{
             OutputPresentationFeedback, surface_presentation_feedback_flags_from_states,
             surface_primary_scanout_output, take_presentation_feedback_surface_tree,
+            with_surfaces_surface_tree,
         },
     },
     input::{
@@ -56,9 +57,11 @@ use smithay::{
         wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1,
         wayland_server::{Client, protocol::wl_surface::WlSurface},
     },
-    utils::{IsAlive, Logical, Point, Rectangle, Serial, Size},
+    utils::{IsAlive, Logical, Monotonic, Point, Rectangle, Serial, Size, Time},
     wayland::{
-        compositor::{SurfaceAttributes, get_parent, with_states},
+        commit_timing::CommitTimerBarrierStateUserData,
+        compositor::{SurfaceAttributes, SurfaceData, get_parent, with_states},
+        fifo::FifoBarrierCachedState,
         seat::WaylandFocus,
         session_lock::LockSurface,
         shell::{
@@ -2142,6 +2145,192 @@ impl Shell {
                         })
                 })
             })
+    }
+
+    pub fn signal_commit_timing(&self, output: &Output, until: Time<Monotonic>) {
+        let processor = |_surface: &WlSurface, states: &SurfaceData| {
+            if let Some(mut commit_timer_state) = states
+                .data_map
+                .get::<CommitTimerBarrierStateUserData>()
+                .map(|commit_timer| commit_timer.lock().unwrap())
+            {
+                commit_timer_state.signal_until(until);
+            }
+        };
+
+        if let Some(session_lock) = self.session_lock.as_ref() {
+            if let Some(lock_surface) = session_lock.surfaces.get(output) {
+                with_surfaces_surface_tree(lock_surface.wl_surface(), processor);
+            }
+        }
+
+        self.workspaces
+            .sets
+            .get(output)
+            .unwrap()
+            .sticky_layer
+            .mapped()
+            .for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+
+        for workspace in self.workspaces.spaces_for_output(output) {
+            for seat in self.seats.iter() {
+                if let Some(window) = workspace.get_fullscreen(seat) {
+                    window.surface.0.with_surfaces(processor);
+                }
+            }
+            workspace.mapped().for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+            workspace.minimized_windows.iter().for_each(|m| {
+                for window in m.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+        }
+
+        let map = smithay::desktop::layer_map_for_output(output);
+        for layer_surface in map.layers() {
+            layer_surface.with_surfaces(processor);
+        }
+
+        self.override_redirect_windows.iter().for_each(|or| {
+            // Find output the override redirect window overlaps the most with
+            let or_geo = or.geometry().as_global();
+            let max_intersect_output = self
+                .outputs()
+                .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
+                .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
+                .map(|(o, _)| o);
+            if max_intersect_output == Some(output) {
+                if let Some(wl_surface) = or.wl_surface() {
+                    with_surfaces_surface_tree(&wl_surface, processor);
+                }
+            }
+        });
+
+        for seat in self
+            .seats
+            .iter()
+            .filter(|seat| &seat.active_output() == output)
+        {
+            let cursor_status = seat.cursor_image_status();
+
+            if let CursorImageStatus::Surface(wl_surface) = cursor_status {
+                with_surfaces_surface_tree(&wl_surface, processor);
+            }
+
+            if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
+                if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
+                    for (window, _) in grab_state.element().windows() {
+                        window.0.with_surfaces(processor);
+                    }
+                }
+            }
+
+            if let Some(icon) = get_dnd_icon(seat) {
+                with_surfaces_surface_tree(&icon.surface, processor);
+            }
+        }
+    }
+
+    pub fn signal_fifos(&self, output: &Output) {
+        fn processor(_surface: &WlSurface, states: &SurfaceData) {
+            let fifo_barrier = states
+                .cached_state
+                .get::<FifoBarrierCachedState>()
+                .current()
+                .barrier
+                .take();
+            if let Some(fifo_barrier) = fifo_barrier {
+                fifo_barrier.signal();
+            }
+        }
+
+        if let Some(session_lock) = self.session_lock.as_ref() {
+            if let Some(lock_surface) = session_lock.surfaces.get(output) {
+                with_surfaces_surface_tree(lock_surface.wl_surface(), processor);
+            }
+        }
+
+        self.workspaces
+            .sets
+            .get(output)
+            .unwrap()
+            .sticky_layer
+            .mapped()
+            .for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+
+        for workspace in self.workspaces.spaces_for_output(output) {
+            for seat in self.seats.iter() {
+                if let Some(window) = workspace.get_fullscreen(seat) {
+                    window.surface.0.with_surfaces(processor);
+                }
+            }
+            workspace.mapped().for_each(|mapped| {
+                for (window, _) in mapped.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+            workspace.minimized_windows.iter().for_each(|m| {
+                for window in m.windows() {
+                    window.0.with_surfaces(processor);
+                }
+            });
+        }
+
+        let map = smithay::desktop::layer_map_for_output(output);
+        for layer_surface in map.layers() {
+            layer_surface.with_surfaces(processor);
+        }
+
+        self.override_redirect_windows.iter().for_each(|or| {
+            // Find output the override redirect window overlaps the most with
+            let or_geo = or.geometry().as_global();
+            let max_intersect_output = self
+                .outputs()
+                .filter_map(|o| Some((o, o.geometry().intersection(or_geo)?)))
+                .max_by_key(|(_, intersection)| intersection.size.w * intersection.size.h)
+                .map(|(o, _)| o);
+            if max_intersect_output == Some(output) {
+                if let Some(wl_surface) = or.wl_surface() {
+                    with_surfaces_surface_tree(&wl_surface, processor);
+                }
+            }
+        });
+
+        for seat in self
+            .seats
+            .iter()
+            .filter(|seat| &seat.active_output() == output)
+        {
+            let cursor_status = seat.cursor_image_status();
+
+            if let CursorImageStatus::Surface(wl_surface) = cursor_status {
+                with_surfaces_surface_tree(&wl_surface, processor);
+            }
+
+            if let Some(move_grab) = seat.user_data().get::<SeatMoveGrabState>() {
+                if let Some(grab_state) = move_grab.lock().unwrap().as_ref() {
+                    for (window, _) in grab_state.element().windows() {
+                        window.0.with_surfaces(processor);
+                    }
+                }
+            }
+
+            if let Some(icon) = get_dnd_icon(seat) {
+                with_surfaces_surface_tree(&icon.surface, processor);
+            }
+        }
     }
 
     pub fn workspace_for_surface(&self, surface: &WlSurface) -> Option<(WorkspaceHandle, Output)> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -74,6 +74,7 @@ use smithay::{
     wayland::{
         alpha_modifier::AlphaModifierState,
         background_effect::BackgroundEffectState,
+        commit_timing::CommitTimingManagerState,
         compositor::{CompositorClientState, CompositorState, SurfaceData},
         cursor_shape::CursorShapeManagerState,
         dmabuf::{DmabufFeedback, DmabufGlobal, DmabufState},
@@ -308,6 +309,7 @@ pub struct Common {
     pub dbus_state: DBusState,
     pub keyboard_layout_state: KeyboardLayoutState,
     pub background_effect_state: BackgroundEffectState,
+    pub commit_timing_manager_state: CommitTimingManagerState,
     pub fifo_manager_state: FifoManagerState,
 
     // shell-related wayland state
@@ -765,6 +767,8 @@ impl State {
 
         let dbus_state = DBusState::init(&handle);
 
+        let commit_timing_manager_state = CommitTimingManagerState::unmanaged::<State>(dh);
+
         let fifo_manager_state = FifoManagerState::new::<State>(dh);
 
         State {
@@ -828,6 +832,7 @@ impl State {
                 workspace_state,
                 background_effect_state,
                 a11y_state,
+                commit_timing_manager_state,
                 fifo_manager_state,
                 xwayland_scale: None,
                 xwayland_state: None,

--- a/src/state.rs
+++ b/src/state.rs
@@ -769,7 +769,7 @@ impl State {
 
         let commit_timing_manager_state = CommitTimingManagerState::unmanaged::<State>(dh);
 
-        let fifo_manager_state = FifoManagerState::new::<State>(dh);
+        let fifo_manager_state = FifoManagerState::unmanaged::<State>(dh);
 
         State {
             common: Common {

--- a/src/state.rs
+++ b/src/state.rs
@@ -77,6 +77,7 @@ use smithay::{
         compositor::{CompositorClientState, CompositorState, SurfaceData},
         cursor_shape::CursorShapeManagerState,
         dmabuf::{DmabufFeedback, DmabufGlobal, DmabufState},
+        fifo::FifoManagerState,
         fixes::FixesState,
         fractional_scale::{FractionalScaleManagerState, with_fractional_scale},
         idle_inhibit::IdleInhibitManagerState,
@@ -307,6 +308,7 @@ pub struct Common {
     pub dbus_state: DBusState,
     pub keyboard_layout_state: KeyboardLayoutState,
     pub background_effect_state: BackgroundEffectState,
+    pub fifo_manager_state: FifoManagerState,
 
     // shell-related wayland state
     pub xdg_shell_state: XdgShellState,
@@ -763,6 +765,8 @@ impl State {
 
         let dbus_state = DBusState::init(&handle);
 
+        let fifo_manager_state = FifoManagerState::new::<State>(dh);
+
         State {
             common: Common {
                 config,
@@ -824,6 +828,7 @@ impl State {
                 workspace_state,
                 background_effect_state,
                 a11y_state,
+                fifo_manager_state,
                 xwayland_scale: None,
                 xwayland_state: None,
                 xwayland_shell_state,

--- a/src/state.rs
+++ b/src/state.rs
@@ -769,7 +769,7 @@ impl State {
 
         let commit_timing_manager_state = CommitTimingManagerState::unmanaged::<State>(dh);
 
-        let fifo_manager_state = FifoManagerState::unmanaged::<State>(dh);
+        let fifo_manager_state = FifoManagerState::new::<State>(dh);
 
         State {
             common: Common {

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -16,6 +16,7 @@ use crate::{config::EdidProduct, shell::zoom::OutputZoomState};
 
 use std::{
     cell::{Ref, RefCell, RefMut},
+    collections::HashMap,
     sync::{
         Mutex,
         atomic::{AtomicU8, Ordering},
@@ -203,13 +204,18 @@ impl OutputExt for Output {
             return;
         };
 
-        let dh = &state.common.display_handle.clone();
+        let mut clients = HashMap::new();
         fifo_barriers.0.lock().unwrap().drain(..).for_each(|item| {
             item.barrier.signal();
-            state
-                .client_compositor_state(&item.client)
-                .blocker_cleared(state, dh);
+            clients.insert(item.client.id(), item.client);
         });
+
+        let dh = &state.common.display_handle.clone();
+        for (_id, client) in clients {
+            state
+                .client_compositor_state(&client)
+                .blocker_cleared(state, dh);
+        }
     }
 
     fn set_avg_frametime(&self, duration: Option<Duration>) {

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -2,7 +2,9 @@ use cosmic_comp_config::output::comp::{AdaptiveSync, OutputConfig, OutputState};
 use smithay::{
     backend::drm::VrrSupport as Support,
     output::{Output, WeakOutput},
+    reexports::wayland_server::Client,
     utils::Rectangle,
+    wayland::compositor::{Barrier, CompositorHandler},
 };
 
 pub use super::geometry::*;
@@ -36,11 +38,24 @@ pub trait OutputExt {
     fn config_mut(&self) -> RefMut<'_, OutputConfig>;
 
     fn edid(&self) -> Option<&EdidProduct>;
+
+    fn init_fifo(&self);
+    fn fifo_barrier(&self, barrier: Barrier, client: Client);
+    fn signal_fifo(&self, state: &mut State);
 }
 
 struct Vrr(AtomicU8);
 struct VrrSupport(AtomicU8);
 struct Mirroring(Mutex<Option<WeakOutput>>);
+
+#[derive(Debug, Clone)]
+pub struct FifoBarrierItem {
+    pub barrier: Barrier,
+    pub client: Client,
+}
+
+#[derive(Default)]
+struct FifoBarriers(Mutex<Vec<FifoBarrierItem>>);
 
 impl OutputExt for Output {
     fn is_internal(&self) -> bool {
@@ -166,5 +181,34 @@ impl OutputExt for Output {
 
     fn edid(&self) -> Option<&EdidProduct> {
         self.user_data().get()
+    }
+
+    fn init_fifo(&self) {
+        self.user_data()
+            .insert_if_missing_threadsafe(|| FifoBarriers(Mutex::new(Vec::new())));
+    }
+
+    fn fifo_barrier(&self, barrier: Barrier, client: Client) {
+        let user_data = self.user_data();
+        user_data.insert_if_missing_threadsafe(|| FifoBarriers(Mutex::new(Vec::new())));
+        if let Some(barriers) = user_data.get::<FifoBarriers>()
+            && let Ok(mut barriers_vec) = barriers.0.lock()
+        {
+            barriers_vec.push(FifoBarrierItem { barrier, client });
+        }
+    }
+
+    fn signal_fifo(&self, state: &mut State) {
+        let Some(fifo_barriers) = self.user_data().get::<FifoBarriers>() else {
+            return;
+        };
+
+        let dh = &state.common.display_handle.clone();
+        fifo_barriers.0.lock().unwrap().drain(..).for_each(|item| {
+            item.barrier.signal();
+            state
+                .client_compositor_state(&item.client)
+                .blocker_cleared(state, dh);
+        });
     }
 }

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -1,4 +1,5 @@
 use cosmic_comp_config::output::comp::{AdaptiveSync, OutputConfig, OutputState};
+use parking_lot::RwLock;
 use smithay::{
     backend::drm::VrrSupport as Support,
     output::{Output, WeakOutput},
@@ -19,6 +20,7 @@ use std::{
         Mutex,
         atomic::{AtomicU8, Ordering},
     },
+    time::Duration,
 };
 
 pub trait OutputExt {
@@ -42,6 +44,9 @@ pub trait OutputExt {
     fn init_fifo(&self);
     fn fifo_barrier(&self, barrier: Barrier, client: Client);
     fn signal_fifo(&self, state: &mut State);
+
+    fn set_avg_frametime(&self, duration: Option<Duration>);
+    fn get_avg_frametime(&self) -> Option<Duration>;
 }
 
 struct Vrr(AtomicU8);
@@ -56,6 +61,8 @@ pub struct FifoBarrierItem {
 
 #[derive(Default)]
 struct FifoBarriers(Mutex<Vec<FifoBarrierItem>>);
+
+struct AvgFrameTime(RwLock<Option<Duration>>);
 
 impl OutputExt for Output {
     fn is_internal(&self) -> bool {
@@ -210,5 +217,17 @@ impl OutputExt for Output {
                 .client_compositor_state(&item.client)
                 .blocker_cleared(state, dh);
         });
+    }
+
+    fn set_avg_frametime(&self, duration: Option<Duration>) {
+        let user_data = self.user_data();
+        user_data.insert_if_missing_threadsafe(|| AvgFrameTime(RwLock::new(None)));
+        if let Some(avg_frametime) = user_data.get::<AvgFrameTime>() {
+            *avg_frametime.0.write() = duration;
+        }
+    }
+
+    fn get_avg_frametime(&self) -> Option<Duration> {
+        *self.user_data().get::<AvgFrameTime>()?.0.read()
     }
 }

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -41,7 +41,6 @@ pub trait OutputExt {
 
     fn edid(&self) -> Option<&EdidProduct>;
 
-    fn init_fifo(&self);
     fn fifo_barrier(&self, barrier: Barrier, client: Client);
     fn signal_fifo(&self, state: &mut State);
 
@@ -190,19 +189,13 @@ impl OutputExt for Output {
         self.user_data().get()
     }
 
-    fn init_fifo(&self) {
-        self.user_data()
-            .insert_if_missing_threadsafe(|| FifoBarriers(Mutex::new(Vec::new())));
-    }
-
     fn fifo_barrier(&self, barrier: Barrier, client: Client) {
-        let user_data = self.user_data();
-        user_data.insert_if_missing_threadsafe(|| FifoBarriers(Mutex::new(Vec::new())));
-        if let Some(barriers) = user_data.get::<FifoBarriers>()
-            && let Ok(mut barriers_vec) = barriers.0.lock()
-        {
-            barriers_vec.push(FifoBarrierItem { barrier, client });
-        }
+        self.user_data()
+            .get_or_insert_threadsafe(|| FifoBarriers(Mutex::new(Vec::new())))
+            .0
+            .lock()
+            .unwrap()
+            .push(FifoBarrierItem { barrier, client });
     }
 
     fn signal_fifo(&self, state: &mut State) {
@@ -220,11 +213,11 @@ impl OutputExt for Output {
     }
 
     fn set_avg_frametime(&self, duration: Option<Duration>) {
-        let user_data = self.user_data();
-        user_data.insert_if_missing_threadsafe(|| AvgFrameTime(RwLock::new(None)));
-        if let Some(avg_frametime) = user_data.get::<AvgFrameTime>() {
-            *avg_frametime.0.write() = duration;
-        }
+        *self
+            .user_data()
+            .get_or_insert_threadsafe(|| AvgFrameTime(RwLock::new(None)))
+            .0
+            .write() = duration;
     }
 
     fn get_avg_frametime(&self) -> Option<Duration> {

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{shell::grabs::SeatMoveGrabState, state::ClientState, utils::prelude::*};
-use calloop::Interest;
+use calloop::{
+    Interest,
+    timer::{TimeoutAction, Timer},
+};
 use smithay::{
     backend::{
         input::InputTime,
@@ -14,6 +17,7 @@ use smithay::{
     reexports::wayland_server::{Client, Resource, protocol::wl_surface::WlSurface},
     utils::{Clock, Logical, Monotonic, SERIAL_COUNTER, Size, Time},
     wayland::{
+        commit_timing::{CommitTimerBarrierStateUserData, CommitTimerStateUserData, Timestamp},
         compositor::{
             BufferAssignment, CompositorClientState, CompositorHandler, CompositorState,
             SurfaceAttributes, SurfaceData, TraversalAction, add_blocker, add_post_commit_hook,
@@ -235,6 +239,27 @@ impl CompositorHandler for State {
             }
         });
 
+        add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
+            let timestamp = with_states(surface, |states| {
+                states
+                    .data_map
+                    .get::<CommitTimerStateUserData>()
+                    .and_then(|state| state.borrow_mut().timestamp.take())
+            });
+
+            if let Some(timestamp) = timestamp {
+                let barrier = with_states(surface, |states| {
+                    let barrier_state = states
+                        .data_map
+                        .get_or_insert(CommitTimerBarrierStateUserData::default);
+                    barrier_state.lock().unwrap().register(timestamp)
+                });
+
+                add_blocker(surface, barrier);
+                state.schedule_commit_timing(surface, timestamp);
+            }
+        });
+
         add_post_commit_hook::<Self, _>(surface, |state, _dh, surface| {
             let now = state.common.clock.now();
             with_states(surface, |states| {
@@ -378,6 +403,57 @@ impl CompositorHandler for State {
 }
 
 impl State {
+    fn schedule_commit_timing(&self, surface: &WlSurface, deadline: Timestamp) {
+        // TODO: further improve the timing based on render time and vblank timing
+        let next_deadline = Time::elapsed(&self.common.clock.now(), deadline.into());
+        let timer = Timer::from_duration(next_deadline);
+        let week_surface = surface.downgrade();
+
+        let _ = self
+            .common
+            .event_loop_handle
+            .insert_source(timer, move |_instant, _, state| {
+                let Ok(surface) = week_surface.upgrade() else {
+                    return TimeoutAction::Drop;
+                };
+
+                let Some(client) = surface.client() else {
+                    return TimeoutAction::Drop;
+                };
+
+                let Some((signaled, next_deadline)) = with_states(&surface, |states| {
+                    let Some(commit_timer_barrier_state) =
+                        states.data_map.get::<CommitTimerBarrierStateUserData>()
+                    else {
+                        return None;
+                    };
+
+                    let mut commit_timer_barrier_state = commit_timer_barrier_state.lock().unwrap();
+
+                    Some((
+                        commit_timer_barrier_state.signal_until(deadline),
+                        commit_timer_barrier_state.next_deadline(),
+                    ))
+                }) else {
+                    return TimeoutAction::Drop;
+                };
+
+                if signaled {
+                    let dh = &state.common.display_handle.clone();
+                    state
+                        .client_compositor_state(&client)
+                        .blocker_cleared(state, dh);
+                }
+
+                if let Some(deadline) = next_deadline {
+                    state.schedule_commit_timing(&surface, deadline);
+                }
+
+                TimeoutAction::Drop
+            })
+            .expect("failed to register commit-timing timer");
+    }
+
     fn send_initial_configure_and_map(&mut self, surface: &WlSurface) -> bool {
         let mut shell = self.common.shell.write();
 

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -19,12 +19,13 @@ use smithay::{
     wayland::{
         commit_timing::{CommitTimerBarrierStateUserData, CommitTimerStateUserData, Timestamp},
         compositor::{
-            BufferAssignment, CompositorClientState, CompositorHandler, CompositorState,
+            Barrier, BufferAssignment, CompositorClientState, CompositorHandler, CompositorState,
             SurfaceAttributes, SurfaceData, TraversalAction, add_blocker, add_post_commit_hook,
-            add_pre_commit_hook, with_states, with_surface_tree_downward,
+            add_pre_commit_hook, is_sync_subsurface, with_states, with_surface_tree_downward,
         },
         dmabuf::get_dmabuf,
         drm_syncobj::DrmSyncobjCachedState,
+        fifo::{FifoBarrierCachedState, FifoCachedState},
         seat::WaylandFocus,
         shell::{
             wlr_layer::LayerSurfaceAttributes,
@@ -260,6 +261,59 @@ impl CompositorHandler for State {
             }
         });
 
+        add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
+            let fifo_barrier = with_states(surface, |states| {
+                let fifo_state = *states.cached_state.get::<FifoCachedState>().pending();
+
+                // The pending state will contain any previously set barrier on this surface
+                // In case this commit updates the barrier with `set_barrier`, but also mandates to
+                // wait for a previously set barrier it is important to first retrieve the previously
+                // set barrier to not overwrite it with our own.
+                let fifo_barrier = fifo_state
+                    .wait_barrier
+                    .then(|| {
+                        states
+                            .cached_state
+                            .get::<FifoBarrierCachedState>()
+                            .pending()
+                            .barrier
+                            .take()
+                    })
+                    .flatten();
+
+                // If requested set the barrier for this commit.
+                // The barrier will be available for the next commit requesting to wait on it
+                // in the pending state.
+                // The barrier will also be either put in the current state in case this commit
+                // is not blocked or into a transaction otherwise eventually ending in the current
+                // state when it is unblocked.
+                if fifo_state.set_barrier {
+                    states
+                        .cached_state
+                        .get::<FifoBarrierCachedState>()
+                        .pending()
+                        .barrier = Some(Barrier::new(false));
+                }
+
+                fifo_barrier
+            });
+
+            if let Some(barrier) = fifo_barrier {
+                let skip = barrier.is_signaled() || is_sync_subsurface(surface);
+                if !skip
+                    && let Some(output) = state
+                        .common
+                        .shell
+                        .read()
+                        .visible_output_for_surface(surface)
+                    && let Some(client) = surface.client()
+                {
+                    add_blocker(surface, barrier.clone());
+                    output.fifo_barrier(barrier, client);
+                }
+            }
+        });
+
         add_post_commit_hook::<Self, _>(surface, |state, _dh, surface| {
             let now = state.common.clock.now();
             with_states(surface, |states| {
@@ -407,13 +461,13 @@ impl State {
         // TODO: further improve the timing based on render time and vblank timing
         let next_deadline = Time::elapsed(&self.common.clock.now(), deadline.into());
         let timer = Timer::from_duration(next_deadline);
-        let week_surface = surface.downgrade();
+        let weak_surface = surface.downgrade();
 
         let _ = self
             .common
             .event_loop_handle
             .insert_source(timer, move |_instant, _, state| {
-                let Ok(surface) = week_surface.upgrade() else {
+                let Ok(surface) = weak_surface.upgrade() else {
                     return TimeoutAction::Drop;
                 };
 
@@ -422,13 +476,11 @@ impl State {
                 };
 
                 let Some((signaled, next_deadline)) = with_states(&surface, |states| {
-                    let Some(commit_timer_barrier_state) =
-                        states.data_map.get::<CommitTimerBarrierStateUserData>()
-                    else {
-                        return None;
-                    };
-
-                    let mut commit_timer_barrier_state = commit_timer_barrier_state.lock().unwrap();
+                    let mut commit_timer_barrier_state = states
+                        .data_map
+                        .get::<CommitTimerBarrierStateUserData>()?
+                        .lock()
+                        .unwrap();
 
                     Some((
                         commit_timer_barrier_state.signal_until(deadline),

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -458,9 +458,20 @@ impl CompositorHandler for State {
 
 impl State {
     fn schedule_commit_timing(&self, surface: &WlSurface, deadline: Timestamp) {
-        // TODO: further improve the timing based on render time and vblank timing
+        const SAFE_MARGE: Duration = Duration::from_millis(1);
         let next_deadline = Time::elapsed(&self.common.clock.now(), deadline.into());
-        let timer = Timer::from_duration(next_deadline);
+
+        let target_deadline = if let Some(output) =
+            self.common.shell.read().visible_output_for_surface(surface)
+            && let Some(avg_frametime) = output.get_avg_frametime()
+        {
+            // content update should be presented as closely as possible to, but not before, a specified time
+            next_deadline.saturating_sub(avg_frametime.saturating_sub(SAFE_MARGE))
+        } else {
+            next_deadline
+        };
+
+        let timer: Timer = Timer::from_duration(target_deadline);
         let weak_surface = surface.downgrade();
 
         let _ = self

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -21,11 +21,11 @@ use smithay::{
         compositor::{
             Barrier, BufferAssignment, CompositorClientState, CompositorHandler, CompositorState,
             SurfaceAttributes, SurfaceData, TraversalAction, add_blocker, add_post_commit_hook,
-            add_pre_commit_hook, is_sync_subsurface, with_states, with_surface_tree_downward,
+            add_pre_commit_hook, with_states, with_surface_tree_downward,
         },
         dmabuf::get_dmabuf,
         drm_syncobj::DrmSyncobjCachedState,
-        fifo::{FifoBarrierCachedState, FifoCachedState},
+        fifo::FifoBarrierCachedState,
         seat::WaylandFocus,
         shell::{
             wlr_layer::LayerSurfaceAttributes,
@@ -198,57 +198,6 @@ impl CompositorHandler for State {
                 state.schedule_commit_timing(surface, timestamp, Some(barrier));
             }
 
-            let fifo_barrier = with_states(surface, |states| {
-                let fifo_state = *states.cached_state.get::<FifoCachedState>().pending();
-
-                // The pending state will contain any previously set barrier on this surface
-                // In case this commit updates the barrier with `set_barrier`, but also mandates to
-                // wait for a previously set barrier it is important to first retrieve the previously
-                // set barrier to not overwrite it with our own.
-                let fifo_barrier = fifo_state
-                    .wait_barrier
-                    .then(|| {
-                        states
-                            .cached_state
-                            .get::<FifoBarrierCachedState>()
-                            .pending()
-                            .barrier
-                            .take()
-                    })
-                    .flatten();
-
-                // If requested set the barrier for this commit.
-                // The barrier will be available for the next commit requesting to wait on it
-                // in the pending state.
-                // The barrier will also be either put in the current state in case this commit
-                // is not blocked or into a transaction otherwise eventually ending in the current
-                // state when it is unblocked.
-                if fifo_state.set_barrier {
-                    states
-                        .cached_state
-                        .get::<FifoBarrierCachedState>()
-                        .pending()
-                        .barrier = Some(Barrier::new(false));
-                }
-
-                fifo_barrier
-            });
-
-            if let Some(barrier) = fifo_barrier {
-                let skip = barrier.is_signaled() || is_sync_subsurface(surface);
-                if !skip
-                    && let Some(output) = state
-                        .common
-                        .shell
-                        .read()
-                        .visible_output_for_surface(surface)
-                    && let Some(client) = surface.client()
-                {
-                    add_blocker(surface, barrier.clone());
-                    output.fifo_barrier(barrier, client);
-                }
-            }
-
             let mut acquire_point = None;
             let maybe_dmabuf = with_states(surface, |surface_data| {
                 acquire_point = surface_data
@@ -331,6 +280,40 @@ impl CompositorHandler for State {
                 }
                 data.last_commit = Some(now);
             });
+
+            let fifo_barrier = with_states(surface, |states| {
+                states
+                    .cached_state
+                    .get::<FifoBarrierCachedState>()
+                    .current()
+                    .barrier
+                    .take()
+            });
+
+            if let Some(barrier) = fifo_barrier
+                && let Some(client) = surface.client()
+            {
+                if let Some(output) = state
+                    .common
+                    .shell
+                    .read()
+                    .visible_output_for_surface(surface)
+                {
+                    output.fifo_barrier(barrier, client);
+                } else {
+                    let _ = state.common.event_loop_handle.insert_source(
+                        Timer::immediate(),
+                        move |_, _, state| {
+                            barrier.signal();
+                            let dh = state.common.display_handle.clone();
+                            state
+                                .client_compositor_state(&client)
+                                .blocker_cleared(state, &dh);
+                            TimeoutAction::Drop
+                        },
+                    );
+                }
+            }
         });
     }
 

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -180,6 +180,75 @@ impl CompositorHandler for State {
 
     fn new_surface(&mut self, surface: &WlSurface) {
         add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
+            let timestamp = with_states(surface, |states| {
+                states
+                    .data_map
+                    .get::<CommitTimerStateUserData>()
+                    .and_then(|state| state.borrow_mut().timestamp.take())
+            });
+
+            if let Some(timestamp) = timestamp {
+                let barrier = with_states(surface, |states| {
+                    let barrier_state = states
+                        .data_map
+                        .get_or_insert(CommitTimerBarrierStateUserData::default);
+                    barrier_state.lock().unwrap().register(timestamp)
+                });
+
+                state.schedule_commit_timing(surface, timestamp, Some(barrier));
+            }
+
+            let fifo_barrier = with_states(surface, |states| {
+                let fifo_state = *states.cached_state.get::<FifoCachedState>().pending();
+
+                // The pending state will contain any previously set barrier on this surface
+                // In case this commit updates the barrier with `set_barrier`, but also mandates to
+                // wait for a previously set barrier it is important to first retrieve the previously
+                // set barrier to not overwrite it with our own.
+                let fifo_barrier = fifo_state
+                    .wait_barrier
+                    .then(|| {
+                        states
+                            .cached_state
+                            .get::<FifoBarrierCachedState>()
+                            .pending()
+                            .barrier
+                            .take()
+                    })
+                    .flatten();
+
+                // If requested set the barrier for this commit.
+                // The barrier will be available for the next commit requesting to wait on it
+                // in the pending state.
+                // The barrier will also be either put in the current state in case this commit
+                // is not blocked or into a transaction otherwise eventually ending in the current
+                // state when it is unblocked.
+                if fifo_state.set_barrier {
+                    states
+                        .cached_state
+                        .get::<FifoBarrierCachedState>()
+                        .pending()
+                        .barrier = Some(Barrier::new(false));
+                }
+
+                fifo_barrier
+            });
+
+            if let Some(barrier) = fifo_barrier {
+                let skip = barrier.is_signaled() || is_sync_subsurface(surface);
+                if !skip
+                    && let Some(output) = state
+                        .common
+                        .shell
+                        .read()
+                        .visible_output_for_surface(surface)
+                    && let Some(client) = surface.client()
+                {
+                    add_blocker(surface, barrier.clone());
+                    output.fifo_barrier(barrier, client);
+                }
+            }
+
             let mut acquire_point = None;
             let maybe_dmabuf = with_states(surface, |surface_data| {
                 acquire_point = surface_data
@@ -236,80 +305,6 @@ impl CompositorHandler for State {
                     if res.is_ok() {
                         add_blocker(surface, blocker);
                     }
-                }
-            }
-        });
-
-        add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
-            let timestamp = with_states(surface, |states| {
-                states
-                    .data_map
-                    .get::<CommitTimerStateUserData>()
-                    .and_then(|state| state.borrow_mut().timestamp.take())
-            });
-
-            if let Some(timestamp) = timestamp {
-                let barrier = with_states(surface, |states| {
-                    let barrier_state = states
-                        .data_map
-                        .get_or_insert(CommitTimerBarrierStateUserData::default);
-                    barrier_state.lock().unwrap().register(timestamp)
-                });
-
-                add_blocker(surface, barrier);
-                state.schedule_commit_timing(surface, timestamp);
-            }
-        });
-
-        add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
-            let fifo_barrier = with_states(surface, |states| {
-                let fifo_state = *states.cached_state.get::<FifoCachedState>().pending();
-
-                // The pending state will contain any previously set barrier on this surface
-                // In case this commit updates the barrier with `set_barrier`, but also mandates to
-                // wait for a previously set barrier it is important to first retrieve the previously
-                // set barrier to not overwrite it with our own.
-                let fifo_barrier = fifo_state
-                    .wait_barrier
-                    .then(|| {
-                        states
-                            .cached_state
-                            .get::<FifoBarrierCachedState>()
-                            .pending()
-                            .barrier
-                            .take()
-                    })
-                    .flatten();
-
-                // If requested set the barrier for this commit.
-                // The barrier will be available for the next commit requesting to wait on it
-                // in the pending state.
-                // The barrier will also be either put in the current state in case this commit
-                // is not blocked or into a transaction otherwise eventually ending in the current
-                // state when it is unblocked.
-                if fifo_state.set_barrier {
-                    states
-                        .cached_state
-                        .get::<FifoBarrierCachedState>()
-                        .pending()
-                        .barrier = Some(Barrier::new(false));
-                }
-
-                fifo_barrier
-            });
-
-            if let Some(barrier) = fifo_barrier {
-                let skip = barrier.is_signaled() || is_sync_subsurface(surface);
-                if !skip
-                    && let Some(output) = state
-                        .common
-                        .shell
-                        .read()
-                        .visible_output_for_surface(surface)
-                    && let Some(client) = surface.client()
-                {
-                    add_blocker(surface, barrier.clone());
-                    output.fifo_barrier(barrier, client);
                 }
             }
         });
@@ -457,8 +452,12 @@ impl CompositorHandler for State {
 }
 
 impl State {
-    fn schedule_commit_timing(&self, surface: &WlSurface, deadline: Timestamp) {
-        const SAFE_MARGE: Duration = Duration::from_millis(1);
+    fn schedule_commit_timing(
+        &self,
+        surface: &WlSurface,
+        deadline: Timestamp,
+        barrier: Option<Barrier>,
+    ) {
         let next_deadline = Time::elapsed(&self.common.clock.now(), deadline.into());
 
         let target_deadline = if let Some(output) =
@@ -466,10 +465,19 @@ impl State {
             && let Some(avg_frametime) = output.get_avg_frametime()
         {
             // content update should be presented as closely as possible to, but not before, a specified time
-            next_deadline.saturating_sub(avg_frametime.saturating_sub(SAFE_MARGE))
+            next_deadline.saturating_sub(avg_frametime)
         } else {
             next_deadline
         };
+
+        if !target_deadline.is_zero()
+            && let Some(barrier) = barrier
+        {
+            add_blocker(surface, barrier);
+        } else if target_deadline.is_zero() && barrier.is_some() {
+            // let it go
+            return;
+        }
 
         let timer: Timer = Timer::from_duration(target_deadline);
         let weak_surface = surface.downgrade();
@@ -509,7 +517,7 @@ impl State {
                 }
 
                 if let Some(deadline) = next_deadline {
-                    state.schedule_commit_timing(&surface, deadline);
+                    state.schedule_commit_timing(&surface, deadline, None);
                 }
 
                 TimeoutAction::Drop


### PR DESCRIPTION
related: https://github.com/pop-os/cosmic-comp/pull/1549

The main purpose of this PR is to verify that the `commit-timing-1` and `fifo-1` functionality work correctly.

Test conditions:
- Vsync ON
- Enable built-in frame limiter
- PROTON_ENABLE_WAYLAND=1
- Disable DLSS, FSR, XeSS (those tech will force Vsync to turn off)
- WAYLAND_DEBUG show `wp_commit_timer_v1` and `wp_fifo_v1`
- no crash, no hang indefinitely and frame limiter work = :white_check_mark:

| Game | Vulkan | DXVK | VKD3D | Note |
|----------|------------|---------|------------| -------|
|   Ready or Not    |        |      |  :white_check_mark:    |  AMD  |
|   Elden Ring    |        |      |  :white_check_mark:    |  AMD  |
|   STAR WARS Zero Company    |        |      |  :white_check_mark:    |  AMD  |
|   MONSTER HUNTER WILD    |        |      |  :white_check_mark:    |  AMD  |
|   ARC Raiders    |        |      |  :white_check_mark:    |  AMD  |
|   PRAGMATA   |        |      |  :white_check_mark:    |  AMD  |
|   Sekiro™: Shadows Die Twice   |        |   :white_check_mark:   |    |  AMD  |

Note: if someone want to test DXVK game, you need custon proton: https://github.com/NelloKudo/proton-dev/actions/runs/33871680219 and `PROTON_PRESENT_TIMING=1 PROTON_ENABLE_WAYLAND=1`

logs sample:

```
[12:38:32.982612] {mesa vk surface 39 swapchain 2 queue} wp_presentation_feedback#60.sync_output(wl_output#22)
[12:38:32.982619] {mesa vk surface 39 swapchain 2 queue} wp_presentation_feedback#60.presented(0, 5433, 958401000, 4166840, 0, 34657727, 7)
[12:38:32.984089] {mesa vk display queue}  -> wp_linux_drm_syncobj_surface_v1#65.set_acquire_point(wp_linux_drm_syncobj_timeline_v1#63, 0, 10)
[12:38:32.984097] {mesa vk display queue}  -> wp_linux_drm_syncobj_surface_v1#65.set_release_point(wp_linux_drm_syncobj_timeline_v1#68, 0, 10)
[12:38:32.984102] {mesa vk display queue}  -> wl_surface#39.attach(wl_buffer#75, 0, 0)
[12:38:32.984104] {mesa vk display queue}  -> wl_surface#39.damage_buffer(0, 0, 2147483647, 2147483647)
[12:38:32.984107] {mesa vk display queue}  -> wp_commit_timer_v1#57.set_timestamp(0, 5433, 970401520)
[12:38:32.984111] {mesa vk surface 39 swapchain 2 queue}  -> wp_presentation#43.feedback(wl_surface#39, new id wp_presentation_feedback#60)
[12:38:32.984121] {mesa vk display queue}  -> wp_fifo_v1#56.set_barrier()
[12:38:32.984129] {mesa vk display queue}  -> wp_fifo_v1#56.wait_barrier()
[12:38:32.984136] {mesa vk display queue}  -> wl_surface#39.commit()
[12:38:32.984144] {mesa vk display queue}  -> wp_fifo_v1#56.wait_barrier()
[12:38:32.984151] {mesa vk display queue}  -> wl_surface#39.commit()
[12:38:32.984174] {mesa vk display queue} discarded wl_buffer#79.release()
[12:38:32.986777] {Display Queue} wl_display#1.delete_id(62)
[12:38:32.986787] {mesa vk surface 39 swapchain 2 queue} wp_presentation_feedback#62.sync_output(wl_output#22)
[12:38:32.986793] {mesa vk surface 39 swapchain 2 queue} wp_presentation_feedback#62.presented(0, 5433, 962567000, 4166840, 0, 34657728, 7)
```


~need: https://github.com/Smithay/smithay/pull/2149~

~The purpose of this PR is to serve as a proof of concept (POC) for validating the `schedule_barrier` handler I added to Smithay.~  No longer need to update smithay.

~The `OutputSurface` introduced in this PR is optional rather than required. It is only used to make it easier for me to iterate on and test the output/window behavior during development, and is not intended to be a fundamental requirement of the approach.~ No longer need to lookup


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

