### PR TITLE
protocols/keyboard-layout: Send ei `modifiers` on group change

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -842,7 +842,9 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                 }
                 if !state.common.ei_seats.is_empty() {
                     let seat = state.common.shell.read().seats.last_active().clone();
-                    state.broadcast_ei_keyboard_modifiers(&seat);
+                    if let Some(keyboard) = seat.get_keyboard() {
+                        state.broadcast_ei_keyboard_modifiers(&keyboard);
+                    }
                 }
                 state.common.config.cosmic_conf.xkb_config = value;
             }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -49,6 +49,7 @@ use smithay::{
     desktop::{PopupKeyboardGrab, WindowSurfaceType, utils::under_from_surface_tree},
     input::{
         Seat,
+        keyboard::KeyboardHandle,
         keyboard::{FilterResult, KeyboardSource, KeysymHandle, ModifiersState},
         pointer::{
             AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent,
@@ -1907,13 +1908,7 @@ impl State {
 
     /// Mirror the seat's current modifier state to every libei sender with a keyboard via
     /// `ei_keyboard.modifiers`
-    pub(crate) fn broadcast_ei_keyboard_modifiers(&self, seat: &Seat<State>) {
-        if self.common.ei_seats.is_empty() {
-            return;
-        }
-        let Some(keyboard) = seat.get_keyboard() else {
-            return;
-        };
+    pub(crate) fn broadcast_ei_keyboard_modifiers(&self, keyboard: &KeyboardHandle<State>) {
         let s = keyboard.modifier_state().serialized;
         for ei_seat in self.common.ei_seats.values() {
             ei_seat.keyboard_modifiers(s.depressed, s.locked, s.latched, s.layout_effective);
@@ -1958,7 +1953,7 @@ impl State {
     ) -> FilterResult<Option<(Action, shortcuts::Binding)>> {
         if previous_modifiers != *modifiers {
             seat.set_last_modifier_change(backend_id, serial);
-            self.broadcast_ei_keyboard_modifiers(seat);
+            self.broadcast_ei_keyboard_modifiers(&seat.get_keyboard().unwrap());
         }
 
         let current_focus = seat.get_keyboard().unwrap().current_focus();

--- a/src/libei.rs
+++ b/src/libei.rs
@@ -124,7 +124,9 @@ pub fn setup_ei(
                         data.update_ei_input_method();
                         // Notify the remaining libei clients of the now-cleared modifier state
                         let seat = data.common.shell.read().seats.last_active().clone();
-                        data.broadcast_ei_keyboard_modifiers(&seat);
+                        if let Some(keyboard) = seat.get_keyboard() {
+                            data.broadcast_ei_keyboard_modifiers(&keyboard);
+                        }
                     }
                     EiInputEvent::Event(event) => {
                         use smithay::backend::input::{InputEvent, KeyboardKeyEvent};

--- a/src/wayland/handlers/keyboard_layout.rs
+++ b/src/wayland/handlers/keyboard_layout.rs
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use smithay::input::keyboard::KeyboardHandle;
+
 use crate::state::State;
 use crate::wayland::protocols::keyboard_layout::{KeyboardLayoutHandler, KeyboardLayoutState};
 
 impl KeyboardLayoutHandler for State {
     fn keyboard_layout_state(&mut self) -> &mut KeyboardLayoutState {
         &mut self.common.keyboard_layout_state
+    }
+
+    fn group_changed(&mut self, keyboard: &KeyboardHandle<Self>) {
+        self.broadcast_ei_keyboard_modifiers(keyboard);
     }
 }

--- a/src/wayland/protocols/keyboard_layout.rs
+++ b/src/wayland/protocols/keyboard_layout.rs
@@ -17,8 +17,10 @@ use smithay::{
 use std::mem;
 use wayland_backend::server::{ClientId, GlobalId};
 
-pub trait KeyboardLayoutHandler {
+pub trait KeyboardLayoutHandler: SeatHandler {
     fn keyboard_layout_state(&mut self) -> &mut KeyboardLayoutState;
+    /// Group has been changed through the protocol
+    fn group_changed(&mut self, keyboard: &KeyboardHandle<Self>);
 }
 
 #[derive(Debug)]
@@ -57,6 +59,7 @@ impl KeyboardLayoutState {
                 let active_layout = handle.with_xkb_state(state, |context| {
                     context.xkb().lock().unwrap().active_layout()
                 });
+                state.group_changed(handle);
                 if *last_layout != Some(active_layout) {
                     keyboard_layout.group(active_layout.0);
                     *last_layout = Some(active_layout);


### PR DESCRIPTION
This makes `cosmic-osk` show a group change on `super+space`. Previously a change like that wouldn't be sent until a keyboard input changed the modifier state, for instance releasing the shift key.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

