### PR TITLE
tabs: avoid two HashSet allocations in tab-change detection

### DIFF
--- a/src/shell/element/stack/tabs.rs
+++ b/src/shell/element/stack/tabs.rs
@@ -31,7 +31,7 @@ use keyframe::{
     functions::{EaseInOutCubic, EaseOutCubic},
 };
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     time::{Duration, Instant},
 };
 
@@ -757,12 +757,10 @@ where
             state.last_state = Some(current_state.clone());
         }
         let last_state = state.last_state.as_mut().unwrap();
-        let unknown_keys = current_state
-            .keys()
-            .collect::<HashSet<_>>()
-            .symmetric_difference(&last_state.keys().collect::<HashSet<_>>())
-            .next()
-            .is_some();
+        let unknown_keys = current_state.len() != last_state.len()
+            || current_state
+                .keys()
+                .any(|key| !last_state.contains_key(key));
 
         enum Difference {
             NewOrRemoved,


### PR DESCRIPTION
Firstly love Cosmic - run it on my desktop and laptop, thank you for your efforts in building and maintaining!

I'm trying to contribute to make opensource projects that I use daily better.  I've also been experimenting with using llms to find speed, binary size optimizations and reduce heap allocations.  

We're creating two hashsets and inserting hashed keys into each, rather than just comparing (with an early out).   As Tabs in a stack aren't likely numerous, and the two allocation + hashing both elements in last_state and current_state would cancel out any gain from a hash based search.

Feedback on this PR is very welcome. 



---

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described. (I had the LLM build a unit test equivalency harness - I can commit it if you want).
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
---


Below here is llm generated:
---

Created with the help of DeepSeek V4 Flash, some testing and checking was done with OpenAI Sol 5.6 for extra validation.


## Timing Results

### Identical key sets

This represents the normal steady-state case in which no tabs were added or
removed.

| Keys | Original | Replacement | Speedup | Time reduction |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 33.70 ns | 4.27 ns | 7.89x | 87.3% |
| 1 | 218.89 ns | 33.44 ns | 6.55x | 84.7% |
| 2 | 322.03 ns | 58.62 ns | 5.49x | 81.8% |
| 4 | 352.74 ns | 69.53 ns | 5.07x | 80.3% |
| 8 | 642.05 ns | 135.41 ns | 4.74x | 78.9% |
| 16 | 1,248.54 ns | 275.18 ns | 4.54x | 78.0% |
| 32 | 2,470.75 ns | 544.30 ns | 4.54x | 78.0% |
| 64 | 4,867.80 ns | 1,102.35 ns | 4.42x | 77.4% |
| 128 | 9,662.88 ns | 2,208.19 ns | 4.38x | 77.1% |
| 256 | 19,720.97 ns | 4,451.18 ns | 4.43x | 77.4% |
| 512 | 40,560.14 ns | 9,136.24 ns | 4.44x | 77.5% |
| 1,024 | 83,451.24 ns | 18,370.27 ns | 4.54x | 78.0% |

### Removed key

When a key is removed, the replacement detects the unequal map lengths in
constant time and does not perform any hash lookups.

| Previous keys | Original | Replacement | Speedup | Time saved |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 91.30 ns | 2.52 ns | 36.16x | 88.78 ns |
| 2 | 165.00 ns | 1.54 ns | 107.03x | 163.46 ns |
| 4 | 298.08 ns | 1.54 ns | 193.33x | 296.54 ns |
| 8 | 560.40 ns | 1.54 ns | 363.38x | 558.86 ns |
| 16 | 1,074.54 ns | 1.54 ns | 696.30x | 1,073.00 ns |
| 32 | 2,173.75 ns | 1.54 ns | 1,407.27x | 2,172.21 ns |
| 64 | 4,283.93 ns | 1.55 ns | 2,770.03x | 4,282.38 ns |
| 128 | 8,487.25 ns | 1.56 ns | 5,437.06x | 8,485.69 ns |
| 256 | 17,141.27 ns | 1.56 ns | 10,996.45x | 17,139.71 ns |
| 512 | 35,251.06 ns | 1.55 ns | 22,727.96x | 35,249.51 ns |
| 1,024 | 76,561.09 ns | 1.62 ns | 47,289.12x | 76,559.47 ns |

The very large ratios in this case should be interpreted alongside the
absolute timings. The replacement is performing only a length comparison.

### Equal-length key replacement

This case removes one key and adds another while preserving the number of
entries.

| Keys | Original | Replacement | Speedup | Time reduction |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 180.46 ns | 30.39 ns | 5.94x | 83.2% |
| 2 | 179.44 ns | 20.84 ns | 8.61x | 88.4% |
| 4 | 259.19 ns | 68.51 ns | 3.78x | 73.6% |
| 8 | 434.90 ns | 18.80 ns | 23.14x | 95.7% |
| 16 | 812.18 ns | 18.70 ns | 43.42x | 97.7% |
| 32 | 1,636.89 ns | 166.73 ns | 9.82x | 89.8% |
| 64 | 3,122.80 ns | 18.40 ns | 169.76x | 99.4% |
| 128 | 6,214.19 ns | 780.47 ns | 7.96x | 87.4% |
| 256 | 12,281.55 ns | 2,507.40 ns | 4.90x | 79.6% |
| 512 | 24,955.30 ns | 681.87 ns | 36.60x | 97.3% |
| 1,024 | 50,550.38 ns | 10,547.30 ns | 4.79x | 79.1% |

The exact result varies because `HashMap` iteration order determines how soon
the differing key is encountered. Both implementations short-circuit after
finding a difference.





