### PR TITLE
fix: clear sticky windows, or floating windows focus hint if focus moves

### DIFF
--- a/src/shell/element/mod.rs
+++ b/src/shell/element/mod.rs
@@ -430,6 +430,10 @@ impl CosmicMapped {
         }
     }
 
+    pub fn is_sticky(&self) -> bool {
+        self.active_window().is_sticky()
+    }
+
     pub fn pending_size(&self) -> Option<Size<i32, Logical>> {
         match &self.element {
             CosmicMappedInternal::Stack(s) => s.pending_size(),

--- a/src/shell/focus/mod.rs
+++ b/src/shell/focus/mod.rs
@@ -249,8 +249,17 @@ impl Shell {
         let workspace = if let Some(workspace) = workspace {
             self.workspaces.space_for_handle_mut(&workspace.0).unwrap()
         } else {
-            //should this be the active output or the focused output?
-            self.active_space_mut(&seat.focused_or_active_output())
+            let output = match &target {
+                FocusTarget::Window(mapped) => self
+                    .workspaces
+                    .sets
+                    .iter()
+                    .find(|(_, set)| set.sticky_layer.mapped().any(|m| m == mapped))
+                    .map(|(output, _)| output.clone()),
+                FocusTarget::Fullscreen(_) => None,
+            };
+
+            self.active_space_mut(&output.unwrap_or_else(|| seat.active_output()))
                 .unwrap()
         };
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -513,6 +513,12 @@ impl WorkspaceSet {
         }
     }
 
+    fn refresh_focus_stacks(&mut self) {
+        for workspace in &mut self.workspaces {
+            workspace.refresh_focus_stack();
+        }
+    }
+
     fn activate(
         &mut self,
         idx: usize,
@@ -617,6 +623,7 @@ impl WorkspaceSet {
             self.workspaces[self.active].refresh();
         }
         self.sticky_layer.refresh();
+        self.refresh_focus_stacks();
     }
 
     fn add_empty_workspace(&mut self, state: &mut WorkspaceUpdateGuard<State>) {

--- a/src/shell/workspace.rs
+++ b/src/shell/workspace.rs
@@ -526,10 +526,16 @@ impl Workspace {
                     .mapped()
                     .chain(self.tiling_layer.mapped().map(|(w, _)| w))
                     .chain(move_mapped.iter())
+                    .chain(
+                        self.minimized_windows
+                            .iter()
+                            .flat_map(MinimizedWindow::mapped),
+                    )
             };
             stack.retain(|w| match w {
                 FocusTarget::Fullscreen(s) => fullscreen_surfaces.contains(&s),
-                FocusTarget::Window(w) => mapped().any(|m| w == m),
+                // Sticky windows live in the `WorkspaceSet` but are shown on whichever workspace is current
+                FocusTarget::Window(w) => w.is_sticky() || mapped().any(|m| w == m),
             });
         }
     }
@@ -1767,13 +1773,17 @@ impl Workspace {
 
             self.floating_layer.render(
                 renderer,
-                focused.as_ref().and_then(|target| {
-                    if let FocusTarget::Window(mapped) = target {
-                        Some(mapped)
-                    } else {
-                        None
-                    }
-                }),
+                render_focus
+                    .then(|| {
+                        focused.as_ref().and_then(|target| {
+                            if let FocusTarget::Window(mapped) = target {
+                                Some(mapped)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .flatten(),
                 resize_indicator.clone(),
                 indicator_thickness,
                 alpha,


### PR DESCRIPTION
If you open a window in floating mode and then move focus to a window on another output, the floating window in the previous output still has the focus hint around it.

This was part of https://github.com/pop-os/cosmic-comp/pull/2549. But can be reviewed and merged separately.
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

