### PR TITLE
feat(input): add four-finger workspace overview gesture

### DIFF
--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -141,6 +141,16 @@ impl State {
                     &mut self.common.workspace_state.update(),
                 );
             }
+            SwipeAction::WorkspaceOverview => {
+                if let Some(command) = self
+                    .common
+                    .config
+                    .system_actions
+                    .get(&shortcuts::action::System::WorkspaceOverview)
+                {
+                    self.spawn_command(command.clone());
+                }
+            }
         }
     }
 

--- a/src/input/gestures/mod.rs
+++ b/src/input/gestures/mod.rs
@@ -16,6 +16,7 @@ pub struct SwipeEvent {
 pub enum SwipeAction {
     NextWorkspace,
     PrevWorkspace,
+    WorkspaceOverview,
 }
 
 #[derive(Debug, Clone)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1151,7 +1151,10 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    if event.fingers() >= 3 && !workspace_overview_is_open(&seat.active_output()) {
+                    if event.fingers() >= 3
+                        && (event.fingers() >= 4
+                            || !workspace_overview_is_open(&seat.active_output()))
+                    {
                         self.common.gesture_state = Some(GestureState::new(event.fingers()));
                     } else {
                         let serial = SERIAL_COUNTER.next_serial();
@@ -1213,7 +1216,21 @@ impl State {
                                                     Some(SwipeAction::NextWorkspace)
                                                 }
                                             }
-                                            _ => None, // TODO: Other actions
+                                            Some(Direction::Up)
+                                                if !workspace_overview_is_open(
+                                                    &seat.active_output(),
+                                                ) =>
+                                            {
+                                                Some(SwipeAction::WorkspaceOverview)
+                                            }
+                                            Some(Direction::Down)
+                                                if workspace_overview_is_open(
+                                                    &seat.active_output(),
+                                                ) =>
+                                            {
+                                                Some(SwipeAction::WorkspaceOverview)
+                                            }
+                                            _ => None,
                                         }
                                     } else {
                                         match gesture_state.direction {


### PR DESCRIPTION
Add four-finger swipe up to open the workspace overview and swipe down to close it, using the existing WorkspaceOverview system action.

## What does this change do?

Adds four-finger vertical swipe gestures for the existing workspace overview:

- Four-finger swipe up opens the workspace overview.
- Four-finger swipe down closes the workspace overview.
- Existing four-finger horizontal workspace navigation is unchanged.

## Why?

COSMIC already provides a workspace overview and supports four-finger touchpad gestures for workspace navigation. This adds the corresponding vertical gesture for opening and closing the existing overview.

## Implementation

The gesture is handled in `cosmic-comp` and uses the existing `System::WorkspaceOverview` action, so the compositor does not duplicate any workspace overview UI logic.

## Testing

Tested locally with:

- `cargo fmt --check`
- `cargo check`
- `cargo build --release`
- `git diff --check`
- Four-finger swipe up/down on the running COSMIC desktop
- Existing four-finger horizontal workspace gestures

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

