### PR TITLE
Fix style bug.

### DIFF
--- a/src/shell/element/resize_indicator.rs
+++ b/src/shell/element/resize_indicator.rs
@@ -264,7 +264,6 @@ impl Program for ResizeIndicatorInternal {
         .align_x(Alignment::Center)
         .align_y(Alignment::Center)
         .padding(16)
-        .apply(container)
         .class(theme::Container::custom(|theme| {
             let mut background = theme.cosmic().accent_color();
             if theme.transparent {

--- a/src/shell/element/stack_hover.rs
+++ b/src/shell/element/stack_hover.rs
@@ -103,7 +103,6 @@ impl Program for StackHoverInternal {
         .align_x(Alignment::Center)
         .align_y(Alignment::Center)
         .padding(16)
-        .apply(container)
         .class(theme::Container::custom(|theme| {
             let mut background = theme.cosmic().accent_color();
             if theme.transparent {

--- a/src/shell/element/swap_indicator.rs
+++ b/src/shell/element/swap_indicator.rs
@@ -105,7 +105,6 @@ impl Program for SwapIndicatorInternal {
         .align_x(Alignment::Center)
         .align_y(Alignment::Center)
         .padding(16)
-        .apply(container)
         .class(theme::Container::custom(|theme| {
             let mut background = theme.cosmic().accent_color();
             if theme.transparent {


### PR DESCRIPTION
The following views:

StackHover
ResizeIndicator
SwapIndicator

Were all broken by this change to libcosmic:

https://github.com/pop-os/libcosmic/pull/1196/changes#diff-732fbaed65fbf90b1ca8073c25e67d137ab8b9944df32f39fe07e5d2adc6e03fR488

That change modified the behavior of Container::Transparent (the default style applied to containers). Previously it used iced_container::default() which used None for the icon_color, text_color, and background.

After the change to libcosmic, however, Container::Tranparent was modified to specify a style that specified the icon_color and text_color, but kept the background as None.  All 3 components used 2 .apply(container) calls. One was styled explictly, the other was not.

The change to libcosmic caused the second apply(container) to overwrite the icon_color and text_color to the default, but keep the backgound color from the first one.

This lead to very low contrast between the background color and the text, despite the explicit style in the code to use the theme's "on accent" color.  This made the text impossible to read.

The change here was to remove the second .apply(container) call from each affected view. The second container would no longer do anything (it applied the style, but the first container would have undone the icon and text color changes).

This fixes the constrast so the views render as intended.

Bug:

<img width="1000" height="993" alt="Bug" src="https://github.com/user-attachments/assets/2733d9a7-c74c-4e48-9ea8-b4f2c1b798fb" />

Fix:

<img width="1000" height="993" alt="Fix" src="https://github.com/user-attachments/assets/958ee7a1-bdc2-4df7-91e0-dce71c286ea2" />


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x ] I understand these changes in full and will be able to respond to review comments.
- [x ] My change is accurately described in the commit message.
- [x ] My contribution is tested and working as described.
- [x ] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

