### PR TITLE
fix(xwayland): Properly hide KDE video bridge

### DIFF
--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -653,6 +653,8 @@ impl CosmicMapped {
             return None;
         }
 
+        let alpha = self.active_window().effective_render_alpha(alpha);
+
         match &self.element {
             CosmicMappedInternal::Stack(s) => s
                 .shadow_render_element::<R, CosmicMappedRenderElement<R>>(
@@ -694,6 +696,8 @@ impl CosmicMapped {
         R::TextureId: Send + Clone + 'static,
         CosmicMappedRenderElement<R>: RenderElement<R>,
     {
+        let alpha = self.active_window().effective_render_alpha(alpha);
+
         #[cfg(feature = "debug")]
         if let Some(debug) = self.debug.lock().unwrap().as_mut() {
             let window = self.active_window();

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -211,6 +211,15 @@ struct Sticky(AtomicBool);
 struct GlobalGeometry(Mutex<Option<Rectangle<i32, Global>>>);
 
 impl CosmicSurface {
+    pub fn effective_render_alpha(&self, alpha: f32) -> f32 {
+        match self.0.underlying_surface() {
+            WindowSurface::Wayland(_) => alpha,
+            WindowSurface::X11(surface) => {
+                alpha * surface.opacity().unwrap_or(u32::MAX) as f32 / u32::MAX as f32
+            }
+        }
+    }
+
     pub fn title(&self) -> String {
         match self.0.underlying_surface() {
             WindowSurface::Wayland(toplevel) => with_states(toplevel.wl_surface(), |states| {

--- a/src/shell/grabs/moving.rs
+++ b/src/shell/grabs/moving.rs
@@ -405,7 +405,10 @@ impl MoveGrab {
             let mut window_geo = self.window.geometry();
             window_geo.loc += location.to_i32_round() + grab_state.window_offset;
 
-            if matches!(self.previous, ManagedLayer::Floating | ManagedLayer::Sticky) {
+            if matches!(
+                self.previous,
+                ManagedLayer::Floating | ManagedLayer::Below | ManagedLayer::Sticky
+            ) {
                 let loc = grab_state.window_offset.to_f64() + grab_state.location;
                 let size = window_geo.size.to_f64();
                 let output_geom = self.cursor_output.geometry().to_f64().as_logical();
@@ -843,6 +846,18 @@ impl Drop for MoveGrab {
                                 .unwrap()
                                 .tiling_layer
                                 .drop_window(grab_state.window);
+                            Some((window, location.to_global(&output)))
+                        }
+                        ManagedLayer::Below => {
+                            grab_state.window.set_geometry(Rectangle::new(
+                                window_location,
+                                grab_state.window.geometry().size.as_global(),
+                            ));
+                            let workspace = shell.active_space_mut(&output).unwrap();
+                            let (window, location) = workspace.below_layer.drop_window(
+                                grab_state.window,
+                                window_location.to_local(&workspace.output),
+                            );
                             Some((window, location.to_global(&output)))
                         }
                         _ => {

--- a/src/shell/layout/mod.rs
+++ b/src/shell/layout/mod.rs
@@ -101,3 +101,25 @@ pub fn has_floating_exception(exceptions: &TilingExceptions, window: &CosmicSurf
 
     false
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitialWindowLayer {
+    Below,
+    Floating,
+    Tiling,
+}
+
+pub fn initial_window_layer(
+    is_below: bool,
+    is_dialog: bool,
+    floating_exception: bool,
+    tiling_enabled: bool,
+) -> InitialWindowLayer {
+    if is_below {
+        InitialWindowLayer::Below
+    } else if is_dialog || floating_exception || !tiling_enabled {
+        InitialWindowLayer::Floating
+    } else {
+        InitialWindowLayer::Tiling
+    }
+}

--- a/src/shell/layout/tiling/mod.rs
+++ b/src/shell/layout/tiling/mod.rs
@@ -5418,7 +5418,7 @@ fn render_new_tree_windows<R>(
             renderer,
             render_loc,
             output_scale.into(),
-            1.0,
+            window.effective_render_alpha(1.0),
             None,
             scanout_node,
             false,

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2212,6 +2212,9 @@ impl Shell {
                         || w.tiling_layer
                             .mapped()
                             .any(|(m, _)| m.windows().any(|(s, _)| &s == surface))
+                        || w.below_layer
+                            .mapped()
+                            .any(|m| m.windows().any(|(s, _)| &s == surface))
                 })
         })
     }
@@ -2440,7 +2443,7 @@ impl Shell {
                 .floating_layer
                 .stacking_indicator(),
             ManagedLayer::Tiling => self.active_space(output)?.tiling_layer.stacking_indicator(),
-            ManagedLayer::Fullscreen => None,
+            ManagedLayer::Fullscreen | ManagedLayer::Below => None,
         }
     }
 
@@ -2703,6 +2706,7 @@ impl Shell {
         let seat = self.seats.last_active();
         let workspace = match &state {
             Some(FullscreenRestoreState::Floating { workspace, .. })
+            | Some(FullscreenRestoreState::Below { workspace, .. })
             | Some(FullscreenRestoreState::Tiling { workspace, .. }) => {
                 let workspace = self.workspaces.space_for_handle_mut(workspace);
                 let workspace = match workspace {
@@ -2773,6 +2777,25 @@ impl Shell {
                     );
                 } else if let Some(corners) = was_snapped {
                     workspace.floating_layer.snap_to_corner(&window, &corners);
+                }
+            }
+            Some(FullscreenRestoreState::Below { state, .. }) => {
+                workspace.below_layer.map_internal(
+                    window.clone(),
+                    Some(state.geometry.loc),
+                    Some(state.geometry.size.as_logical()),
+                    Some(fullscreen_geometry),
+                );
+                if state.was_maximized {
+                    let geometry = workspace.below_layer.element_geometry(&window).unwrap();
+                    *window.maximized_state.lock().unwrap() = Some(MaximizedState {
+                        original_geometry: geometry,
+                        original_layer: ManagedLayer::Below,
+                        original_snapped: None,
+                    });
+                    workspace
+                        .below_layer
+                        .map_maximized(window.clone(), geometry, true);
                 }
             }
             Some(FullscreenRestoreState::Tiling {
@@ -2914,7 +2937,16 @@ impl Shell {
             self.workspaces.active_mut(&output).unwrap()
         };
 
-        toplevel_info.new_toplevel(&window, workspace_state);
+        let x11_surface = window.x11_surface();
+        let is_below = x11_surface
+            .as_ref()
+            .is_some_and(|surface| surface.is_below());
+        let skip_taskbar = x11_surface
+            .as_ref()
+            .is_some_and(|surface| surface.is_skip_taskbar());
+        if !skip_taskbar {
+            toplevel_info.new_toplevel(&window, workspace_state);
+        }
         toplevel_enter_output(&window, &output);
         toplevel_enter_workspace(&window, &workspace.handle);
 
@@ -2926,6 +2958,12 @@ impl Shell {
         let workspace_handle = workspace.handle;
         let is_dialog = layout::is_dialog(&window);
         let floating_exception = layout::has_floating_exception(&self.tiling_exceptions, &window);
+        let initial_layer = layout::initial_window_layer(
+            is_below,
+            is_dialog,
+            floating_exception,
+            workspace.tiling_enabled,
+        );
 
         if should_be_fullscreen {
             workspace.map_fullscreen(&window, &seat, None, None);
@@ -2938,7 +2976,8 @@ impl Shell {
         }
 
         let maybe_focused = workspace.focus_stack.get(&seat).iter().next().cloned();
-        if let Some(FocusTarget::Window(focused)) = maybe_focused
+        if initial_layer != layout::InitialWindowLayer::Below
+            && let Some(FocusTarget::Window(focused)) = maybe_focused
             && let Some(stack) = focused.stack_ref()
             && !is_dialog
             && !should_be_minimized
@@ -2964,23 +3003,31 @@ impl Shell {
             mapped.set_debug(self.debug_active);
         }
 
-        let workspace_empty = workspace.mapped().next().is_none();
-        if is_dialog || floating_exception || !workspace.tiling_enabled {
-            workspace.floating_layer.map(mapped.clone(), None);
-        } else {
-            for mapped in workspace
-                .mapped()
-                .filter(|m| m.maximized_state.lock().unwrap().is_some())
-                .cloned()
-                .collect::<Vec<_>>()
-                .into_iter()
-            {
-                workspace.unmaximize_request(&mapped);
+        let workspace_empty = workspace.floating_layer.mapped().next().is_none()
+            && workspace.tiling_layer.mapped().next().is_none();
+        match initial_layer {
+            layout::InitialWindowLayer::Below => {
+                workspace.map_below(mapped, None);
+                return None;
             }
-            let focus_stack = workspace.focus_stack.get(&seat);
-            workspace
-                .tiling_layer
-                .map(mapped.clone(), Some(focus_stack.iter()), None);
+            layout::InitialWindowLayer::Floating => {
+                workspace.floating_layer.map(mapped.clone(), None);
+            }
+            layout::InitialWindowLayer::Tiling => {
+                for mapped in workspace
+                    .mapped()
+                    .filter(|m| m.maximized_state.lock().unwrap().is_some())
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                {
+                    workspace.unmaximize_request(&mapped);
+                }
+                let focus_stack = workspace.focus_stack.get(&seat);
+                workspace
+                    .tiling_layer
+                    .map(mapped.clone(), Some(focus_stack.iter()), None);
+            }
         }
 
         if should_be_sticky {
@@ -3344,7 +3391,8 @@ impl Shell {
                     was_stack: previous.was_stack(),
                 };
             } else if let FullscreenRestoreState::Tiling { workspace, .. }
-            | FullscreenRestoreState::Floating { workspace, .. } = previous
+            | FullscreenRestoreState::Floating { workspace, .. }
+            | FullscreenRestoreState::Below { workspace, .. } = previous
             {
                 *workspace = *to;
             }
@@ -3362,6 +3410,16 @@ impl Shell {
                     ));
                     window.set_minimized(true);
                     MinimizedWindow::Floating { window, previous }
+                }
+                WorkspaceRestoreData::Below(previous) => {
+                    let window = CosmicMapped::from(CosmicWindow::new(
+                        window.clone(),
+                        evlh.clone(),
+                        self.theme.clone(),
+                        self.appearance_conf,
+                    ));
+                    window.set_minimized(true);
+                    MinimizedWindow::Below { window, previous }
                 }
                 WorkspaceRestoreData::Tiling(previous) => {
                     let window = CosmicMapped::from(CosmicWindow::new(
@@ -3420,7 +3478,20 @@ impl Shell {
         let to_mapped = to_workspace.mapped().cloned().collect::<Vec<_>>();
 
         let focus_target: KeyboardFocusTarget =
-            if !matches!(window_state, WorkspaceRestoreData::Fullscreen(_))
+            if let WorkspaceRestoreData::Below(data) = window_state {
+                let mapped = CosmicMapped::from(CosmicWindow::new(
+                    window.clone(),
+                    evlh.clone(),
+                    self.theme.clone(),
+                    self.appearance_conf,
+                ));
+                let geometry = Rectangle::new(
+                    data.position_relative(to_workspace.output.geometry().size.as_logical()),
+                    data.geometry.size,
+                );
+                to_workspace.map_below(mapped.clone(), Some(geometry));
+                mapped.into()
+            } else if !matches!(window_state, WorkspaceRestoreData::Fullscreen(_))
                 && !to_workspace.tiling_enabled
             {
                 let mapped = CosmicMapped::from(CosmicWindow::new(
@@ -3528,7 +3599,13 @@ impl Shell {
         };
 
         let to_workspace = self.workspaces.space_for_handle_mut(to).unwrap(); // checked above
-        if !to_workspace.tiling_enabled {
+        if let WorkspaceRestoreData::Below(data) = &window_state {
+            let geometry = Rectangle::new(
+                data.position_relative(to_workspace.output.geometry().size.as_logical()),
+                data.geometry.size,
+            );
+            to_workspace.map_below(mapped.clone(), Some(geometry));
+        } else if !to_workspace.tiling_enabled {
             let (position, was_maximized, was_snapped) = match &window_state {
                 WorkspaceRestoreData::Floating(data) => (
                     Some(data.position_relative(to_workspace.output.geometry().size.as_logical())),
@@ -3881,22 +3958,40 @@ impl Shell {
                     None
                 };
 
-                let layer = if if mapped == old_mapped {
+                let layer = if mapped == old_mapped {
                     let was_floating = workspace.floating_layer.unmap(&mapped, None);
+                    let was_below = workspace.below_layer.unmap(&mapped, None);
                     let was_tiled = workspace
                         .tiling_layer
                         .unmap_as_placeholder(&mapped, PlaceholderType::GrabbedWindow);
-                    assert!(was_floating.is_some() != was_tiled.is_some());
+                    assert_eq!(
+                        [
+                            was_floating.is_some(),
+                            was_below.is_some(),
+                            was_tiled.is_some()
+                        ]
+                        .into_iter()
+                        .filter(|mapped| *mapped)
+                        .count(),
+                        1
+                    );
                     if was_floating.is_some_and(|geo| geo.size != elem_geo.size) {
                         new_size = was_floating.map(|geo| geo.size.as_logical());
                     }
-                    was_tiled.is_some()
-                } else {
-                    workspace
-                        .tiling_layer
-                        .mapped()
-                        .any(|(m, _)| m == &old_mapped)
-                } {
+                    if was_below.is_some() {
+                        ManagedLayer::Below
+                    } else if was_tiled.is_some() {
+                        ManagedLayer::Tiling
+                    } else {
+                        ManagedLayer::Floating
+                    }
+                } else if workspace.below_layer.mapped().any(|m| m == &old_mapped) {
+                    ManagedLayer::Below
+                } else if workspace
+                    .tiling_layer
+                    .mapped()
+                    .any(|(m, _)| m == &old_mapped)
+                {
                     ManagedLayer::Tiling
                 } else {
                     ManagedLayer::Floating
@@ -4217,8 +4312,16 @@ impl Shell {
 
                     let workspace = self.active_space_mut(&output).unwrap();
                     workspace
-                        .floating_layer
-                        .move_current_element(direction, seat, ManagedLayer::Floating, theme)
+                        .below_layer
+                        .move_current_element(direction, seat, ManagedLayer::Below, theme.clone())
+                        .or_else(|| {
+                            workspace.floating_layer.move_current_element(
+                                direction,
+                                seat,
+                                ManagedLayer::Floating,
+                                theme,
+                            )
+                        })
                         .or_else(|| workspace.tiling_layer.move_current_node(direction, seat))
                 }
             }
@@ -4445,13 +4548,20 @@ impl Shell {
             let geometry = set.sticky_layer.element_geometry(mapped).unwrap();
             (ManagedLayer::Sticky, &mut set.sticky_layer, geometry)
         } else if let Some(workspace) = self.space_for_mut(mapped) {
-            let layer = if workspace.is_tiled(&mapped.active_window()) {
+            let layer = if workspace.is_below(&mapped.active_window()) {
+                ManagedLayer::Below
+            } else if workspace.is_tiled(&mapped.active_window()) {
                 ManagedLayer::Tiling
             } else {
                 ManagedLayer::Floating
             };
             let geometry = workspace.element_geometry(mapped).unwrap();
-            (layer, &mut workspace.floating_layer, geometry)
+            let floating_layer = if layer == ManagedLayer::Below {
+                &mut workspace.below_layer
+            } else {
+                &mut workspace.floating_layer
+            };
+            (layer, floating_layer, geometry)
         } else {
             return;
         };
@@ -4512,6 +4622,75 @@ impl Shell {
         }
     }
 
+    pub fn set_x11_below(
+        &mut self,
+        window: &X11Surface,
+        below: bool,
+        loop_handle: &LoopHandle<'static, State>,
+    ) -> Option<Output> {
+        let mut mapped = self.element_for_surface(window).cloned()?;
+        let workspace = self.space_for(&mapped)?;
+        let output = workspace.output.clone();
+
+        if below {
+            if mapped.stack_ref().is_some_and(|stack| stack.len() > 1) {
+                let theme = self.theme.clone();
+                let appearance_conf = self.appearance_conf;
+                let workspace = self.space_for_mut(&mapped)?;
+                let (surface, _) = workspace.unmap_surface(window)?;
+                mapped = CosmicMapped::from(CosmicWindow::new(
+                    surface,
+                    loop_handle.clone(),
+                    theme,
+                    appearance_conf,
+                ));
+                workspace.map_below(mapped, None);
+                return Some(output);
+            }
+            self.space_for_mut(&mapped)?.move_to_below(&mapped);
+            return Some(output);
+        }
+
+        let is_dialog = layout::is_dialog(&mapped.active_window());
+        let floating_exception =
+            layout::has_floating_exception(&self.tiling_exceptions, &mapped.active_window());
+        let seat = self.seats.last_active().clone();
+        let workspace = self.space_for_mut(&mapped)?;
+        if mapped.maximized_state.lock().unwrap().is_some() {
+            workspace.unmaximize_request(&mapped);
+        }
+        let geometry = workspace.take_below(&mapped)?;
+        match layout::initial_window_layer(
+            false,
+            is_dialog,
+            floating_exception,
+            workspace.tiling_enabled,
+        ) {
+            layout::InitialWindowLayer::Below => unreachable!(),
+            layout::InitialWindowLayer::Floating => workspace.floating_layer.map_internal(
+                mapped,
+                Some(geometry.loc),
+                Some(geometry.size.as_logical()),
+                None,
+            ),
+            layout::InitialWindowLayer::Tiling => {
+                for other in workspace
+                    .mapped()
+                    .filter(|other| other.maximized_state.lock().unwrap().is_some())
+                    .cloned()
+                    .collect::<Vec<_>>()
+                {
+                    workspace.unmaximize_request(&other);
+                }
+                let focus_stack = workspace.focus_stack.get(&seat);
+                workspace
+                    .tiling_layer
+                    .map(mapped, Some(focus_stack.iter()), None);
+            }
+        }
+        Some(output)
+    }
+
     pub fn resize_request(
         &mut self,
         surface: &WlSurface,
@@ -4552,7 +4731,11 @@ impl Shell {
             &mut set.sticky_layer
         } else {
             let workspace = self.space_for_mut(&mapped)?;
-            &mut workspace.floating_layer
+            if workspace.is_below(&mapped.active_window()) {
+                &mut workspace.below_layer
+            } else {
+                &mut workspace.floating_layer
+            }
         };
 
         let grab: ResizeGrab = if let Some(grab) = floating_layer.resize_request(
@@ -4968,6 +5151,12 @@ impl Shell {
                             workspace: handle,
                             state: floating_state,
                             was_stack: mapped.is_stack(),
+                        })
+                    }
+                    WorkspaceRestoreData::Below(below_state) => {
+                        Some(FullscreenRestoreState::Below {
+                            workspace: handle,
+                            state: below_state,
                         })
                     }
                     WorkspaceRestoreData::Tiling(tiling_state) => {

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -105,6 +105,7 @@ pub struct Workspace {
     pub output: Output,
     pub tiling_layer: TilingLayout,
     pub floating_layer: FloatingLayout,
+    pub below_layer: FloatingLayout,
     pub minimized_windows: Vec<MinimizedWindow>,
     pub tiling_enabled: bool,
     pub fullscreen_surfaces: Vec<FullscreenSurface>,
@@ -130,6 +131,10 @@ pub enum MinimizedWindow {
         window: CosmicMapped,
         previous: FloatingRestoreData,
     },
+    Below {
+        window: CosmicMapped,
+        previous: FloatingRestoreData,
+    },
     Tiling {
         window: CosmicMapped,
         previous: TilingRestoreData,
@@ -145,37 +150,37 @@ impl PartialEq<CosmicMapped> for MinimizedWindow {
 impl MinimizedWindow {
     pub fn mapped(&self) -> Option<&CosmicMapped> {
         match self {
-            MinimizedWindow::Floating { window, .. } | MinimizedWindow::Tiling { window, .. } => {
-                Some(window)
-            }
+            MinimizedWindow::Floating { window, .. }
+            | MinimizedWindow::Below { window, .. }
+            | MinimizedWindow::Tiling { window, .. } => Some(window),
             _ => None,
         }
     }
 
     pub fn mapped_mut(&mut self) -> Option<&mut CosmicMapped> {
         match self {
-            MinimizedWindow::Floating { window, .. } | MinimizedWindow::Tiling { window, .. } => {
-                Some(window)
-            }
+            MinimizedWindow::Floating { window, .. }
+            | MinimizedWindow::Below { window, .. }
+            | MinimizedWindow::Tiling { window, .. } => Some(window),
             _ => None,
         }
     }
 
     pub fn active_window(&self) -> CosmicSurface {
         match self {
-            MinimizedWindow::Floating { window, .. } | MinimizedWindow::Tiling { window, .. } => {
-                window.active_window()
-            }
+            MinimizedWindow::Floating { window, .. }
+            | MinimizedWindow::Below { window, .. }
+            | MinimizedWindow::Tiling { window, .. } => window.active_window(),
             MinimizedWindow::Fullscreen { surface, .. } => surface.clone(),
         }
     }
 
     pub fn windows(&self) -> impl Iterator<Item = CosmicSurface> + '_ {
         match self {
-            MinimizedWindow::Floating { window, .. } | MinimizedWindow::Tiling { window, .. } => {
-                Box::new(window.windows().map(|(s, _)| s))
-                    as Box<dyn Iterator<Item = CosmicSurface>>
-            }
+            MinimizedWindow::Floating { window, .. }
+            | MinimizedWindow::Below { window, .. }
+            | MinimizedWindow::Tiling { window, .. } => Box::new(window.windows().map(|(s, _)| s))
+                as Box<dyn Iterator<Item = CosmicSurface>>,
             MinimizedWindow::Fullscreen { surface, .. } => {
                 Box::new(std::iter::once(surface.clone())) as _
             }
@@ -197,6 +202,9 @@ impl MinimizedWindow {
                 window.configure();
             }
             MinimizedWindow::Floating {
+                window, previous, ..
+            }
+            | MinimizedWindow::Below {
                 window, previous, ..
             } => {
                 previous.geometry = original_geometry;
@@ -244,6 +252,7 @@ pub enum ManagedLayer {
     Fullscreen,
     Tiling,
     Floating,
+    Below,
     Sticky,
 }
 
@@ -259,6 +268,10 @@ pub enum FullscreenRestoreState {
         state: FloatingRestoreData,
         was_stack: bool,
     },
+    Below {
+        workspace: WorkspaceHandle,
+        state: FloatingRestoreData,
+    },
     Sticky {
         output: WeakOutput,
         state: FloatingRestoreData,
@@ -273,6 +286,7 @@ impl FullscreenRestoreState {
     pub fn was_maximized(&self) -> bool {
         match self {
             FullscreenRestoreState::Floating { state, .. }
+            | FullscreenRestoreState::Below { state, .. }
             | FullscreenRestoreState::Sticky { state, .. } => state.was_maximized,
             FullscreenRestoreState::Tiling { state, .. } => state.was_maximized,
             FullscreenRestoreState::Stack { .. } => false,
@@ -285,6 +299,7 @@ impl FullscreenRestoreState {
             FullscreenRestoreState::Floating { was_stack, .. }
             | FullscreenRestoreState::Sticky { was_stack, .. } => *was_stack,
             FullscreenRestoreState::Tiling { was_stack, .. } => *was_stack,
+            FullscreenRestoreState::Below { .. } => false,
             // Stack wasn't removed; surface was removed from the stack
             FullscreenRestoreState::Stack { .. } => false,
         }
@@ -296,6 +311,7 @@ pub enum WorkspaceRestoreData {
     Fullscreen(Option<FullscreenRestoreData>),
     Tiling(TilingRestoreData),
     Floating(FloatingRestoreData),
+    Below(FloatingRestoreData),
     Stack(StackRestoreData),
 }
 
@@ -389,13 +405,15 @@ impl Workspace {
         appearance: AppearanceConfig,
     ) -> Workspace {
         let tiling_layer = TilingLayout::new(theme.clone(), appearance, &output);
-        let floating_layer = FloatingLayout::new(theme, appearance, &output);
+        let floating_layer = FloatingLayout::new(theme.clone(), appearance, &output);
+        let below_layer = FloatingLayout::new(theme, appearance, &output);
         let output_match = output_match_for_output(&output);
 
         Workspace {
             output,
             tiling_layer,
             floating_layer,
+            below_layer,
             tiling_enabled,
             minimized_windows: Vec::new(),
             fullscreen_surfaces: Vec::new(),
@@ -423,13 +441,15 @@ impl Workspace {
         appearance: AppearanceConfig,
     ) -> Self {
         let tiling_layer = TilingLayout::new(theme.clone(), appearance, &output);
-        let floating_layer = FloatingLayout::new(theme, appearance, &output);
+        let floating_layer = FloatingLayout::new(theme.clone(), appearance, &output);
+        let below_layer = FloatingLayout::new(theme, appearance, &output);
         let output_match = output_match_for_output(&output);
 
         Workspace {
             output,
             tiling_layer,
             floating_layer,
+            below_layer,
             tiling_enabled: pinned.tiling_enabled,
             minimized_windows: Vec::new(),
             fullscreen_surfaces: Vec::new(),
@@ -478,6 +498,7 @@ impl Workspace {
 
         self.floating_layer.refresh();
         self.tiling_layer.refresh();
+        self.below_layer.refresh();
     }
 
     fn has_activation_token(&self, xdg_activation_state: &XdgActivationState) -> bool {
@@ -525,6 +546,7 @@ impl Workspace {
                 self.floating_layer
                     .mapped()
                     .chain(self.tiling_layer.mapped().map(|(w, _)| w))
+                    .chain(self.below_layer.mapped())
                     .chain(move_mapped.iter())
             };
             stack.retain(|w| match w {
@@ -537,6 +559,7 @@ impl Workspace {
     pub fn animations_going(&self) -> bool {
         self.tiling_layer.animations_going()
             || self.floating_layer.animations_going()
+            || self.below_layer.animations_going()
             || self.fullscreen_surfaces.iter().any(|f| f.is_animating())
             || self.dirty.swap(false, Ordering::SeqCst)
     }
@@ -564,6 +587,7 @@ impl Workspace {
 
         let clients = self.tiling_layer.update_animation_state();
         self.floating_layer.update_animation_state();
+        self.below_layer.update_animation_state();
         clients
     }
 
@@ -583,6 +607,7 @@ impl Workspace {
     pub fn set_output(&mut self, output: &Output, explicit: bool) {
         self.tiling_layer.set_output(output);
         self.floating_layer.set_output(output);
+        self.below_layer.set_output(output);
         for mapped in self.mapped() {
             for (surface, _) in mapped.windows() {
                 toplevel_leave_output(&surface, &self.output);
@@ -657,6 +682,7 @@ impl Workspace {
                 MinimizedWindow::Floating { previous, .. } => {
                     WorkspaceRestoreData::Floating(previous)
                 }
+                MinimizedWindow::Below { previous, .. } => WorkspaceRestoreData::Below(previous),
                 MinimizedWindow::Tiling { previous, .. } => WorkspaceRestoreData::Tiling(previous),
                 MinimizedWindow::Fullscreen { .. } => unreachable!(),
             });
@@ -666,6 +692,15 @@ impl Workspace {
             return Some(WorkspaceRestoreData::Tiling(TilingRestoreData {
                 state,
                 was_maximized: was_maximized.is_some(),
+            }));
+        }
+
+        if let Some(geometry) = self.below_layer.unmap(mapped, None) {
+            return Some(WorkspaceRestoreData::Below(FloatingRestoreData {
+                geometry,
+                output_size: self.output.geometry().size.as_logical(),
+                was_maximized: was_maximized.is_some(),
+                was_snapped: None,
             }));
         }
 
@@ -776,6 +811,7 @@ impl Workspace {
         self.floating_layer
             .mapped()
             .chain(self.tiling_layer.mapped().map(|(w, _)| w))
+            .chain(self.below_layer.mapped())
             .chain(self.minimized_windows.iter().flat_map(|w| w.mapped()))
             .find(|e| e.windows().any(|(w, _)| &w == surface))
     }
@@ -827,6 +863,7 @@ impl Workspace {
                 }
                 None
             })
+            .or_else(|| self.below_layer.popup_element_under(location, seat))
     }
 
     pub fn toplevel_element_under(
@@ -876,6 +913,7 @@ impl Workspace {
                 }
                 None
             })
+            .or_else(|| self.below_layer.toplevel_element_under(location, seat))
     }
 
     pub fn popup_surface_under(
@@ -925,6 +963,7 @@ impl Workspace {
                     .popup_surface_under(location, overview, seat)
             })
             .or_else(|| self.get_fullscreen(seat).and_then(check_fullscreen))
+            .or_else(|| self.below_layer.popup_surface_under(location, seat))
             .map(|(m, p)| (m, p.to_global(&self.output)))
     }
 
@@ -969,6 +1008,7 @@ impl Workspace {
                     .toplevel_surface_under(location, overview, seat)
             })
             .or_else(|| self.get_fullscreen(seat).and_then(check_fullscreen))
+            .or_else(|| self.below_layer.toplevel_surface_under(location, seat))
             .map(|(m, p)| (m, p.to_global(&self.output)))
     }
 
@@ -980,17 +1020,54 @@ impl Workspace {
         self.floating_layer.update_pointer_position(location);
         self.tiling_layer
             .update_pointer_position(location, overview);
+        self.below_layer.update_pointer_position(location);
     }
 
     pub fn element_geometry(&self, elem: &CosmicMapped) -> Option<Rectangle<i32, Local>> {
         self.floating_layer
             .element_geometry(elem)
             .or_else(|| self.tiling_layer.element_geometry(elem))
+            .or_else(|| self.below_layer.element_geometry(elem))
+    }
+
+    pub fn map_below(&mut self, mapped: CosmicMapped, geometry: Option<Rectangle<i32, Local>>) {
+        let geometry =
+            geometry.unwrap_or_else(|| mapped.geometry().as_global().to_local(&self.output));
+        self.below_layer.map_internal(
+            mapped,
+            Some(geometry.loc),
+            Some(geometry.size.as_logical()),
+            None,
+        );
+    }
+
+    pub fn move_to_below(&mut self, mapped: &CosmicMapped) -> bool {
+        if self.below_layer.element_geometry(mapped).is_some() {
+            return false;
+        }
+
+        if mapped.maximized_state.lock().unwrap().is_some() {
+            self.unmaximize_request(mapped);
+        }
+        let Some(geometry) = self.element_geometry(mapped) else {
+            return false;
+        };
+
+        if self.tiling_layer.unmap(mapped, None).is_err() {
+            self.floating_layer.unmap(mapped, None);
+        }
+        self.map_below(mapped.clone(), Some(geometry));
+        true
+    }
+
+    pub fn take_below(&mut self, mapped: &CosmicMapped) -> Option<Rectangle<i32, Local>> {
+        self.below_layer.unmap(mapped, None)
     }
 
     pub fn recalculate(&mut self) {
         self.tiling_layer.recalculate();
         self.floating_layer.recalculate();
+        self.below_layer.recalculate();
     }
 
     pub fn unmaximize_request(&mut self, elem: &CosmicMapped) -> Option<Rectangle<i32, Local>> {
@@ -1011,6 +1088,16 @@ impl Workspace {
                         elem.configure();
                         self.tiling_layer.recalculate();
                         geo
+                    }
+                    ManagedLayer::Below => {
+                        elem.set_maximized(false);
+                        self.below_layer.map_internal(
+                            elem.clone(),
+                            Some(state.original_geometry.loc),
+                            Some(state.original_geometry.size.as_logical()),
+                            None,
+                        );
+                        Some(state.original_geometry)
                     }
                     ManagedLayer::Sticky => unreachable!(),
 
@@ -1123,6 +1210,18 @@ impl Workspace {
             });
         }
 
+        if let Some(geometry) = self.below_layer.unmap(&mapped, Some(to)) {
+            return Some(MinimizedWindow::Below {
+                window: mapped,
+                previous: FloatingRestoreData {
+                    geometry: was_maximized.unwrap_or(geometry),
+                    output_size: self.output.geometry().size.as_logical(),
+                    was_maximized: was_maximized.is_some(),
+                    was_snapped: None,
+                },
+            });
+        }
+
         if let Ok(state) = self
             .tiling_layer
             .unmap(&mapped, was_maximized.is_none().then_some(to))
@@ -1188,6 +1287,24 @@ impl Workspace {
                     self.floating_layer.snap_to_corner(&window, &corners);
                 }
 
+                None
+            }
+            MinimizedWindow::Below { window, previous } => {
+                let current_output_size = self.output.geometry().size.as_logical();
+                let previous_position = previous.position_relative(current_output_size);
+
+                window.set_minimized(false);
+                self.below_layer
+                    .remap_minimized(window.clone(), from, previous_position);
+                if previous.was_maximized {
+                    let geometry = self.below_layer.element_geometry(&window).unwrap();
+                    *window.maximized_state.lock().unwrap() = Some(MaximizedState {
+                        original_geometry: geometry,
+                        original_layer: ManagedLayer::Below,
+                        original_snapped: None,
+                    });
+                    self.below_layer.map_maximized(window, geometry, true);
+                }
                 None
             }
             MinimizedWindow::Tiling {
@@ -1483,6 +1600,9 @@ impl Workspace {
     }
 
     pub fn toggle_floating_window(&mut self, seat: &Seat<State>, window: &CosmicMapped) {
+        if self.below_layer.element_geometry(window).is_some() {
+            return;
+        }
         if self.tiling_enabled {
             if window.is_maximized(false) {
                 self.unmaximize_request(window);
@@ -1516,11 +1636,13 @@ impl Workspace {
         self.floating_layer
             .mapped()
             .chain(self.tiling_layer.mapped().map(|(w, _)| w))
+            .chain(self.below_layer.mapped())
     }
 
     pub fn len(&self) -> usize {
         self.floating_layer.mapped().count()
             + self.tiling_layer.mapped().count()
+            + self.below_layer.mapped().count()
             + self.minimized_windows.len()
             + self
                 .fullscreen_surfaces
@@ -1532,6 +1654,7 @@ impl Workspace {
     pub fn is_empty(&self) -> bool {
         self.floating_layer.mapped().next().is_none()
             && self.tiling_layer.mapped().next().is_none()
+            && self.below_layer.mapped().next().is_none()
             && self.minimized_windows.is_empty()
             && self.fullscreen_surfaces.is_empty()
     }
@@ -1543,6 +1666,10 @@ impl Workspace {
         self.floating_layer
             .mapped()
             .any(|m| m.windows().any(|(ref s, _)| s == surface))
+            || self
+                .below_layer
+                .mapped()
+                .any(|m| m.windows().any(|(ref s, _)| s == surface))
             || self.minimized_windows.iter().any(|m| {
                 if let MinimizedWindow::Floating { window, .. } = m {
                     window.windows().any(|(ref s, _)| s == surface)
@@ -1550,6 +1677,15 @@ impl Workspace {
                     false
                 }
             })
+    }
+
+    pub fn is_below<S>(&self, surface: &S) -> bool
+    where
+        CosmicSurface: PartialEq<S>,
+    {
+        self.below_layer
+            .mapped()
+            .any(|m| m.windows().any(|(ref s, _)| s == surface))
     }
 
     pub fn is_tiled<S>(&self, surface: &S) -> bool
@@ -1834,6 +1970,19 @@ impl Workspace {
                 )
             }
         }
+
+        self.below_layer
+            .render_popups(renderer, 1.0, scanout_node, &mut |elem| push(elem.into()));
+        self.below_layer.render(
+            renderer,
+            None,
+            None,
+            indicator_thickness,
+            1.0,
+            theme,
+            scanout_node,
+            &mut |elem| push(elem.into()),
+        );
 
         for elem in fullscreen_elements {
             push(elem);

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -1680,6 +1680,7 @@ impl Workspace {
                     }
                     (None, None) => (fullscreen_geo, 1.0),
                 };
+                let alpha = fullscreen.surface.effective_render_alpha(alpha);
 
                 let render_loc = target_geo
                     .loc

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -1207,6 +1207,38 @@ impl XwmHandler for State {
         }
     }
 
+    fn below_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        if let Err(err) = window.set_below(true) {
+            warn!(?window, ?err, "Failed to set X11 window below");
+            return;
+        }
+
+        let output =
+            self.common
+                .shell
+                .write()
+                .set_x11_below(&window, true, &self.common.event_loop_handle);
+        if let Some(output) = output {
+            self.backend.schedule_render(&output);
+        }
+    }
+
+    fn unbelow_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        if let Err(err) = window.set_below(false) {
+            warn!(?window, ?err, "Failed to unset X11 window below");
+            return;
+        }
+
+        let output =
+            self.common
+                .shell
+                .write()
+                .set_x11_below(&window, false, &self.common.event_loop_handle);
+        if let Some(output) = output {
+            self.backend.schedule_render(&output);
+        }
+    }
+
     fn stick_request(&mut self, _xwm: XwmId, window: X11Surface) {
         let mut shell = self.common.shell.write();
         if let Some(pending) = shell

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -53,7 +53,7 @@ use smithay::{
     },
     xwayland::{
         X11Surface, X11Wm, XWayland, XWaylandClientData, XWaylandEvent, XwmHandler,
-        xwm::{Reorder, XwmId},
+        xwm::{Reorder, WmWindowProperty, XwmId},
     },
 };
 use tracing::{error, trace, warn};
@@ -1023,6 +1023,29 @@ impl XwmHandler for State {
                     window.output_leave(&output);
                 }
             }
+        }
+    }
+
+    fn property_notify(&mut self, _xwm: XwmId, window: X11Surface, property: WmWindowProperty) {
+        if property != WmWindowProperty::Opacity {
+            return;
+        }
+
+        let output = {
+            let shell = self.common.shell.read();
+            shell
+                .element_for_surface(&window)
+                .and_then(|mapped| shell.space_for(mapped))
+                .map(|workspace| workspace.output().clone())
+                .or_else(|| {
+                    window
+                        .wl_surface()
+                        .and_then(|surface| shell.visible_output_for_surface(&surface).cloned())
+                })
+        };
+
+        if let Some(output) = output {
+            self.backend.schedule_render(&output);
         }
     }
 


### PR DESCRIPTION
I installed KDE Plasma alongside my COSMIC desktop installation, so I can use KDE when gaming. After logging in to COSMIC after the KDE installation, I ran into #1204. This properly fixes #1204 


Without these fixes:


[2026-08-31 20-39-56-firefox-hq (Copy 1).webm](https://github.com/user-attachments/assets/7741ed17-f1f6-494b-90bd-2f572f5071ef)




With these fixes:

[2026-08-31 20-28-33-firefox-hq.webm](https://github.com/user-attachments/assets/999eb900-ae33-4d16-8541-15f8fc2b0809)






- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

