### PR TITLE
feat: propagate client window metadata

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -82,7 +82,7 @@ use smithay::{
         idle_inhibit::IdleInhibitManagerState,
         idle_notify::IdleNotifierState,
         image_capture_source::{OutputCaptureSourceState, ToplevelCaptureSourceState},
-        image_copy_capture::ImageCopyCaptureState,
+        image_copy_capture::{ImageCopyCaptureState, Session},
         input_method::InputMethodManagerState,
         keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState,
         output::OutputManagerState,
@@ -112,6 +112,7 @@ use smithay::{
         virtual_keyboard::VirtualKeyboardManagerState,
         xdg_activation::XdgActivationState,
         xdg_foreign::XdgForeignState,
+        xdg_toplevel_icon::XdgToplevelIconManager,
         xwayland_keyboard_grab::XWaylandKeyboardGrabState,
         xwayland_shell::XWaylandShellState,
     },
@@ -291,6 +292,7 @@ pub struct Common {
     pub output_capture_source_state: OutputCaptureSourceState,
     pub toplevel_capture_source_state: ToplevelCaptureSourceState,
     pub image_copy_capture_state: ImageCopyCaptureState,
+    pub icon_capture_sessions: Vec<Session>,
     pub seat_state: SeatState<State>,
     pub session_lock_manager_state: SessionLockManagerState,
     pub idle_notifier_state: IdleNotifierState<State>,
@@ -310,6 +312,7 @@ pub struct Common {
 
     // shell-related wayland state
     pub xdg_shell_state: XdgShellState,
+    pub xdg_toplevel_icon_manager: XdgToplevelIconManager,
     pub layer_shell_state: WlrLayerShellState,
     pub toplevel_info_state: ToplevelInfoState<State, CosmicSurface>,
     pub toplevel_management_state: ToplevelManagementState,
@@ -743,6 +746,8 @@ impl State {
                 WmCapabilities::WindowMenu,
             ],
         );
+        let mut xdg_toplevel_icon_manager = XdgToplevelIconManager::new::<State>(dh);
+        xdg_toplevel_icon_manager.add_icon_size(128);
         let xdg_activation_state = XdgActivationState::new::<State>(dh);
         let xdg_foreign_state = XdgForeignState::new::<State>(dh);
         let toplevel_info_state = ToplevelInfoState::new(dh, client_not_sandboxed);
@@ -798,6 +803,7 @@ impl State {
                 output_capture_source_state,
                 toplevel_capture_source_state,
                 image_copy_capture_state,
+                icon_capture_sessions: Vec::new(),
                 shm_state,
                 cursor_shape_manager_state,
                 seat_state,
@@ -816,6 +822,7 @@ impl State {
                 kde_decoration_state,
                 xdg_decoration_state,
                 xdg_shell_state,
+                xdg_toplevel_icon_manager,
                 layer_shell_state,
                 toplevel_info_state,
                 toplevel_management_state,

--- a/src/wayland/handlers/compositor.rs
+++ b/src/wayland/handlers/compositor.rs
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{shell::grabs::SeatMoveGrabState, state::ClientState, utils::prelude::*};
+use crate::{
+    shell::grabs::SeatMoveGrabState,
+    state::ClientState,
+    utils::prelude::*,
+    wayland::{
+        handlers::xdg_toplevel_icon::icon_for_surface, protocols::toplevel_info::WindowIconState,
+    },
+};
 use calloop::Interest;
 use smithay::{
     backend::{
@@ -271,6 +278,23 @@ impl CompositorHandler for State {
         let mapped = self.send_initial_configure_and_map(surface);
 
         let mut shell = self.common.shell.write();
+
+        if let Some(window) = shell.element_for_surface(surface).and_then(|element| {
+            element.windows().find_map(|(window, _)| {
+                (window.wl_surface().as_deref() == Some(surface)).then_some(window)
+            })
+        }) && window.x11_surface().is_none()
+        {
+            let icon = icon_for_surface(surface);
+            window
+                .user_data()
+                .insert_if_missing(WindowIconState::default);
+            window
+                .user_data()
+                .get::<WindowIconState>()
+                .unwrap()
+                .set(icon);
+        }
 
         // schedule a new render
         if let Some(output) = shell.visible_output_for_surface(surface) {

--- a/src/wayland/handlers/image_copy_capture/mod.rs
+++ b/src/wayland/handlers/image_copy_capture/mod.rs
@@ -45,8 +45,26 @@ pub use self::render::*;
 use self::user_data::*;
 pub use self::user_data::{FrameHolder, ImageCopySessions, SessionData, SessionHolder};
 
+const MAX_CAPTURE_PIXELS: usize = 16 * 1024 * 1024;
+
 fn default_cursor_size() -> Size<i32, BufferCoords> {
     Size::new(64, 64)
+}
+
+fn icon_capture_constraints(width: u32, height: u32) -> Option<BufferConstraints> {
+    let width = i32::try_from(width).ok()?;
+    let height = i32::try_from(height).ok()?;
+    let pixels = usize::try_from(width)
+        .ok()?
+        .checked_mul(usize::try_from(height).ok()?)?;
+    if pixels == 0 || pixels > MAX_CAPTURE_PIXELS {
+        return None;
+    }
+    Some(BufferConstraints {
+        size: Size::new(width, height),
+        shm: vec![ShmFormat::Argb8888],
+        dma: None,
+    })
 }
 
 fn seat_for_wl_pointer<'a>(shell: &'a Shell, pointer: &WlPointer) -> Option<&'a Seat<State>> {
@@ -97,15 +115,24 @@ impl ImageCopyCaptureHandler for State {
                     None
                 }
             }
+            ImageCaptureSourceKind::ToplevelIcon { width, height, .. } => {
+                icon_capture_constraints(width, height)
+            }
             ImageCaptureSourceKind::Destroyed => None,
         }
     }
 
     fn cursor_capture_constraints(
         &mut self,
-        _source: &ImageCaptureSource,
+        source: &ImageCaptureSource,
         pointer: &WlPointer,
     ) -> Option<BufferConstraints> {
+        if matches!(
+            ImageCaptureSourceKind::from_source(source),
+            ImageCaptureSourceKind::ToplevelIcon { .. } | ImageCaptureSourceKind::Destroyed
+        ) {
+            return None;
+        }
         let shell = self.common.shell.read();
         let seat = seat_for_wl_pointer(&shell, pointer)?;
         let cursor_geometry = seat.cursor_geometry((0.0, 0.0), self.common.clock.now());
@@ -157,6 +184,9 @@ impl ImageCopyCaptureHandler for State {
                     )))
                 });
                 toplevel.add_session(session);
+            }
+            ImageCaptureSourceKind::ToplevelIcon { .. } => {
+                self.common.icon_capture_sessions.push(session);
             }
             ImageCaptureSourceKind::Destroyed => {
                 session.stop();
@@ -281,6 +311,9 @@ impl ImageCopyCaptureHandler for State {
 
                 toplevel.add_cursor_session(session);
             }
+            ImageCaptureSourceKind::ToplevelIcon { .. } => {
+                session.stop();
+            }
             ImageCaptureSourceKind::Destroyed => {
                 session.stop();
             }
@@ -307,6 +340,11 @@ impl ImageCopyCaptureHandler for State {
 
                 render_window_to_buffer(self, session, frame, &toplevel)
             }
+            ImageCaptureSourceKind::ToplevelIcon {
+                icon,
+                width,
+                height,
+            } => render_icon_to_buffer(frame, &icon, width, height),
             ImageCaptureSourceKind::Destroyed => {
                 frame.fail(CaptureFailureReason::Stopped);
             }
@@ -356,6 +394,11 @@ impl ImageCopyCaptureHandler for State {
                     toplevel.remove_session(&session);
                 }
             }
+            ImageCaptureSourceKind::ToplevelIcon { .. } => {
+                self.common
+                    .icon_capture_sessions
+                    .retain(|stored| stored != &session);
+            }
             ImageCaptureSourceKind::Destroyed => {}
         }
     }
@@ -383,6 +426,7 @@ impl ImageCopyCaptureHandler for State {
                     toplevel.remove_cursor_session(&session)
                 }
             }
+            ImageCaptureSourceKind::ToplevelIcon { .. } => {}
             ImageCaptureSourceKind::Destroyed => {}
         }
     }

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -50,12 +50,14 @@ use crate::{
         handlers::image_copy_capture::{
             SessionData, SessionUserData, constraints_for_output, constraints_for_toplevel,
         },
+        protocols::toplevel_info::WindowIcon,
         protocols::workspace::WorkspaceHandle,
     },
 };
 
 use super::{
-    super::data_device::get_dnd_icon, cursor_capture_constraints, user_data::SessionHolder,
+    super::data_device::get_dnd_icon, MAX_CAPTURE_PIXELS, cursor_capture_constraints,
+    user_data::SessionHolder,
 };
 
 pub fn render_element_buffers<R, E>(
@@ -73,6 +75,136 @@ where
             Some(UnderlyingStorage::Memory(_)) | None => None,
         })
         .collect()
+}
+
+pub(super) fn render_icon_argb8888(icon: &WindowIcon, width: u32, height: u32) -> Option<Vec<u8>> {
+    let pixel_count = usize::try_from(width)
+        .ok()?
+        .checked_mul(usize::try_from(height).ok()?)?;
+    if pixel_count == 0 || pixel_count > MAX_CAPTURE_PIXELS {
+        return None;
+    }
+
+    let source = icon.best_rgba(width, height)?;
+    let source_width = source.width();
+    let source_height = source.height();
+    let (scaled_width, scaled_height) = if u64::from(width) * u64::from(source_height)
+        <= u64::from(height) * u64::from(source_width)
+    {
+        (
+            width,
+            ((u64::from(source_height) * u64::from(width)) / u64::from(source_width)).max(1) as u32,
+        )
+    } else {
+        (
+            ((u64::from(source_width) * u64::from(height)) / u64::from(source_height)).max(1)
+                as u32,
+            height,
+        )
+    };
+    let mut source_pixels = source.pixels().to_vec();
+    for pixel in source_pixels.chunks_exact_mut(4) {
+        let alpha = pixel[3];
+        for channel in &mut pixel[..3] {
+            *channel = ((u16::from(*channel) * u16::from(alpha) + 127) / 255) as u8;
+        }
+    }
+    let image = image::RgbaImage::from_raw(source_width, source_height, source_pixels)?;
+    let image = image::imageops::resize(
+        &image,
+        scaled_width,
+        scaled_height,
+        image::imageops::FilterType::Triangle,
+    );
+
+    let mut output = vec![0; pixel_count.checked_mul(4)?];
+    let offset_x = usize::try_from((width - scaled_width) / 2).ok()?;
+    let offset_y = usize::try_from((height - scaled_height) / 2).ok()?;
+    let target_width = usize::try_from(width).ok()?;
+    for (x, y, pixel) in image.enumerate_pixels() {
+        let [red, green, blue, alpha] = pixel.0;
+        let index = ((offset_y + usize::try_from(y).ok()?) * target_width
+            + offset_x
+            + usize::try_from(x).ok()?)
+            * 4;
+        let argb = (u32::from(alpha) << 24)
+            | (u32::from(red) << 16)
+            | (u32::from(green) << 8)
+            | u32::from(blue);
+        output[index..index + 4].copy_from_slice(&argb.to_ne_bytes());
+    }
+    Some(output)
+}
+
+pub(super) fn render_icon_to_buffer(frame: Frame, icon: &WindowIcon, width: u32, height: u32) {
+    let Some(pixels) = render_icon_argb8888(icon, width, height) else {
+        frame.fail(CaptureFailureReason::Stopped);
+        return;
+    };
+    let buffer = frame.buffer();
+    let copied = with_buffer_contents_mut(&buffer, |ptr, len, data| {
+        let Ok(buffer_width) = u32::try_from(data.width) else {
+            return false;
+        };
+        let Ok(buffer_height) = u32::try_from(data.height) else {
+            return false;
+        };
+        if buffer_width != width
+            || buffer_height != height
+            || data.format != smithay::reexports::wayland_server::protocol::wl_shm::Format::Argb8888
+        {
+            return false;
+        }
+        let Ok(offset) = usize::try_from(data.offset) else {
+            return false;
+        };
+        let Ok(stride) = usize::try_from(data.stride) else {
+            return false;
+        };
+        let Some(row_len) = usize::try_from(width)
+            .ok()
+            .and_then(|width| width.checked_mul(4))
+        else {
+            return false;
+        };
+        let Ok(height) = usize::try_from(height) else {
+            return false;
+        };
+        let Some(end) = height
+            .checked_sub(1)
+            .and_then(|rows| rows.checked_mul(stride))
+            .and_then(|span| span.checked_add(row_len))
+            .and_then(|span| offset.checked_add(span))
+        else {
+            return false;
+        };
+        if stride < row_len || end > len {
+            return false;
+        }
+        for row in 0..height {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    pixels.as_ptr().add(row * row_len),
+                    ptr.add(offset + row * stride),
+                    row_len,
+                );
+            }
+        }
+        true
+    });
+
+    if matches!(copied, Ok(true)) {
+        let size = Size::<i32, BufferCoords>::new(width as i32, height as i32);
+        frame.success(
+            Transform::Normal,
+            vec![Rectangle::from_size(size)],
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO),
+        );
+    } else {
+        frame.fail(CaptureFailureReason::Unknown);
+    }
 }
 
 pub struct PendingImageCopyData {

--- a/src/wayland/handlers/mod.rs
+++ b/src/wayland/handlers/mod.rs
@@ -41,5 +41,6 @@ pub mod workspace;
 pub mod xdg_activation;
 pub mod xdg_foreign;
 pub mod xdg_shell;
+pub mod xdg_toplevel_icon;
 pub mod xwayland_keyboard_grab;
 pub mod xwayland_shell;

--- a/src/wayland/handlers/toplevel_info.rs
+++ b/src/wayland/handlers/toplevel_info.rs
@@ -1,15 +1,29 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use smithay::utils::{Rectangle, user_data::UserDataMap};
+use smithay::{
+    utils::{Rectangle, user_data::UserDataMap},
+    wayland::seat::WaylandFocus,
+};
 
 use crate::{
     shell::CosmicSurface,
     state::State,
     utils::prelude::Global,
-    wayland::protocols::toplevel_info::{
-        ToplevelInfoHandler, ToplevelInfoState, Window, delegate_toplevel_info,
+    wayland::{
+        handlers::xdg_toplevel_icon::icon_for_surface,
+        protocols::toplevel_info::{
+            ToplevelInfoHandler, ToplevelInfoState, Window, WindowIcon, WindowIconState,
+            delegate_toplevel_info,
+        },
     },
 };
+
+fn select_window_icon(
+    cached: Option<WindowIcon>,
+    committed: Option<WindowIcon>,
+) -> Option<WindowIcon> {
+    cached.or(committed)
+}
 
 impl ToplevelInfoHandler for State {
     type Window = CosmicSurface;
@@ -57,6 +71,19 @@ impl Window for CosmicSurface {
 
     fn global_geometry(&self) -> Option<Rectangle<i32, Global>> {
         CosmicSurface::global_geometry(self)
+    }
+
+    fn icon(&self) -> Option<WindowIcon> {
+        let cached = self
+            .user_data()
+            .get::<WindowIconState>()
+            .and_then(|x| x.get());
+        let committed = self
+            .x11_surface()
+            .is_none()
+            .then(|| self.wl_surface().as_deref().and_then(icon_for_surface))
+            .flatten();
+        select_window_icon(cached, committed)
     }
 
     fn user_data(&self) -> &UserDataMap {

--- a/src/wayland/handlers/xdg_toplevel_icon.rs
+++ b/src/wayland/handlers/xdg_toplevel_icon.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use smithay::{
+    reexports::wayland_server::protocol::{wl_buffer::WlBuffer, wl_shm, wl_surface::WlSurface},
+    wayland::{
+        compositor::with_states,
+        shm::with_buffer_contents,
+        xdg_toplevel_icon::{ToplevelIconCachedState, XdgToplevelIconHandler},
+    },
+};
+
+use crate::{
+    state::State,
+    wayland::protocols::toplevel_info::{
+        MAX_RASTER_BYTES, MAX_RASTER_SOURCE_PIXELS, MAX_RASTER_SOURCES, RgbaIcon, WindowIcon,
+    },
+};
+
+fn shm_pixels_to_rgba(
+    data: &[u8],
+    width: i32,
+    height: i32,
+    stride: i32,
+    format: wl_shm::Format,
+) -> Option<Vec<u8>> {
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+    if !matches!(
+        format,
+        wl_shm::Format::Argb8888
+            | wl_shm::Format::Xrgb8888
+            | wl_shm::Format::Abgr8888
+            | wl_shm::Format::Xbgr8888
+    ) {
+        return None;
+    }
+
+    let width = usize::try_from(width).ok()?;
+    let height = usize::try_from(height).ok()?;
+    if width.checked_mul(height)? > MAX_RASTER_SOURCE_PIXELS {
+        return None;
+    }
+    let stride = usize::try_from(stride).ok()?;
+    let row_len = width.checked_mul(4)?;
+    if stride < row_len {
+        return None;
+    }
+    let len = height.checked_mul(row_len)?;
+    let required = (height - 1).checked_mul(stride)?.checked_add(row_len)?;
+    if data.len() < required {
+        return None;
+    }
+
+    let mut rgba = Vec::with_capacity(len);
+    for row in data.chunks(stride).take(height) {
+        for pixel in row[..row_len].chunks_exact(4) {
+            let packed = u32::from_ne_bytes(pixel.try_into().ok()?);
+            let alpha = if matches!(format, wl_shm::Format::Xrgb8888 | wl_shm::Format::Xbgr8888) {
+                255
+            } else {
+                (packed >> 24) as u8
+            };
+            let unpremultiply = |channel: u8| {
+                if alpha == 0 {
+                    0
+                } else {
+                    u8::try_from(
+                        (u32::from(channel) * 255 + u32::from(alpha) / 2) / u32::from(alpha),
+                    )
+                    .unwrap_or(255)
+                }
+            };
+            let (red, green, blue) =
+                if matches!(format, wl_shm::Format::Abgr8888 | wl_shm::Format::Xbgr8888) {
+                    (packed as u8, (packed >> 8) as u8, (packed >> 16) as u8)
+                } else {
+                    ((packed >> 16) as u8, (packed >> 8) as u8, packed as u8)
+                };
+            rgba.extend_from_slice(&[
+                unpremultiply(red),
+                unpremultiply(green),
+                unpremultiply(blue),
+                alpha,
+            ]);
+        }
+    }
+    Some(rgba)
+}
+
+fn shm_layout(
+    width: i32,
+    height: i32,
+    stride: i32,
+    offset: i32,
+    pool_len: usize,
+) -> Option<(usize, usize, usize)> {
+    let width = usize::try_from(width).ok()?;
+    let height = usize::try_from(height).ok()?;
+    let stride = usize::try_from(stride).ok()?;
+    let offset = usize::try_from(offset).ok()?;
+    let pixels = width.checked_mul(height)?;
+    if pixels == 0 || pixels > MAX_RASTER_SOURCE_PIXELS {
+        return None;
+    }
+    let row_len = width.checked_mul(4)?;
+    if stride < row_len {
+        return None;
+    }
+    let packed_len = height.checked_mul(row_len)?;
+    let span = (height - 1).checked_mul(stride)?.checked_add(row_len)?;
+    let end = offset.checked_add(span)?;
+    (end <= pool_len).then_some((row_len, end, packed_len))
+}
+
+fn buffer_to_icon(buffer: &WlBuffer, max_bytes: usize) -> Option<RgbaIcon> {
+    with_buffer_contents(buffer, |ptr, pool_len, metadata| {
+        let offset = usize::try_from(metadata.offset).ok()?;
+        let stride = usize::try_from(metadata.stride).ok()?;
+        let height = usize::try_from(metadata.height).ok()?;
+        let (row_len, _, packed_len) = shm_layout(
+            metadata.width,
+            metadata.height,
+            metadata.stride,
+            metadata.offset,
+            pool_len,
+        )?;
+        if packed_len > max_bytes {
+            return None;
+        }
+
+        let mut bytes = vec![0; packed_len];
+        for row in 0..height {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    ptr.add(offset + row * stride),
+                    bytes.as_mut_ptr().add(row * row_len),
+                    row_len,
+                );
+            }
+        }
+        let pixels = shm_pixels_to_rgba(
+            &bytes,
+            metadata.width,
+            metadata.height,
+            i32::try_from(row_len).ok()?,
+            metadata.format,
+        )?;
+        RgbaIcon::new(
+            u32::try_from(metadata.width).ok()?,
+            u32::try_from(metadata.height).ok()?,
+            pixels,
+        )
+    })
+    .ok()?
+}
+
+pub(super) fn icon_for_surface(surface: &WlSurface) -> Option<WindowIcon> {
+    with_states(surface, |states| {
+        let mut cached = states.cached_state.get::<ToplevelIconCachedState>();
+        let icon = cached.current();
+
+        let name = icon.icon_name().map(str::to_owned);
+        let mut remaining = MAX_RASTER_BYTES;
+        let mut buffers = Vec::new();
+        for (buffer, _scale) in icon.buffers() {
+            if buffers.len() == MAX_RASTER_SOURCES {
+                break;
+            }
+            let Some(rgba) = buffer_to_icon(buffer, remaining) else {
+                continue;
+            };
+            remaining -= rgba.pixels().len();
+            buffers.push(rgba);
+        }
+
+        WindowIcon::new(name, buffers)
+    })
+}
+
+impl XdgToplevelIconHandler for State {}

--- a/src/wayland/protocols/image_capture_source.rs
+++ b/src/wayland/protocols/image_capture_source.rs
@@ -2,6 +2,7 @@ use super::{
     workspace::{WorkspaceHandle, WorkspaceHandler},
 };
 use crate::shell::element::surface::WeakCosmicSurface;
+use crate::wayland::protocols::toplevel_info::WindowIcon;
 use cosmic_protocols::image_capture_source::v1::server::{
     zcosmic_workspace_image_capture_source_manager_v1::{
         Request as CosmicWorkspaceSourceRequest, ZcosmicWorkspaceImageCaptureSourceManagerV1,
@@ -33,6 +34,11 @@ pub enum ImageCaptureSourceKind {
     Output(WeakOutput),
     Workspace(WorkspaceHandle),
     Toplevel(WeakCosmicSurface),
+    ToplevelIcon {
+        icon: WindowIcon,
+        width: u32,
+        height: u32,
+    },
     Destroyed,
 }
 
@@ -45,6 +51,24 @@ impl ImageCaptureSourceKind {
             .cloned()
             .unwrap_or(Self::Destroyed)
     }
+}
+
+pub fn init_image_capture_source<D>(
+    source_handle: New<ExtImageCaptureSourceV1>,
+    kind: ImageCaptureSourceKind,
+    data_init: &mut DataInit<'_, D>,
+) where
+    D: Dispatch<ExtImageCaptureSourceV1, ImageCaptureSourceData> + 'static,
+{
+    let source = ImageCaptureSource::new();
+    source.user_data().insert_if_missing(|| kind);
+    let instance = data_init.init(
+        source_handle,
+        ImageCaptureSourceData {
+            source: source.clone(),
+        },
+    );
+    source.add_instance(&instance);
 }
 
 impl CosmicImageCaptureSourceState {
@@ -122,15 +146,7 @@ where
                 Some(workspace) => ImageCaptureSourceKind::Workspace(workspace),
                 None => ImageCaptureSourceKind::Destroyed,
             };
-            let source = ImageCaptureSource::new();
-            source.user_data().insert_if_missing(|| data);
-            let instance = data_init.init(
-                source_handle,
-                ImageCaptureSourceData {
-                    source: source.clone(),
-                },
-            );
-            source.add_instance(&instance);
+            init_image_capture_source(source_handle, data, data_init);
         }
     }
 }

--- a/src/wayland/protocols/toplevel_info.rs
+++ b/src/wayland/protocols/toplevel_info.rs
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{collections::HashSet, sync::Mutex};
+use std::{
+    collections::HashSet,
+    io::Read,
+    path::Path,
+    sync::{Arc, Mutex},
+};
 
 use smithay::{
     output::Output,
     reexports::{
-        wayland_protocols::ext::foreign_toplevel_list::v1::server::{
-            ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
-            ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        wayland_protocols::ext::{
+            foreign_toplevel_list::v1::server::{
+                ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+                ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+            },
+            image_capture_source::v1::server::ext_image_capture_source_v1::ExtImageCaptureSourceV1,
         },
         wayland_server::{
             Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, Weak,
@@ -16,21 +24,32 @@ use smithay::{
         },
     },
     utils::{IsAlive, Logical, Rectangle, user_data::UserDataMap},
-    wayland::foreign_toplevel_list::{
-        ForeignToplevelHandle, ForeignToplevelListGlobalData, ForeignToplevelListHandler,
-        ForeignToplevelListState,
+    wayland::{
+        foreign_toplevel_list::{
+            ForeignToplevelHandle, ForeignToplevelListGlobalData, ForeignToplevelListHandler,
+            ForeignToplevelListState,
+        },
+        image_capture_source::ImageCaptureSourceData,
     },
 };
 
 use crate::utils::prelude::{Global, OutputExt, RectGlobalExt};
 
-use super::workspace::{WorkspaceHandle, WorkspaceHandler, WorkspaceState};
+use super::{
+    image_capture_source::{ImageCaptureSourceKind, init_image_capture_source},
+    workspace::{WorkspaceHandle, WorkspaceHandler, WorkspaceState},
+};
 
 use cosmic_protocols::toplevel_info::v1::server::{
     zcosmic_toplevel_handle_v1::{self, State as States, ZcosmicToplevelHandleV1},
     zcosmic_toplevel_info_v1::{self, ZcosmicToplevelInfoV1},
 };
 use tracing::error;
+
+pub(crate) const MAX_RASTER_BYTES: usize = 16 * 1024 * 1024;
+pub(crate) const MAX_RASTER_SOURCES: usize = 16;
+pub(crate) const MAX_RASTER_SOURCE_PIXELS: usize = 4 * 1024 * 1024;
+const MAX_ICON_FILE_BYTES: usize = MAX_RASTER_BYTES;
 
 pub trait Window: IsAlive + Clone + PartialEq + Send {
     fn title(&self) -> String;
@@ -42,7 +61,241 @@ pub trait Window: IsAlive + Clone + PartialEq + Send {
     fn is_sticky(&self) -> bool;
     fn is_resizing(&self) -> bool;
     fn global_geometry(&self) -> Option<Rectangle<i32, Global>>;
+    fn icon(&self) -> Option<WindowIcon>;
     fn user_data(&self) -> &UserDataMap;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RgbaIcon {
+    width: u32,
+    height: u32,
+    pixels: Arc<[u8]>,
+}
+
+impl RgbaIcon {
+    pub fn new(width: u32, height: u32, pixels: Vec<u8>) -> Option<Self> {
+        let pixel_count = usize::try_from(width)
+            .ok()?
+            .checked_mul(usize::try_from(height).ok()?)?;
+        if width == 0
+            || height == 0
+            || pixel_count > MAX_RASTER_SOURCE_PIXELS
+            || pixels.len() != pixel_count.checked_mul(4)?
+        {
+            return None;
+        }
+
+        Some(Self {
+            width,
+            height,
+            pixels: pixels.into(),
+        })
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    pub fn pixels(&self) -> &[u8] {
+        &self.pixels
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowIcon {
+    name: Option<String>,
+    rgba: Arc<[RgbaIcon]>,
+}
+
+impl WindowIcon {
+    pub fn new(name: Option<String>, mut rgba: Vec<RgbaIcon>) -> Option<Self> {
+        let name = name.filter(|name| !name.is_empty());
+        rgba.sort_by(|left, right| {
+            let area = |icon: &RgbaIcon| u64::from(icon.width) * u64::from(icon.height);
+            area(right).cmp(&area(left))
+        });
+        rgba.dedup_by_key(|icon| (icon.width, icon.height));
+        let mut total_bytes = 0usize;
+        rgba.retain(|icon| {
+            if total_bytes
+                .checked_add(icon.pixels.len())
+                .is_none_or(|total| total > MAX_RASTER_BYTES)
+            {
+                return false;
+            }
+            total_bytes += icon.pixels.len();
+            true
+        });
+        rgba.truncate(MAX_RASTER_SOURCES);
+        if name.is_none() && rgba.is_empty() {
+            return None;
+        }
+        Some(Self {
+            name,
+            rgba: rgba.into(),
+        })
+    }
+
+    pub fn from_rgba(width: u32, height: u32, pixels: Vec<u8>) -> Option<Self> {
+        Self::new(None, vec![RgbaIcon::new(width, height, pixels)?])
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn best_rgba(&self, width: u32, height: u32) -> Option<&RgbaIcon> {
+        let area = |icon: &&RgbaIcon| u64::from(icon.width) * u64::from(icon.height);
+        self.rgba
+            .iter()
+            .filter(|icon| icon.width >= width && icon.height >= height)
+            .min_by_key(area)
+            .or_else(|| self.rgba.iter().max_by_key(area))
+    }
+}
+
+fn decode_png_icon(data: &[u8]) -> Option<RgbaIcon> {
+    let mut decoder = png::Decoder::new(std::io::Cursor::new(data));
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().ok()?;
+    let output_len = reader.output_buffer_size()?;
+    if output_len > MAX_RASTER_BYTES {
+        return None;
+    }
+
+    let mut decoded = vec![0; output_len];
+    let info = reader.next_frame(&mut decoded).ok()?;
+    let decoded = &decoded[..info.buffer_size()];
+    let pixel_count = usize::try_from(info.width)
+        .ok()?
+        .checked_mul(usize::try_from(info.height).ok()?)?;
+    if pixel_count > MAX_RASTER_SOURCE_PIXELS {
+        return None;
+    }
+    let mut rgba = Vec::with_capacity(pixel_count.checked_mul(4)?);
+    match info.color_type {
+        png::ColorType::Rgba => rgba.extend_from_slice(decoded),
+        png::ColorType::Rgb => {
+            for pixel in decoded.chunks_exact(3) {
+                rgba.extend_from_slice(&[pixel[0], pixel[1], pixel[2], 255]);
+            }
+        }
+        png::ColorType::GrayscaleAlpha => {
+            for pixel in decoded.chunks_exact(2) {
+                rgba.extend_from_slice(&[pixel[0], pixel[0], pixel[0], pixel[1]]);
+            }
+        }
+        png::ColorType::Grayscale => {
+            for value in decoded {
+                rgba.extend_from_slice(&[*value, *value, *value, 255]);
+            }
+        }
+        png::ColorType::Indexed => return None,
+    }
+    RgbaIcon::new(info.width, info.height, rgba)
+}
+
+fn rasterize_svg_icon(data: &[u8], requested_longest_side: u32) -> Option<RgbaIcon> {
+    let tree = resvg::usvg::Tree::from_data(data, &resvg::usvg::Options::default()).ok()?;
+    let svg_size = tree.size();
+    let longest_side = svg_size.width().max(svg_size.height());
+    if !longest_side.is_finite() || longest_side <= 0.0 {
+        return None;
+    }
+
+    // RgbaIcon bounds retained source storage to four megapixels. Capping the
+    // longest side at 2048 keeps even a square vector source within that bound;
+    // image-copy-capture performs any remaining scaling to the requested size.
+    let target = requested_longest_side.clamp(1, 2048) as f32;
+    let scale = target / longest_side;
+    let width = (svg_size.width() * scale).round().max(1.0) as u32;
+    let height = (svg_size.height() * scale).round().max(1.0) as u32;
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height)?;
+    resvg::render(
+        &tree,
+        resvg::tiny_skia::Transform::from_scale(scale, scale),
+        &mut pixmap.as_mut(),
+    );
+
+    let mut rgba = pixmap.take();
+    for pixel in rgba.chunks_exact_mut(4) {
+        let alpha = pixel[3];
+        for channel in &mut pixel[..3] {
+            *channel = if alpha == 0 {
+                0
+            } else {
+                u8::try_from((u32::from(*channel) * 255 + u32::from(alpha) / 2) / u32::from(alpha))
+                    .unwrap_or(255)
+            };
+        }
+    }
+    RgbaIcon::new(width, height, rgba)
+}
+
+fn rasterize_icon_path(path: &Path, data: &[u8], requested_longest_side: u32) -> Option<RgbaIcon> {
+    match path.extension()?.to_str()?.to_ascii_lowercase().as_str() {
+        "png" => decode_png_icon(data),
+        "svg" => rasterize_svg_icon(data, requested_longest_side),
+        _ => None,
+    }
+}
+
+fn read_icon_file(path: &Path) -> Option<Vec<u8>> {
+    let file = std::fs::File::open(path).ok()?;
+    if file.metadata().ok()?.len() > u64::try_from(MAX_ICON_FILE_BYTES).ok()? {
+        return None;
+    }
+    let mut data = Vec::new();
+    file.take(u64::try_from(MAX_ICON_FILE_BYTES).ok()?.checked_add(1)?)
+        .read_to_end(&mut data)
+        .ok()?;
+    (data.len() <= MAX_ICON_FILE_BYTES).then_some(data)
+}
+
+fn icon_for_capture_with(
+    icon: WindowIcon,
+    width: u32,
+    height: u32,
+    resolve_name: impl FnOnce(&str, u16) -> Option<RgbaIcon>,
+) -> Option<WindowIcon> {
+    if icon.best_rgba(width, height).is_some() {
+        return Some(icon);
+    }
+
+    let name = icon.name()?.to_owned();
+    let requested_size = width.max(height).clamp(1, 2048) as u16;
+    let rgba = resolve_name(&name, requested_size)?;
+    WindowIcon::new(Some(name), vec![rgba])
+}
+
+fn icon_for_capture(icon: WindowIcon, width: u32, height: u32) -> Option<WindowIcon> {
+    let theme = cosmic::icon_theme::default();
+    icon_for_capture_with(icon, width, height, |name, requested_size| {
+        let path = freedesktop_icons::lookup(name)
+            .with_size(requested_size)
+            .with_theme(&theme)
+            .force_svg()
+            .find()?;
+        let data = read_icon_file(&path)?;
+        rasterize_icon_path(&path, &data, u32::from(requested_size))
+    })
+}
+
+#[derive(Default)]
+pub struct WindowIconState(Mutex<Option<WindowIcon>>);
+
+impl WindowIconState {
+    pub fn get(&self) -> Option<WindowIcon> {
+        self.0.lock().unwrap().clone()
+    }
+
+    pub fn set(&self, icon: Option<WindowIcon>) {
+        *self.0.lock().unwrap() = icon;
+    }
 }
 
 #[derive(Debug)]
@@ -102,6 +355,7 @@ pub struct ToplevelHandleStateInner<W: Window> {
     title: String,
     app_id: String,
     states: Option<Vec<States>>,
+    icon: Option<Option<WindowIcon>>,
     pub(super) window: Option<W>,
 }
 pub type ToplevelHandleState<W> = Mutex<ToplevelHandleStateInner<W>>;
@@ -116,6 +370,7 @@ impl<W: Window> ToplevelHandleStateInner<W> {
             title: String::new(),
             app_id: String::new(),
             states: None,
+            icon: None,
             window: Some(window.clone()),
         })
     }
@@ -129,8 +384,15 @@ impl<W: Window> ToplevelHandleStateInner<W> {
             title: String::new(),
             app_id: String::new(),
             states: None,
+            icon: None,
             window: None,
         })
+    }
+}
+
+fn invalidate_toplevel_handle<W: Window + 'static>(handle: &ZcosmicToplevelHandleV1) {
+    if let Some(data) = handle.data::<ToplevelHandleState<W>>() {
+        data.lock().unwrap().window = None;
     }
 }
 
@@ -243,6 +505,7 @@ where
     D: GlobalDispatch<ZcosmicToplevelInfoV1, ToplevelInfoGlobalData>
         + Dispatch<ZcosmicToplevelInfoV1, ()>
         + Dispatch<ZcosmicToplevelHandleV1, ToplevelHandleState<W>>
+        + Dispatch<ExtImageCaptureSourceV1, ImageCaptureSourceData>
         + ToplevelInfoHandler<Window = W>
         + 'static,
     W: Window,
@@ -250,13 +513,44 @@ where
     fn request(
         _state: &mut D,
         _client: &Client,
-        _obj: &ZcosmicToplevelHandleV1,
+        obj: &ZcosmicToplevelHandleV1,
         request: zcosmic_toplevel_handle_v1::Request,
-        _data: &ToplevelHandleState<W>,
+        data: &ToplevelHandleState<W>,
         _dh: &DisplayHandle,
-        _data_init: &mut DataInit<'_, D>,
+        data_init: &mut DataInit<'_, D>,
     ) {
-        if let zcosmic_toplevel_handle_v1::Request::Destroy = request {}
+        match request {
+            zcosmic_toplevel_handle_v1::Request::Destroy => {}
+            zcosmic_toplevel_handle_v1::Request::CreateIconSource {
+                source,
+                width,
+                height,
+            } => {
+                let kind = if width == 0 || height == 0 {
+                    obj.post_error(
+                        zcosmic_toplevel_handle_v1::Error::InvalidIconSize,
+                        "icon capture dimensions must be non-zero".to_owned(),
+                    );
+                    ImageCaptureSourceKind::Destroyed
+                } else {
+                    data.lock()
+                        .unwrap()
+                        .window
+                        .as_ref()
+                        .and_then(Window::icon)
+                        .and_then(|icon| icon_for_capture(icon, width, height))
+                        .map_or(ImageCaptureSourceKind::Destroyed, |icon| {
+                            ImageCaptureSourceKind::ToplevelIcon {
+                                icon,
+                                width,
+                                height,
+                            }
+                        })
+                };
+                init_image_capture_source(source, kind, data_init);
+            }
+            _ => unreachable!(),
+        }
     }
 
     fn destroyed(
@@ -318,7 +612,7 @@ where
         F: for<'a> Fn(&'a Client) -> bool + Send + Sync + Clone + 'static,
     {
         let global = dh.create_global::<D, ZcosmicToplevelInfoV1, _>(
-            3,
+            4,
             ToplevelInfoGlobalData {
                 filter: Box::new(client_filter.clone()),
             },
@@ -362,6 +656,7 @@ where
         if let Some(state) = toplevel.user_data().get::<ToplevelState>() {
             let mut state_inner = state.lock().unwrap();
             for (_info, handle) in &state_inner.instances {
+                invalidate_toplevel_handle::<W>(handle);
                 // don't send events to stopped instances
                 if handle.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE
                     && self
@@ -408,6 +703,7 @@ where
                 true
             } else {
                 for (_info, handle) in &state.instances {
+                    invalidate_toplevel_handle::<W>(handle);
                     // don't send events to stopped instances
                     if handle.version() < zcosmic_toplevel_info_v1::REQ_GET_COSMIC_TOPLEVEL_SINCE
                         && self
@@ -537,6 +833,13 @@ where
         None
     };
 
+    let new_icon = (instance.version() >= zcosmic_toplevel_handle_v1::EVT_ICON_CHANGED_SINCE
+        && handle_state
+            .icon
+            .as_ref()
+            .is_none_or(|icon| icon != &window.icon()))
+    .then(|| window.icon());
+
     let geometry_changed = if !window.is_resizing() {
         let geometry = window.global_geometry();
         if handle_state.geometry != geometry {
@@ -557,6 +860,7 @@ where
     if new_title.is_none()
         && new_app_id.is_none()
         && new_states.is_none()
+        && new_icon.is_none()
         && !geometry_changed
         && !outputs_changed
         && !workspaces_changed
@@ -595,6 +899,17 @@ where
             .flat_map(|state| (*state as u32).to_ne_bytes())
             .collect::<Vec<u8>>();
         instance.state(states);
+        changed = true;
+    }
+
+    if let Some(icon) = new_icon {
+        match &icon {
+            Some(icon) => instance.icon_changed(icon.name().map(str::to_owned)),
+            None => {
+                instance.icon_removed();
+            }
+        }
+        handle_state.icon = Some(icon);
         changed = true;
     }
 

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -35,7 +35,10 @@ use smithay::{
     },
     desktop::space::SpaceElement,
     input::{keyboard::ModifiersState, pointer::CursorIcon, tablet::TabletSeatTrait},
-    reexports::{wayland_server::Client, x11rb::protocol::xproto::Window as X11Window},
+    reexports::{
+        wayland_server::Client,
+        x11rb::{errors::ConnectionError, protocol::xproto::Window as X11Window},
+    },
     utils::{
         Buffer as BufferCoords, Logical, Point, Rectangle, SERIAL_COUNTER, Serial, Size, Transform,
     },
@@ -55,12 +58,59 @@ use smithay::{
     },
     xwayland::{
         X11Surface, X11Wm, XWayland, XWaylandClientData, XWaylandEvent, XwmHandler,
-        xwm::{Reorder, XwmId},
+        xwm::{Reorder, WmWindowProperty, X11SurfaceIcon, XwmId},
     },
 };
 use tracing::{error, trace, warn};
 use xcursor::parser::Image;
 use xkbcommon::xkb::Keysym;
+
+use crate::wayland::protocols::toplevel_info::{
+    MAX_RASTER_BYTES, MAX_RASTER_SOURCES, RgbaIcon, WindowIcon, WindowIconState,
+};
+
+fn net_wm_icons(icons: &[X11SurfaceIcon]) -> Option<WindowIcon> {
+    let mut remaining = MAX_RASTER_BYTES;
+    let mut rgba = Vec::new();
+    for icon in icons.iter().take(MAX_RASTER_SOURCES) {
+        let Some(byte_len) = icon.pixels.len().checked_mul(4) else {
+            continue;
+        };
+        if byte_len > remaining {
+            continue;
+        }
+        let pixels = icon
+            .pixels
+            .iter()
+            .flat_map(|pixel| {
+                [
+                    (pixel >> 16) as u8,
+                    (pixel >> 8) as u8,
+                    *pixel as u8,
+                    (pixel >> 24) as u8,
+                ]
+            })
+            .collect();
+        let Some(icon) = RgbaIcon::new(icon.width, icon.height, pixels) else {
+            continue;
+        };
+        remaining -= byte_len;
+        rgba.push(icon);
+    }
+
+    WindowIcon::new(None, rgba)
+}
+
+fn x11_surface_icon(window: &X11Surface) -> Result<Option<WindowIcon>, ConnectionError> {
+    window.icons().map(|icons| net_wm_icons(&icons))
+}
+
+fn select_icon_update_target<T>(
+    registered: Option<T>,
+    shell_fallback: impl FnOnce() -> Option<T>,
+) -> Option<T> {
+    registered.or_else(shell_fallback)
+}
 
 #[derive(Debug)]
 pub struct XWaylandState {
@@ -783,11 +833,59 @@ impl XwmHandler for State {
     fn new_override_redirect_window(&mut self, _xwm: XwmId, _window: X11Surface) {}
     fn destroyed_window(&mut self, _xwm: XwmId, _window: X11Surface) {}
 
+    fn property_notify(&mut self, _xwm: XwmId, window: X11Surface, property: WmWindowProperty) {
+        if property != WmWindowProperty::Icon {
+            return;
+        }
+
+        let icon = match x11_surface_icon(&window) {
+            Ok(icon) => icon,
+            Err(err) => {
+                warn!(?window, ?err, "Failed to read X11 window icons");
+                return;
+            }
+        };
+        let registered = self
+            .common
+            .toplevel_info_state
+            .registered_toplevels()
+            .find(|surface| surface.x11_surface() == Some(&window))
+            .cloned();
+        let surface = select_icon_update_target(registered, || {
+            let shell = self.common.shell.read();
+            shell
+                .element_for_surface(&window)
+                .and_then(|mapped| {
+                    mapped.windows().find_map(|(surface, _)| {
+                        (surface.x11_surface() == Some(&window)).then_some(surface)
+                    })
+                })
+                .or_else(|| {
+                    shell
+                        .pending_windows
+                        .iter()
+                        .find(|pending| pending.surface.x11_surface() == Some(&window))
+                        .map(|pending| pending.surface.clone())
+                })
+        });
+
+        if let Some(surface) = surface {
+            surface
+                .user_data()
+                .get_or_insert(WindowIconState::default)
+                .set(icon);
+        }
+    }
+
     fn map_window_request(&mut self, _xwm: XwmId, window: X11Surface) {
         if let Err(err) = window.set_mapped(true) {
             warn!(?window, ?err, "Failed to send Xwayland Mapped-Event",);
         }
 
+        let icon = x11_surface_icon(&window).unwrap_or_else(|err| {
+            warn!(?window, ?err, "Failed to read X11 window icons");
+            None
+        });
         let mut shell = self.common.shell.write();
         let startup_id = window.startup_id();
         if shell.is_surface_mapped(&window) {
@@ -817,12 +915,21 @@ impl XwmHandler for State {
             .iter_mut()
             .find(|w| w.surface == window)
         {
+            pending
+                .surface
+                .user_data()
+                .get_or_insert(WindowIconState::default)
+                .set(icon);
             pending.seat = seat;
             pending.fullscreen = fullscreen;
             pending.minimized = minimized;
             pending.maximized = maximized;
         } else {
             let surface = CosmicSurface::from(window);
+            surface
+                .user_data()
+                .get_or_insert(WindowIconState::default)
+                .set(icon);
             shell.pending_windows.push(PendingWindow {
                 surface,
                 seat,


### PR DESCRIPTION
Use  X11 `_NET_WM_ICON` and native Wayland `xdg-toplevel-icon-v1` metadata. Publish icon-name changes and requested-size capture sources over COSMIC toplevel-info v4 so cosmic-applets can show application icons and names in the dock.

depends on https://github.com/Smithay/smithay/pull/2160
depends on https://github.com/pop-os/cosmic-protocols/pull/87


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

