### PR TITLE
fix: validate layer radius against the pending surface size

### DIFF
--- a/src/wayland/protocols/corner_radius.rs
+++ b/src/wayland/protocols/corner_radius.rs
@@ -5,16 +5,19 @@ use cosmic_protocols::corner_radius::v1::server::cosmic_corner_radius_toplevel_v
 use cosmic_protocols::corner_radius::v1::server::{
     cosmic_corner_radius_manager_v1, cosmic_corner_radius_toplevel_v1,
 };
+use smithay::backend::renderer::buffer_dimensions;
+use smithay::backend::renderer::utils::RendererSurfaceStateUserData;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_popup::XdgPopup;
 use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::server::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1;
 use smithay::reexports::wayland_server::New;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{HookId, Logical, Rectangle};
-use smithay::wayland::compositor::Cacheable;
 use smithay::wayland::compositor::add_pre_commit_hook;
 use smithay::wayland::compositor::with_states;
-use smithay::wayland::shell::wlr_layer::{LayerSurfaceAttributes, WlrLayerShellHandler};
+use smithay::wayland::compositor::{BufferAssignment, Cacheable, SurfaceAttributes};
+use smithay::wayland::shell::wlr_layer::WlrLayerShellHandler;
 use smithay::wayland::shell::xdg::{SurfaceCachedState, XdgShellSurfaceUserData};
+use smithay::wayland::viewporter::ViewportCachedState;
 use smithay::{
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel::XdgToplevel,
@@ -664,25 +667,31 @@ fn layer_radius_hook<D: 'static>(_state: &mut D, _dh: &DisplayHandle, surface: &
             .get::<CacheablePadding>()
             .pending();
 
-        //  The radius and padding is relative to the size of `zwlr_layer_surface_v1` (according to
-        //  the protocol). That is the configure the client acked.
-        //
-        // `last_acked` is the becomes current as part of this commit,
-        // so it is staged consistently with the pending radius/padding above.
-        //
-        // Until the client acks a configure there is no defined size, and nothing to check.
-        let Some(size) = surface_data
-            .data_map
-            .get::<Mutex<LayerSurfaceAttributes>>()
-            .and_then(|attrs| {
-                attrs
-                    .lock()
-                    .unwrap()
-                    .last_acked
-                    .as_ref()
-                    .and_then(|configure| configure.state.size)
+        // The wl_surface size after this commit is:
+        // - viewport destination if set
+        // - else the logical size of the buffer that will be current attached now
+        // - else existing
+        let size = surface_data
+            .cached_state
+            .get::<ViewportCachedState>()
+            .pending()
+            .size()
+            .or_else(|| {
+                let mut guard = surface_data.cached_state.get::<SurfaceAttributes>();
+                let attrs = guard.pending();
+                match &attrs.buffer {
+                    Some(BufferAssignment::NewBuffer(buffer)) => buffer_dimensions(buffer)
+                        .map(|d| d.to_logical(attrs.buffer_scale, attrs.buffer_transform.into())),
+                    _ => None,
+                }
             })
-        else {
+            .or_else(|| {
+                surface_data
+                    .data_map
+                    .get::<RendererSurfaceStateUserData>()
+                    .and_then(|state| state.lock().unwrap().surface_size())
+            });
+        let Some(size) = size else {
             return;
         };
 


### PR DESCRIPTION
This changes the logic in https://github.com/pop-os/cosmic-comp/pull/2788 to not validate against acked size. Ack is a suggestion, and the client is allowed to commit a surface with a different size. Cosmic-panel asks for 1 pixel placeholder, and after getting an ack, commits 8 pixels.

Now, first we validate against pending size, else the attached buffer, else the existing value (it's not using bbox, since bbox would contain the subsurfaces too).

This still works for xdg-desktop-portal-cosmic, since this returns on an unmapped surface, and works for cosmic-panel too, since it's not validating against the acked size.



I've been looking into specs to make sure the comp side is correct. Then if we face any client facing issues, we know it's the client's fault.

The corner radius [spec](https://github.com/pop-os/cosmic-protocols/blob/a2da48188362c4ea05d33de2f6c67d8148deba88/unstable/cosmic-corner-radius-unstable-v1.xml#L217-L220) says the radius is relative to "the remaining size of the associated zwlr_layer_surface_v1 after padding". The [`zwlr_layer_surface_v1` spec](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:event:configure) says the size is a hint, the client can go smaller, or ignore it, it doesn't say it can go larger. But since ack is a hint, a larger client can ask for a smaller size, but then ignore it, or can ask for a larger size, and commit something smaller which the radius is too big for, so not using ack for validation is the right choice. Even though cosmic-panel shouldn't ask for a small size that it doesn't intend to use and commit a larger size.

TODOs:

- We probably should add something to cosmic-protocols and make this unambiguous. We should state that the size is the wl_surface size at commit time, viewport included, and that no check happens while the surface has no buffer.
- Another thing we should look at is that libcosmic clamps to half of its known size when the app sets the radius, but doesn't re-clamp on resize.
- Also libcosmic doesn't clamp the padding at all, which would be its own protocol error.


___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

