### PR TITLE
refactor: align the corner radii order with the theme

### DIFF
--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -286,10 +286,10 @@ impl IndicatorShader {
                     Uniform::new(
                         "radius",
                         [
-                            outer_radius[3] as f32,
-                            outer_radius[1] as f32,
                             outer_radius[0] as f32,
+                            outer_radius[1] as f32,
                             outer_radius[2] as f32,
+                            outer_radius[3] as f32,
                         ],
                     ),
                     Uniform::new("scale", scale as f32),

--- a/src/backend/render/shadow.rs
+++ b/src/backend/render/shadow.rs
@@ -86,12 +86,6 @@ impl ShadowShader {
             let offset = [0., 5.];
             let color = [0., 0., 0., if dark_mode { 0.45 } else { 0.35 }];
             let radius = radius.map(|r| ceil(r as f64));
-            let radius = [
-                radius[3], // top_left
-                radius[1], // top_right
-                radius[0], // bottom_right
-                radius[2], // bottom_left
-            ];
 
             let width = softness;
             let sigma = width / 2.;

--- a/src/backend/render/wayland/blur_effect.rs
+++ b/src/backend/render/wayland/blur_effect.rs
@@ -247,10 +247,10 @@ impl BlurElement {
             Uniform::new(
                 "corner_radius",
                 [
-                    radii[3] as f32,
-                    radii[1] as f32,
                     radii[0] as f32,
+                    radii[1] as f32,
                     radii[2] as f32,
+                    radii[3] as f32,
                 ],
             ),
             Uniform::new(

--- a/src/backend/render/wayland/clipped_surface.rs
+++ b/src/backend/render/wayland/clipped_surface.rs
@@ -99,10 +99,10 @@ where
             Uniform::new(
                 "corner_radius",
                 [
-                    radius[3] as f32,
-                    radius[1] as f32,
                     radius[0] as f32,
+                    radius[1] as f32,
                     radius[2] as f32,
+                    radius[3] as f32,
                 ],
             ),
             Uniform::new(
@@ -145,10 +145,10 @@ where
         geo: Rectangle<f64, Logical>,
         radius: [u8; 4],
     ) -> [Rectangle<f64, Logical>; 4] {
-        let top_left = radius[3] as f64;
+        let top_left = radius[0] as f64;
         let top_right = radius[1] as f64;
-        let bottom_right = radius[0] as f64;
-        let bottom_left = radius[2] as f64;
+        let bottom_right = radius[2] as f64;
+        let bottom_left = radius[3] as f64;
 
         [
             Rectangle::new(geo.loc, Size::from((top_left, top_left))),

--- a/src/shell/element/stack.rs
+++ b/src/shell/element/stack.rs
@@ -842,7 +842,7 @@ impl CosmicStack {
                 )));
             };
 
-            let radii = radii.map(|[a, _, c, _]| [a, 0, c, 0]);
+            let radii = radii.map(|[_, _, c, d]| [0, 0, c, d]);
             windows[active].push_render_elements(
                 renderer,
                 window_loc,
@@ -1015,17 +1015,17 @@ impl CosmicStack {
                     .corner_radius(geometry_size)
                     .unwrap_or([default_radius; 4]);
 
+                corners[0] = 0;
                 corners[1] = 0;
-                corners[3] = 0;
 
                 corners
             } else {
                 let mut corners = active_window.corner_radius(geometry_size).unwrap_or(radii);
 
-                corners[0] = radii[0].max(corners[0]);
+                corners[0] = radii[0];
                 corners[1] = radii[1];
                 corners[2] = radii[2].max(corners[2]);
-                corners[3] = radii[3];
+                corners[3] = radii[3].max(corners[3]);
 
                 corners
             }

--- a/src/shell/element/window.rs
+++ b/src/shell/element/window.rs
@@ -438,12 +438,12 @@ impl CosmicWindow {
                 .map(|x| (x * scale as f32).round() as u8);
             if has_ssd && !clip {
                 // bottom corners
-                radii[0] = 0;
                 radii[2] = 0;
+                radii[3] = 0;
                 if is_tiled {
                     // top corners
+                    radii[0] = 0;
                     radii[1] = 0;
-                    radii[3] = 0;
                 }
             }
 
@@ -510,12 +510,12 @@ impl CosmicWindow {
             && !is_maximized;
         if has_ssd && !clip {
             // bottom corners
-            radii[0] = 0;
             radii[2] = 0;
+            radii[3] = 0;
             if is_tiled {
                 // top corners
+                radii[0] = 0;
                 radii[1] = 0;
-                radii[3] = 0;
             }
         }
 
@@ -560,8 +560,8 @@ impl CosmicWindow {
         self.0.with_program(|p| {
             let mut radii = radii;
             if has_ssd {
+                radii[0] = 0;
                 radii[1] = 0;
-                radii[3] = 0;
             }
             let theme = p.theme.lock().unwrap();
             let frosted = if theme.cosmic().frosted_windows {
@@ -585,8 +585,8 @@ impl CosmicWindow {
         });
 
         if has_ssd {
-            radii[0] = 0;
             radii[2] = 0;
+            radii[3] = 0;
             let ssd_loc = location
                 + self
                     .0
@@ -691,26 +691,26 @@ impl CosmicWindow {
                 (has_ssd, true) => {
                     let mut corners = p.window.corner_radius(geometry_size).unwrap_or(radii);
 
-                    corners[0] = radii[0].max(corners[0]);
+                    corners[0] = if has_ssd {
+                        radii[0]
+                    } else {
+                        radii[0].max(corners[0])
+                    };
                     corners[1] = if has_ssd {
                         radii[1]
                     } else {
                         radii[1].max(corners[1])
                     };
                     corners[2] = radii[2].max(corners[2]);
-                    corners[3] = if has_ssd {
-                        radii[3]
-                    } else {
-                        radii[3].max(corners[3])
-                    };
+                    corners[3] = radii[3].max(corners[3]);
 
                     corners
                 }
                 (true, false) => p
                     .window
                     .corner_radius(geometry_size)
-                    .map(|[a, _, c, _]| [a, radii[1], c, radii[3]])
-                    .unwrap_or([default_radius, radii[1], default_radius, radii[3]]),
+                    .map(|[_, _, c, d]| [radii[0], radii[1], c, d])
+                    .unwrap_or([radii[0], radii[1], default_radius, default_radius]),
                 (false, false) => p
                     .window
                     .corner_radius(geometry_size)


### PR DESCRIPTION
It's [TL, TR, BR, BL] everywhere now!

For example setting [0,x,x,x] for corner radius in the theme, now works correctly.
Before:
<img width="1338" height="1118" alt="image" src="https://github.com/user-attachments/assets/6f5bf46e-7cd8-4b1d-beda-0482a5dd8464" />

After:
<img width="1474" height="1183" alt="image" src="https://github.com/user-attachments/assets/26ef0ff2-e892-418b-849d-419cb9cbb40d" />


___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

