### PR TITLE
fix: keep Xwayland frame callbacks progressing

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -139,6 +139,14 @@ struct Localizations;
 pub static LANG_LOADER: LazyLock<FluentLanguageLoader> =
     LazyLock::new(|| fluent_language_loader!());
 
+fn xwayland_frame_throttle(throttle: Option<Duration>, is_xwayland: bool) -> Option<Duration> {
+    if is_xwayland {
+        Some(Duration::ZERO)
+    } else {
+        throttle
+    }
+}
+
 #[macro_export]
 macro_rules! fl {
     ($message_id:literal) => {{
@@ -1365,7 +1373,9 @@ impl Common {
                 && let Some(grab_state) = move_grab.lock().unwrap().as_ref()
             {
                 for (window, _) in grab_state.element().windows() {
-                    window.send_frame(output, time, throttle(&window), should_send);
+                    let throttle =
+                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    window.send_frame(output, time, throttle, should_send);
                 }
             }
 
@@ -1389,25 +1399,34 @@ impl Common {
             .mapped()
             .for_each(|mapped| {
                 for (window, _) in mapped.windows() {
-                    window.send_frame(output, time, throttle(&window), should_send);
+                    let throttle =
+                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    window.send_frame(output, time, throttle, should_send);
                 }
             });
 
         if let Some(active) = shell.active_space(output) {
             if let Some(fs) = active.get_fullscreen(shell.seats.last_active()) {
-                fs.surface
-                    .send_frame(output, time, throttle(&fs.surface), should_send);
+                let throttle = xwayland_frame_throttle(
+                    throttle(&fs.surface),
+                    fs.surface.x11_surface().is_some(),
+                );
+                fs.surface.send_frame(output, time, throttle, should_send);
             }
             active.mapped().for_each(|mapped| {
                 for (window, _) in mapped.windows() {
-                    window.send_frame(output, time, throttle(&window), should_send);
+                    let throttle =
+                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    window.send_frame(output, time, throttle, should_send);
                 }
             });
 
             // other (throttled) windows
             active.minimized_windows.iter().for_each(|m| {
                 for window in m.windows() {
-                    window.send_frame(output, time, throttle(&window), |_, _| None);
+                    let throttle =
+                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    window.send_frame(output, time, throttle, |_, _| None);
                 }
             });
 
@@ -1418,17 +1437,25 @@ impl Common {
             {
                 if let Some(fs) = space.get_fullscreen(shell.seats.last_active()) {
                     let throttle = min(throttle(space), throttle(&fs.surface));
+                    let throttle =
+                        xwayland_frame_throttle(throttle, fs.surface.x11_surface().is_some());
                     fs.surface.send_frame(output, time, throttle, |_, _| None);
                 }
                 space.mapped().for_each(|mapped| {
                     for (window, _) in mapped.windows() {
                         let throttle = min(throttle(space), throttle(&window));
+                        let throttle =
+                            xwayland_frame_throttle(throttle, window.x11_surface().is_some());
                         window.send_frame(output, time, throttle, |_, _| None);
                     }
                 });
                 space.minimized_windows.iter().for_each(|m| {
                     for window in m.windows() {
-                        window.send_frame(output, time, throttle(&window), |_, _| None);
+                        let throttle = xwayland_frame_throttle(
+                            throttle(&window),
+                            window.x11_surface().is_some(),
+                        );
+                        window.send_frame(output, time, throttle, |_, _| None);
                     }
                 })
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -139,14 +139,6 @@ struct Localizations;
 pub static LANG_LOADER: LazyLock<FluentLanguageLoader> =
     LazyLock::new(|| fluent_language_loader!());
 
-fn xwayland_frame_throttle(throttle: Option<Duration>, is_xwayland: bool) -> Option<Duration> {
-    if is_xwayland {
-        Some(Duration::ZERO)
-    } else {
-        throttle
-    }
-}
-
 #[macro_export]
 macro_rules! fl {
     ($message_id:literal) => {{
@@ -1336,8 +1328,12 @@ impl Common {
         const THROTTLE: Option<Duration> = Some(Duration::from_millis(995));
         const SCREENCOPY_THROTTLE: Option<Duration> = Some(Duration::from_nanos(16_666_666));
 
-        fn throttle(session_holder: &impl SessionHolder) -> Option<Duration> {
-            if session_holder.sessions().is_empty() && session_holder.cursor_sessions().is_empty() {
+        fn throttle(session_holder: &impl SessionHolder, is_xwayland: bool) -> Option<Duration> {
+            if is_xwayland {
+                Some(Duration::ZERO)
+            } else if session_holder.sessions().is_empty()
+                && session_holder.cursor_sessions().is_empty()
+            {
                 THROTTLE
             } else {
                 SCREENCOPY_THROTTLE
@@ -1373,8 +1369,7 @@ impl Common {
                 && let Some(grab_state) = move_grab.lock().unwrap().as_ref()
             {
                 for (window, _) in grab_state.element().windows() {
-                    let throttle =
-                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    let throttle = throttle(&window, window.x11_surface().is_some());
                     window.send_frame(output, time, throttle, should_send);
                 }
             }
@@ -1399,24 +1394,19 @@ impl Common {
             .mapped()
             .for_each(|mapped| {
                 for (window, _) in mapped.windows() {
-                    let throttle =
-                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    let throttle = throttle(&window, window.x11_surface().is_some());
                     window.send_frame(output, time, throttle, should_send);
                 }
             });
 
         if let Some(active) = shell.active_space(output) {
             if let Some(fs) = active.get_fullscreen(shell.seats.last_active()) {
-                let throttle = xwayland_frame_throttle(
-                    throttle(&fs.surface),
-                    fs.surface.x11_surface().is_some(),
-                );
+                let throttle = throttle(&fs.surface, fs.surface.x11_surface().is_some());
                 fs.surface.send_frame(output, time, throttle, should_send);
             }
             active.mapped().for_each(|mapped| {
                 for (window, _) in mapped.windows() {
-                    let throttle =
-                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    let throttle = throttle(&window, window.x11_surface().is_some());
                     window.send_frame(output, time, throttle, should_send);
                 }
             });
@@ -1424,8 +1414,7 @@ impl Common {
             // other (throttled) windows
             active.minimized_windows.iter().for_each(|m| {
                 for window in m.windows() {
-                    let throttle =
-                        xwayland_frame_throttle(throttle(&window), window.x11_surface().is_some());
+                    let throttle = throttle(&window, window.x11_surface().is_some());
                     window.send_frame(output, time, throttle, |_, _| None);
                 }
             });
@@ -1436,25 +1425,24 @@ impl Common {
                 .filter(|w| w.handle != active.handle)
             {
                 if let Some(fs) = space.get_fullscreen(shell.seats.last_active()) {
-                    let throttle = min(throttle(space), throttle(&fs.surface));
-                    let throttle =
-                        xwayland_frame_throttle(throttle, fs.surface.x11_surface().is_some());
+                    let throttle = min(
+                        throttle(space, false),
+                        throttle(&fs.surface, fs.surface.x11_surface().is_some()),
+                    );
                     fs.surface.send_frame(output, time, throttle, |_, _| None);
                 }
                 space.mapped().for_each(|mapped| {
                     for (window, _) in mapped.windows() {
-                        let throttle = min(throttle(space), throttle(&window));
-                        let throttle =
-                            xwayland_frame_throttle(throttle, window.x11_surface().is_some());
+                        let throttle = min(
+                            throttle(space, false),
+                            throttle(&window, window.x11_surface().is_some()),
+                        );
                         window.send_frame(output, time, throttle, |_, _| None);
                     }
                 });
                 space.minimized_windows.iter().for_each(|m| {
                     for window in m.windows() {
-                        let throttle = xwayland_frame_throttle(
-                            throttle(&window),
-                            window.x11_surface().is_some(),
-                        );
+                        let throttle = throttle(&window, window.x11_surface().is_some());
                         window.send_frame(output, time, throttle, |_, _| None);
                     }
                 })


### PR DESCRIPTION
This fixes sluggish Steam overlays in fullscreen Xwayland games. It does so by letting frame callbacks keep advancing for mapped X11 windows, even ones that are hidden behind other windows or minimized. Native Wayland windows are unaffected and keep their current visibility-based throttling.

fixes #2799

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

