### PR TITLE
Fix blender thinking super is still held down if opened via cosmic-launcher

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2096,6 +2096,21 @@ impl State {
             backend_id, seat, modifiers, handle, serial, keycode, key_state, time,
         );
 
+        // A modifier-only binding fires on the modifier's release, but its press was already
+        // forwarded. Forward the release too.
+        if key_state == KeyState::Released
+            && matches!(&result, FilterResult::Intercept(Some((_, binding))) if binding.key.is_none())
+        {
+            seat.get_keyboard().unwrap().input_forward(
+                self,
+                keycode,
+                key_state,
+                serial,
+                time,
+                previous_modifiers != *modifiers,
+            );
+        }
+
         if (matches!(result, FilterResult::Forward)
             && !seat.get_keyboard().unwrap().is_grabbed()
             && !shortcuts_inhibited


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-comp/issues/2791
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

