### PR TITLE
Don't lose the session when an output is missing from the workspace sets

### DIFF
--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -284,7 +284,25 @@ impl Shell {
                 }
 
                 let output = seat.focused_or_active_output();
-                let space = self.active_space(&output).unwrap();
+                // `focused_or_active_output()` is seat-stored state that is never
+                // validated against `sets`. `Common::refresh_focus` re-points stale
+                // seats before it calls `update_active`, but the other caller,
+                // `Shell::set_focus`, does not - and it fires as a consequence of an
+                // output change, with no user input needed.
+                //
+                // The fallback inside `active_space` is no help on its own. Removing
+                // the last output parks its set in `backup_set` and skips the seat
+                // fix-ups; the next `add_output` then *takes* that backup for the new
+                // output. `sets` is non-empty and `backup_set` is `None` while the
+                // seat still names the output that went away.
+                let Some(space) = self.active_space(&output) else {
+                    tracing::warn!(
+                        target: "cosmic_comp::wsdiag",
+                        output = %output.name(),
+                        "update_active: output absent from workspace sets (upstream unwrap would abort here)"
+                    );
+                    return None;
+                };
                 let stack = space.focus_stack.get(seat);
                 stack.last().and_then(|target| match target {
                     FocusTarget::Window(window) => Some(window.clone()),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -857,6 +857,7 @@ impl Workspaces {
     pub fn add_output(
         &mut self,
         output: &Output,
+        seats: &Seats,
         workspace_state: &mut WorkspaceUpdateGuard<'_, State>,
     ) {
         if self.sets.contains_key(output) {
@@ -922,6 +923,26 @@ impl Workspaces {
             }
         }
         self.sets.insert(output.clone(), set);
+
+        // Taking `backup_set` above is the point where the fallback stops covering
+        // for stale seats. `remove_output` re-points seats only inside its
+        // `if let Some(new_output)` branch, which is skipped when the *last* output
+        // goes away: it parks the set in `backup_set` and leaves every seat naming
+        // an output that is no longer in `sets`. Bring them back in line here, so
+        // that an output-keyed lookup cannot miss on a seat nothing ever fixed up.
+        //
+        // Only the insert path needs this - it is the one that consumes the backup.
+        for seat in seats.iter() {
+            if !self.sets.contains_key(&seat.active_output()) {
+                seat.set_active_output(output);
+            }
+            if seat
+                .focused_output()
+                .is_some_and(|focused| !self.sets.contains_key(&focused))
+            {
+                seat.set_focused_output(None);
+            }
+        }
     }
 
     pub fn remove_output<'a>(
@@ -1362,12 +1383,14 @@ impl Workspaces {
     }
 
     pub fn active_num(&self, output: &Output) -> (Option<usize>, usize) {
-        let set = self.sets.get(output).or(self.backup_set.as_ref()).unwrap();
+        let Some(set) = self.sets.get(output).or(self.backup_set.as_ref()) else {
+            return (None, 0);
+        };
         (set.previously_active.map(|(idx, _)| idx), set.active)
     }
 
     pub fn idx_for_handle(&self, output: &Output, handle: &WorkspaceHandle) -> Option<usize> {
-        let set = self.sets.get(output).unwrap();
+        let set = self.sets.get(output).or(self.backup_set.as_ref())?;
         set.workspaces
             .iter()
             .enumerate()
@@ -1375,8 +1398,10 @@ impl Workspaces {
     }
 
     pub fn len(&self, output: &Output) -> usize {
-        let set = self.sets.get(output).unwrap();
-        set.workspaces.len()
+        self.sets
+            .get(output)
+            .or(self.backup_set.as_ref())
+            .map_or(0, |set| set.workspaces.len())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&Output, &WorkspaceSet)> {
@@ -1535,9 +1560,12 @@ impl Drop for OutputId {
 impl Common {
     pub fn add_output(&mut self, output: &Output) {
         let mut shell = self.shell.write();
-        shell
-            .workspaces
-            .add_output(output, &mut self.workspace_state.update());
+        let shell_ref = &mut *shell;
+        shell_ref.workspaces.add_output(
+            output,
+            &shell_ref.seats,
+            &mut self.workspace_state.update(),
+        );
 
         output
             .user_data()
@@ -2690,12 +2718,22 @@ impl Shell {
                 .upgrade()
                 .unwrap_or_else(|| self.seats.last_active().active_output());
             toplevel_enter_output(&window.active_window(), &output);
-            let set = self
+            // Same window as `update_active`: `active_output()` can name an output
+            // that is in neither `sets` nor `backup_set`. Carrying the fallback is
+            // not sufficient - it has to be allowed to miss.
+            let Some(set) = self
                 .workspaces
                 .sets
                 .get_mut(&output)
                 .or(self.workspaces.backup_set.as_mut())
-                .unwrap();
+            else {
+                tracing::warn!(
+                    target: "cosmic_comp::wsdiag",
+                    output = %output.name(),
+                    "remap_unfullscreened_window: output absent from workspace sets (upstream unwrap would abort here)"
+                );
+                return window;
+            };
             set.sticky_layer.map_internal(
                 window.clone(),
                 Some(state.geometry.loc),
@@ -4065,7 +4103,18 @@ impl Shell {
             return FocusResult::None;
         }
 
-        let set = self.workspaces.sets.get(&output).unwrap();
+        // `seat.active_output()` can name an output that is no longer in `sets`:
+        // `remove_output` only re-points seats when another output remains, so
+        // removing the last one leaves every seat pointing at it while its set
+        // moves to `backup_set`. Fall back the way the other accessors do.
+        let Some(set) = self
+            .workspaces
+            .sets
+            .get(&output)
+            .or(self.workspaces.backup_set.as_ref())
+        else {
+            return FocusResult::None;
+        };
         let sticky_layer = &set.sticky_layer;
         let workspace = &set.workspaces[set.active];
 
@@ -4699,7 +4748,15 @@ impl Shell {
         loop_handle: &LoopHandle<'static, State>,
     ) -> Option<KeyboardFocusTarget> {
         let focused_output = seat.focused_output()?;
-        let set = self.workspaces.sets.get_mut(&focused_output).unwrap();
+        // Same stale-output case as `next_focus`. Note the `?` above does not
+        // cover it: the `set_focused_output(None)` that would make it `None`
+        // lives in the same branch of `remove_output` that is skipped when the
+        // last output goes away.
+        let set = self
+            .workspaces
+            .sets
+            .get_mut(&focused_output)
+            .or(self.workspaces.backup_set.as_mut())?;
         let workspace = &mut set.workspaces[set.active];
 
         if matches!(
@@ -5113,9 +5170,9 @@ impl Shell {
             }
         });
 
+        let namespace = self.workspaces.active_num(output).1;
         let map = smithay::desktop::layer_map_for_output(output);
         for layer_surface in map.layers() {
-            let namespace = self.workspaces.active_num(output).1;
             layer_surface.take_presentation_feedback(
                 &mut output_presentation_feedback,
                 surface_primary_scanout_output,

--- a/src/state.rs
+++ b/src/state.rs
@@ -581,7 +581,12 @@ impl LockedBackend<'_> {
             });
 
             match final_config.enabled {
-                OutputState::Enabled => shell_ref.workspaces.add_output(output, workspace_state),
+                OutputState::Enabled => {
+                    let shell = &mut *shell_ref;
+                    shell
+                        .workspaces
+                        .add_output(output, &shell.seats, workspace_state)
+                }
                 _ => {
                     let shell = &mut *shell_ref;
                     shell.workspaces.remove_output(

--- a/src/wayland/handlers/image_copy_capture/render.rs
+++ b/src/wayland/handlers/image_copy_capture/render.rs
@@ -306,7 +306,9 @@ pub fn render_workspace_to_buffer(
     };
 
     let mut output = workspace.output().clone();
-    let idx = shell.workspaces.idx_for_handle(&output, &handle).unwrap();
+    let Some(idx) = shell.workspaces.idx_for_handle(&output, &handle) else {
+        return;
+    };
     std::mem::drop(shell);
 
     let mode = output


### PR DESCRIPTION
Switching a monitor off, or a dock dropping its link, can currently take down the
whole COSMIC session and every open window with it. The worst part is the delay. The
session usually keeps running for minutes or hours after the display change that
broke it, so the crash looks like it was caused by whatever you happened to be doing
at the time. On one machine here the gap between cause and crash reached 23 hours.

What happens is that an output's render thread asks about workspaces for an output
the main thread has just removed. On a laptop the common case is the built in panel
being switched off because the lid is closed, while its own render thread is still
finishing a frame. `active_num` unwraps that lookup instead of handling the miss, so
the thread panics. The panic poisons a lock on its way out, and the compositor then
aborts at the next display operation, whenever that happens to be.

This makes the three `Workspaces` lookups total instead of partial, the way `active`
and `active_mut` already are. `idx_for_handle` and `len` had no `backup_set` fallback
at all. It also moves one call out from under the layer map guard so that a panic
there cannot poison it, and fixes a double unwrap on the same accessor in the image
capture path.

Two further sites reach the same lookups through a seat rather than through the
render loop, and neither is covered by the `backup_set` fallback. A seat keeps its
own idea of which output is focused or active, and that field is never checked
against `sets`. When the last output goes away the fallback stores the workspace set
aside and the seat fix ups are skipped, so every seat still names an output that no
longer exists. `update_active` then unwraps `active_space` on it and aborts on the
main thread, with no delay and no poisoned lock, which is a different failure from
the one above but the same root cause.

Rather than harden each consumer, `add_output` now restores the invariant. When it
takes the stored set back it re points any seat that still names an output which is
no longer present. That covers the sites in this PR and any future caller that
trusts a seat's output, which is what the rest of the code already assumes it can do.

A surface on its way out asking about workspaces that are already gone is now a no-op
instead of a session ending abort. The worst case after this is one frame of layer
shell surfaces tagged with workspace zero, on an output that is being torn down
anyway.

### How it was checked

Running on one laptop with an external display on USB-C since 2026-08-31. In that
time the guarded lookup absorbed four faults that would each have aborted the
compositor on an unpatched build, the most recent on 2026-09-07, and the session
survived all of them with the same process still running. Before the patches the
same machine lost its session ten times.

The second commit also covers `send_frames` and `send_dmabuf_feedback`, which unwrap
the same missing set on the main thread when an output becomes a mirror. #2811 found
those two and fixes them the same way; it overlaps with the `active_num` change here
too, so the two will conflict and either can be folded into the other.

Fixes #2727, fixes #2706.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Written with assistance from Claude Opus 5.0, as disclosed in the commit message.
The changes were reviewed, built and run on a daily driver for five and a half
weeks before submitting, and I can answer review comments on any of it.
