### PR TITLE
xwayland: handle transient relationships and shapes

### DIFF
--- a/src/backend/render/wayland/mod.rs
+++ b/src/backend/render/wayland/mod.rs
@@ -1,7 +1,11 @@
 use smithay::{
     backend::renderer::{
         ImportAll, Renderer,
-        element::surface::{KindEvaluation, WaylandSurfaceRenderElement},
+        element::{
+            NamespacedElement,
+            surface::{KindEvaluation, WaylandSurfaceRenderElement},
+            utils::CropRenderElement,
+        },
         utils::RendererSurfaceStateUserData,
     },
     reexports::wayland_server::protocol::wl_surface,
@@ -23,6 +27,7 @@ render_elements! {
     pub SurfaceRenderElement<R> where R: AsGlowRenderer + ImportAll, R::TextureId: Send;
     Blur=BlurElement,
     Clipped=ClippedSurfaceRenderElement<R>,
+    Cropped=NamespacedElement<CropRenderElement<WaylandSurfaceRenderElement<R>>>,
     Wayland=WaylandSurfaceRenderElement<R>,
 }
 

--- a/src/shell/element/surface.rs
+++ b/src/shell/element/surface.rs
@@ -966,6 +966,20 @@ impl CosmicSurface {
                 )
             }
             WindowSurface::X11(surface) => {
+                if surface.render_shape().is_some() {
+                    for element in smithay::backend::renderer::element::AsRenderElements::render_elements::<
+                        smithay::backend::renderer::element::NamespacedElement<
+                            smithay::backend::renderer::element::utils::CropRenderElement<
+                                smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement<R>,
+                            >,
+                        >,
+                    >(surface, renderer, location, scale, alpha)
+                    {
+                        push_above(element.into());
+                    }
+                    return;
+                }
+
                 let Some(surface) = surface.wl_surface() else {
                     return;
                 };

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -461,7 +461,25 @@ fn update_focus_state(
     }
 }
 
+fn x11_transient_parent_matches(child_parent: Option<u32>, parent_window: Option<u32>) -> bool {
+    child_parent
+        .zip(parent_window)
+        .is_some_and(|(child_parent, parent_window)| child_parent == parent_window)
+}
+
 fn raise_with_children(floating_layer: &mut FloatingLayout, focused: &CosmicMapped) {
+    raise_with_children_inner(floating_layer, focused, &mut IndexSet::new());
+}
+
+fn raise_with_children_inner(
+    floating_layer: &mut FloatingLayout,
+    focused: &CosmicMapped,
+    raised: &mut IndexSet<CosmicMapped>,
+) {
+    if !raised.insert(focused.clone()) {
+        return;
+    }
+
     if floating_layer.mapped().any(|m| m == focused) {
         floating_layer.space.raise_element(focused, true);
         for element in floating_layer
@@ -469,25 +487,30 @@ fn raise_with_children(floating_layer: &mut FloatingLayout, focused: &CosmicMapp
             .elements()
             .filter(|elem| elem != &focused)
             .filter(|elem| {
-                let parent = elem
-                    .active_window()
-                    .0
-                    .toplevel()
-                    .and_then(|toplevel| toplevel.parent());
-                parent.is_some_and(|parent| {
-                    focused
-                        .active_window()
+                let child = elem.active_window();
+                let parent = focused.active_window();
+                let wayland_parent = child.0.toplevel().and_then(|toplevel| toplevel.parent());
+                let is_wayland_child = wayland_parent.is_some_and(|wayland_parent| {
+                    parent
                         .wl_surface()
                         .map(Cow::into_owned)
-                        .map(|focused| parent == focused)
+                        .map(|parent| wayland_parent == parent)
                         .unwrap_or(false)
-                })
+                });
+                let is_x11_child = x11_transient_parent_matches(
+                    child
+                        .x11_surface()
+                        .and_then(|child| child.is_transient_for()),
+                    parent.x11_surface().map(|parent| parent.window_id()),
+                );
+
+                is_wayland_child || is_x11_child
             })
             .cloned()
             .collect::<Vec<_>>()
             .into_iter()
         {
-            raise_with_children(floating_layer, &element);
+            raise_with_children_inner(floating_layer, &element, raised);
         }
     }
 }

--- a/src/shell/layout/floating/mod.rs
+++ b/src/shell/layout/floating/mod.rs
@@ -52,6 +52,25 @@ pub use self::grabs::*;
 pub const ANIMATION_DURATION: Duration = Duration::from_millis(200);
 pub const MINIMIZE_ANIMATION_DURATION: Duration = Duration::from_millis(320);
 
+fn centered_transient_location(
+    parent: Rectangle<i32, Local>,
+    child_size: Size<i32, Local>,
+    bounds: Rectangle<i32, Local>,
+) -> Point<i32, Local> {
+    let centered = parent.loc
+        + Point::from((
+            (parent.size.w - child_size.w) / 2,
+            (parent.size.h - child_size.h) / 2,
+        ));
+    let max_x = (bounds.loc.x + bounds.size.w - child_size.w).max(bounds.loc.x);
+    let max_y = (bounds.loc.y + bounds.size.h - child_size.h).max(bounds.loc.y);
+
+    Point::from((
+        centered.x.clamp(bounds.loc.x, max_x),
+        centered.y.clamp(bounds.loc.y, max_y),
+    ))
+}
+
 #[derive(Debug, Default)]
 pub struct FloatingLayout {
     pub(crate) space: Space<CosmicMapped>,
@@ -347,6 +366,51 @@ impl FloatingLayout {
         let position = position.into();
 
         self.map_internal(mapped, position, None, None)
+    }
+
+    pub(in crate::shell) fn position_x11_transients(&mut self, mapped: &CosmicMapped) {
+        let Some(mapped_id) = mapped
+            .active_window()
+            .x11_surface()
+            .map(|surface| surface.window_id())
+        else {
+            return;
+        };
+
+        let elements = self.space.elements().cloned().collect::<Vec<_>>();
+        let relations = elements
+            .iter()
+            .filter_map(|child| {
+                let child_surface = child.active_window();
+                let child_surface = child_surface.x11_surface()?;
+                let parent_id = child_surface.is_transient_for()?;
+                if child_surface.window_id() != mapped_id && parent_id != mapped_id {
+                    return None;
+                }
+
+                let parent = elements.iter().find(|parent| {
+                    parent
+                        .active_window()
+                        .x11_surface()
+                        .is_some_and(|surface| surface.window_id() == parent_id)
+                })?;
+                (parent != child).then(|| (child.clone(), parent.clone()))
+            })
+            .collect::<Vec<_>>();
+
+        let output = self.space.outputs().next().unwrap().clone();
+        let bounds = layer_map_for_output(&output)
+            .non_exclusive_zone()
+            .as_local();
+        for (child, parent) in relations {
+            let Some(parent_geometry) = self.space.element_geometry(&parent).map(RectExt::as_local)
+            else {
+                continue;
+            };
+            let child_size = self.space.element_geometry(&child).unwrap().size.as_local();
+            let location = centered_transient_location(parent_geometry, child_size, bounds);
+            self.map_internal(child, Some(location), None, None);
+        }
     }
 
     pub fn map_maximized(

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -2972,6 +2972,7 @@ impl Shell {
         let workspace_empty = workspace.mapped().next().is_none();
         if is_dialog || floating_exception || !workspace.tiling_enabled {
             workspace.floating_layer.map(mapped.clone(), None);
+            workspace.floating_layer.position_x11_transients(&mapped);
         } else {
             for mapped in workspace
                 .mapped()

--- a/src/xwayland.rs
+++ b/src/xwayland.rs
@@ -1028,6 +1028,20 @@ impl XwmHandler for State {
         }
     }
 
+    fn shape_notify(&mut self, _xwm: XwmId, _window: X11Surface) {
+        let outputs = self
+            .common
+            .shell
+            .read()
+            .outputs()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for output in outputs {
+            self.backend.schedule_render(&output);
+        }
+    }
+
     fn resize_request(
         &mut self,
         _xwm: XwmId,


### PR DESCRIPTION
Improves X11 window handling. Shaped (non-alpha) windows are now cropped to their X Shape bounding regions via clipped render elements and redrawn on shape changes and X11 transient/dialog windows are recognized, raised alongside their parent when focused and positioned centered on the parent while kept within output bounds. 

I just wanted to play Age of Empires II HD Edition (its the older version https://store.steampowered.com/app/221380/Age_of_Empires_II_Retired/) but could not on COSMIC since the launcher is unusable. This fixes that.

depends on https://github.com/Smithay/smithay/pull/2162


before:
<img width="1092" height="713" alt="Screenshot_2026-09-08_13-44-02" src="https://github.com/user-attachments/assets/57e21721-dafe-4e35-8e99-fe7602cf0cde" />



after:
<img width="1028" height="650" alt="Screenshot_2026-09-08_17-03-42" src="https://github.com/user-attachments/assets/5857a464-ef03-4779-b397-e255cbb56119" />




- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

