### PR TITLE
chore: remove the guard against large paddings

### DIFF
--- a/src/backend/render/mod.rs
+++ b/src/backend/render/mod.rs
@@ -899,8 +899,7 @@ where
                 let geometry = geometry.to_local(output).as_logical();
 
                 let padded = with_states(layer.wl_surface(), |states| {
-                    surface_padding(states, geometry.size)
-                        .and_then(|padding| pad_rect(geometry, &padding))
+                    surface_padding(states).and_then(|padding| pad_rect(geometry, &padding))
                 })
                 .unwrap_or(geometry);
                 let radii = with_states(layer.wl_surface(), |states| {

--- a/src/wayland/handlers/corner_radius.rs
+++ b/src/wayland/handlers/corner_radius.rs
@@ -45,18 +45,11 @@ pub fn surface_corners(states: &SurfaceData, size: Size<i32, Logical>) -> Option
     ])
 }
 
-pub fn surface_padding(states: &SurfaceData, size: Size<i32, Logical>) -> Option<[i32; 4]> {
+pub fn surface_padding(states: &SurfaceData) -> Option<[i32; 4]> {
     let mut guard = states.cached_state.get::<CacheablePadding>();
 
     let padding = guard.current().0?;
-
-    // guard against padding being too large
-    Some([
-        padding.top.min(size.h / 2),
-        padding.right.min(size.w / 2),
-        padding.bottom.min(size.h / 2),
-        padding.left.min(size.w / 2),
-    ])
+    Some([padding.top, padding.right, padding.bottom, padding.left])
 }
 
 pub fn pad_rect(


### PR DESCRIPTION
This is an alternative approach to https://github.com/pop-os/cosmic-comp/pull/2794.
We don't have such gaurd for radius either. No need to change the padding. It gets checked at commit time and rejected if wrong.

Fixes https://github.com/pop-os/cosmic-comp/issues/2804 and https://github.com/pop-os/cosmic-app-library/issues/387
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

