### PR TITLE
input: map tablets to an output on systems without an internal panel

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1594,7 +1594,7 @@ impl State {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     notify_cursor_activity(self, &seat);
                     let Some(output) =
-                        mapped_output_for_device(&self.common.config, &shell, &event.device())
+                        mapped_output_for_tablet(&self.common.config, &shell, &event.device())
                             .cloned()
                     else {
                         return;
@@ -1698,7 +1698,7 @@ impl State {
                     self.common.idle_notifier_state.notify_activity(&seat);
                     notify_cursor_activity(self, &seat);
                     let Some(output) =
-                        mapped_output_for_device(&self.common.config, &shell, &event.device())
+                        mapped_output_for_tablet(&self.common.config, &shell, &event.device())
                             .cloned()
                     else {
                         return;
@@ -3181,6 +3181,17 @@ fn mapped_output_for_device<'a, D: Device + 'static>(
         None
     };
     map_to_output.or_else(|| shell.builtin_output())
+}
+
+/// The output a tablet tool maps onto. Unlike touch this never resolves to `None` while any
+/// output exists: [`Shell::builtin_output`] fits a laptop touchscreen but not a tablet, and
+/// dropping every event leaves the tablet silently dead on a machine with no internal panel.
+fn mapped_output_for_tablet<'a, D: Device + 'static>(
+    config: &Config,
+    shell: &'a Shell,
+    device: &D,
+) -> Option<&'a Output> {
+    mapped_output_for_device(config, shell, device).or_else(|| shell.outputs().next())
 }
 
 pub fn update_output_image_copy_cursor_position(


### PR DESCRIPTION
My Huion Drawing tablet does not move the cursor on my desktop, and it turns out the events never
make it out of the input handlers.

## Problem

`mapped_output_for_device` decides which output an absolute device maps onto.
With no per-device `map_to_output` set it falls back to `Shell::builtin_output()`,
which only matches `eDP-`/`LVDS-`/`DSI-` connectors. A desktop has none of those,
so it returns `None` and the `else { return }` arms in `TabletToolAxis` and
`TabletToolProximity` drop every event.

What makes this a pain to track down is that nothing else is broken. The
compositor opens the evdev node and emits `zwp_tablet_v2` perfectly well —
XWayland even builds stylus/eraser/cursor devices out of it — so there's no error
message anywhere, the tablet is just silently dead.

## Fix

Fall back to the first output for tablet tools. Touch keeps what it does now:
assuming the built-in panel is fair for a laptop touchscreen, and working out
which output an *external* touchscreen belongs to is a separate problem — the
TODO above the function already asks about it.

This is a no-op on any machine that has an enabled internal panel, since
`builtin_output()` returns `Some` there and the new fallback never runs. It also
covers a docked laptop with the lid closed, where the `eDP-` output has been
removed from the set and tablets are dead for the same reason.

## What this doesn't do

It doesn't try to answer which output a tablet *should* map to. That needs the
settings work in #141, and libwacom so a display tablet can map to itself —
nothing available here tells an opaque tablet apart from a Kamvas. All this does
is stop the events being dropped when there's no answer at all. Whether that
partial step is worth taking is your call.

## AI/LLM disclosure

Done with the help of an LLM coding agent, directed and reviewed by me, and
disclosed in the commit message. I understand the change in full — it's one
`.or_else` behind a two-line wrapper, with two call sites pointed at it — and
I'll handle review comments myself.

## Testing

Huion H1060P on Pop!_OS 24.04 (COSMIC), two external outputs (3440x1440 and a
rotated 2560x1440), no internal panel, built at master (a557859). With no
`input_devices` config the cursor doesn't move at all. Running this branch on a
bare VT with that same empty config, it does.

Context: #313 and pop-os/cosmic-epoch#2826. #1495 landed on this same line and was
closed with the config workaround — this makes the unconfigured case work.

## Checklist

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
