### PR TITLE
fix: set keyboard focus on touch target (similar to tablet/pointer)

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1462,11 +1462,18 @@ impl State {
                     };
                     let under = State::surface_under(position, &output, &shell)
                         .map(|(target, pos)| (target, pos.as_logical()));
+                    let focus_target = State::element_under(position, &output, &shell, &seat);
 
                     std::mem::drop(shell);
 
                     let serial = SERIAL_COUNTER.next_serial();
                     let touch = seat.get_touch().unwrap();
+                    // change the keyboard focus unless the touch is grabbed, like pointer buttons
+                    if !touch.is_grabbed()
+                        && let Some(target) = focus_target.as_ref()
+                    {
+                        Shell::set_focus(self, Some(target), &seat, Some(serial), false);
+                    }
                     touch.down(
                         self,
                         under,


### PR DESCRIPTION
Currently if you touch a window using your touchscreen, the event is sent to that window, but the window doesn't get brought to the front, or get the focus hint around it.
This fixes it.

fixes https://github.com/pop-os/cosmic-comp/issues/840
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

