### PR TITLE
Power the built-in panel down when the lid closes instead of leaving it lit

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1918,14 +1918,40 @@ impl State {
             #[allow(unused_variables)]
             InputEvent::SwitchToggle { event } => {
                 #[cfg(feature = "logind")]
-                if event.switch() == Some(Switch::Lid) && self.common.inhibit_lid_fd.is_some() {
+                if event.switch() == Some(Switch::Lid) {
+                    let closed = event.state() == SwitchState::On;
+                    self.common.lid_closed = closed;
+
+                    if self.common.inhibit_lid_fd.is_none() {
+                        // Fewer than two outputs, so the internal panel is the only
+                        // one. Disabling it would leave the session with nowhere to
+                        // render, which is why the lid is otherwise ignored here.
+                        // Powering the connector down instead keeps the output
+                        // configured while the panel goes dark.
+                        let internal = {
+                            let backend = self.backend.lock();
+                            backend
+                                .all_outputs()
+                                .iter()
+                                .find(|o| o.is_internal())
+                                .cloned()
+                        };
+                        if let Some(output) = internal {
+                            use crate::wayland::protocols::output_power::{
+                                OutputPowerHandler, OutputPowerState,
+                            };
+                            self.set_dpms(&output, !closed);
+                            OutputPowerState::refresh(self);
+                        }
+                        return;
+                    }
+
                     let backend = self.backend.lock();
                     let output = backend
                         .all_outputs()
                         .iter()
                         .find(|o| o.is_internal())
                         .cloned();
-                    let closed = event.state() == SwitchState::On;
 
                     if closed {
                         backend

--- a/src/state.rs
+++ b/src/state.rs
@@ -324,6 +324,24 @@ pub struct Common {
     #[cfg(feature = "logind")]
     pub inhibit_lid_fd: Option<OwnedFd>,
 
+    /// Whether the laptop lid is currently shut.
+    ///
+    /// Kept so the built-in panel can stay powered down for as long as the lid
+    /// is closed. Without this, any input event powers every output back on,
+    /// which lights the panel inside a closed lid.
+    ///
+    /// Fed from two sources that cost nothing: the `SwitchToggle` input event,
+    /// which carries the state and covers every transition while the compositor
+    /// runs, and the `lid_closed()` call `update_inhibitor_locks` already makes
+    /// when it takes the inhibitor. Deliberately never queried on the output
+    /// configuration path - that call blocks the main thread.
+    ///
+    /// The gap this leaves is a compositor that starts with the lid already shut
+    /// and a single output, where nothing has asked yet. `false` is the safe
+    /// default there: the panel stays lit, which is the unpatched behaviour, and
+    /// the first lid transition corrects it.
+    pub lid_closed: bool,
+
     pub with_xwayland: bool,
 }
 
@@ -833,6 +851,7 @@ impl State {
 
                 #[cfg(feature = "logind")]
                 inhibit_lid_fd: None,
+                lid_closed: false,
 
                 with_xwayland,
             },
@@ -886,6 +905,11 @@ impl State {
                                 .cloned();
                             let closed =
                                 crate::dbus::logind::lid_closed(&self.common).unwrap_or(false);
+                            // Reuse the value this branch already fetches. Asking
+                            // logind again on the configuration path would put a
+                            // blocking bus round trip on the main thread, which is
+                            // exactly what must not happen here.
+                            self.common.lid_closed = closed;
 
                             if closed {
                                 backend.disable_internal_output(
@@ -935,11 +959,27 @@ impl State {
 
                 if let Err(err) = self.refresh_output_config() {
                     warn!(?err, "Failed to re-enable internal connector");
-                    if let Some(output) = output {
+                    if let Some(output) = &output {
                         output.config_mut().enabled = OutputState::Disabled;
                         if let Err(err) = self.refresh_output_config() {
                             error!("Unrecoverable output configuration error: {}", err);
                         }
+                    }
+                } else if self.common.lid_closed {
+                    // The second output has just gone away while the lid is still
+                    // shut. Re-enabling the internal panel above is not optional -
+                    // it is the only output left, and a session with none has
+                    // nowhere to render - but it must not light up inside a closed
+                    // lid. Power the connector down instead, which is the same
+                    // trade the single-output lid path makes.
+                    //
+                    // `lid_closed` is a plain field, so this costs no bus traffic
+                    // on the output configuration path. Asking logind here is what
+                    // deadlocked the first version of this fix.
+                    if let Some(output) = &output {
+                        use crate::wayland::protocols::output_power::OutputPowerHandler;
+                        self.set_dpms(output, false);
+                        OutputPowerState::refresh(self);
                     }
                 }
                 // drop _fd

--- a/src/wayland/handlers/output_power.rs
+++ b/src/wayland/handlers/output_power.rs
@@ -12,8 +12,16 @@ use crate::{
 };
 
 pub fn set_all_surfaces_dpms_on(state: &mut State) {
+    // Input events power every output back on. The built-in panel is exempt while
+    // the lid is shut, otherwise the lid switch itself - and any later keypress or
+    // pointer motion from an external device - lights a screen nobody can see.
+    let lid_closed = state.common.lid_closed;
+
     let mut changed = false;
     for surface in kms_surfaces(state) {
+        if lid_closed && surface.output.is_internal() {
+            continue;
+        }
         if !surface.get_dpms() {
             surface.set_dpms(true);
             changed = true;


### PR DESCRIPTION
Close the lid on a laptop and the built-in panel can stay backlit inside it. It goes
dark only when the idle timeout expires, ten minutes by default. On one machine here
the panel was still lit almost four minutes after the lid shut.

This happens when the internal panel is the only enabled output. `should_handle_lid`
requires two or more outputs, so with one the compositor releases its logind
inhibitor and ignores the lid entirely, and the lid switch handler is gated on
holding that inhibitor. logind policy then applies, and none of its options means
stay awake but blank. With `HandleLidSwitch=lock` the session locks and nothing ever
powers the panel down.

The `>= 2` guard is right as far as it goes. Disabling the only output would leave
the session with nowhere to render. But powering a connector down is not the same as
disabling an output. The connector can go dark while the output stays configured and
present, which is what this does. When no inhibitor is held, the lid switch now sets
DPMS on the internal output instead of being ignored.

One more change is needed for that to hold. Every input event powers all surfaces
back on, including the lid switch itself, so internal outputs are exempted while the
lid is shut. That needs the lid state on hand, so it is tracked as a field on
`Common` and seeded from logind when outputs change, which also makes a compositor
started with the lid already closed behave correctly.

The second patch covers the case where the lid is shut and the external display goes
away, for instance when a dock is unplugged. Re-enabling the internal connector at
that point is not optional, since it is the only output left and a session with none
has nowhere to render, but it must not light up inside a closed lid. It is powered
down instead, the same trade the single-output path makes.

The lid state is a plain field rather than a logind query on purpose. Asking the bus
from the output configuration path deadlocked an earlier version of this change and
hung the greeter, so that call is not made there.

### How it was checked

Running on one laptop since 2026-08-31 across daily dock and lid cycles, with no
recurrence of either the lit panel or the greeter hang that the first version caused.

This is only visible when `HandleLidSwitch` has been changed from the default
`suspend`, since suspending blanks the panel as a side effect. That limits who runs
into it, but a panel inside a closed lid arguably should not be lit whatever logind
is configured to do.

Related: pop-os/cosmic-epoch#1532, #2761.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Written with assistance from Claude Opus 5.0, as disclosed in the commit message.
The changes were reviewed, built and run on a daily driver for five and a half
weeks before submitting, and I can answer review comments on any of it.

