### PR TITLE
config: sort outputs by connector for deterministic fallback layout

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -541,7 +541,13 @@ impl Config {
                     primary.config_mut().xwayland_primary = true;
                 }
             }
-            for output in outputs.iter().filter(|o| o.mirroring().is_none()) {
+            // sort by connector name for a deterministic layout independent of hotplug order
+            let mut sorted_outputs = outputs
+                .iter()
+                .filter(|o| o.mirroring().is_none())
+                .collect::<Vec<_>>();
+            sorted_outputs.sort_by_key(|o| o.name());
+            for output in sorted_outputs {
                 {
                     let mut config = output.config_mut();
                     config.position = (w, 0);


### PR DESCRIPTION
Fixes monitor arrangement being restored in the wrong left/right order after reconnecting displays through a KVM switch.

## Problem

When no saved configuration in `outputs.ron` matches the current output set, `read_outputs` generates fallback positions left-to-right in hotplug/registration order. When monitors reconnect sequentially in arbitrary order (e.g. switching back via a KVM), whichever output handshakes first gets position (0,0), producing a swapped layout that is then persisted by `write_outputs` — every later reconnect of that monitor set restores the wrong arrangement.

## Fix

Sort outputs by connector name before generating fallback positions, making the generated layout deterministic regardless of arrival order and consistent with boot-time GPU enumeration order.

## AI/LLM disclosure

This PR was implemented with the assistance of an LLM coding agent (Claude via GitHub Copilot), directed and reviewed by me. I understand the change in full — it is a single-site sort of the fallback iteration in `read_outputs` — and it is disclosed in the commit message. I will respond to review comments myself.

## Testing

Reproduced with two identical Lenovo G27q-20 monitors (DP-3/DP-4) behind a KVM switch on Pop!_OS 24.04 (COSMIC), building at the installed package commit (a830784); the fallback now always yields DP-3 left of DP-4 across reconnects.

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
