### PR TITLE
cursor: Replace the global idle-hide timeout with contextual hiding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "smallvec",
  "smithay",
  "smithay-egui",
+ "tempfile",
  "thiserror 2.0.18",
  "tiny-skia",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,9 @@ version = "0.2.0"
 features = ["svg"]
 optional = true
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 debug = ["egui", "egui_plot", "smithay-egui", "anyhow/backtrace"]
 default = ["systemd"]

--- a/cosmic-comp-config/Cargo.toml
+++ b/cosmic-comp-config/Cargo.toml
@@ -19,3 +19,6 @@ tracing = { version = "0.1.44", features = [
 default = []
 output = ["ron", "tracing"]
 randr = ["cosmic-randr-shell", "output"]
+
+[dev-dependencies]
+ron = "0.12"

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -3,6 +3,7 @@
 use cosmic_config::{CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::Duration;
 
 use crate::input::TouchpadOverride;
 
@@ -106,8 +107,8 @@ pub struct CosmicCompConfig {
     pub edge_snap_threshold: u32,
     pub accessibility_zoom: ZoomConfig,
     pub appearance_settings: AppearanceConfig,
-    /// Hide the cursor after this many seconds of pointer inactivity (None disables)
-    pub cursor_hide_timeout: Option<u32>,
+    /// When the cursor hides itself: idle, fullscreen idle, typing, touch
+    pub cursor_hide: CursorHideConfig,
     /// Briefly magnify the cursor when the pointer is shaken, to help locate it
     pub cursor_shake_to_find: bool,
     pub activation_policy: ActivationPolicy,
@@ -148,7 +149,7 @@ impl Default for CosmicCompConfig {
             edge_snap_threshold: 0,
             accessibility_zoom: ZoomConfig::default(),
             appearance_settings: AppearanceConfig::default(),
-            cursor_hide_timeout: None,
+            cursor_hide: CursorHideConfig::default(),
             cursor_shake_to_find: true,
             activation_policy: ActivationPolicy::default(),
             decoration_preference: DecorationPreference::default(),
@@ -196,6 +197,79 @@ fn default_repeat_rate() -> u32 {
 
 fn default_repeat_delay() -> u32 {
     600
+}
+
+/// What the cursor idle timer should do when it fires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HideDecision {
+    /// Nothing applies in this context; drop the timer until the next activity.
+    Drop,
+    /// Hide the cursor now.
+    Hide,
+    /// Not yet — re-arm for this long.
+    RearmAfter(Duration),
+}
+
+/// When the cursor hides itself. Every trigger is revealed by pointer input, so
+/// these differ only in what arms the hide and after how long.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CursorHideConfig {
+    /// Seconds of pointer inactivity before hiding, anywhere. `None` disables.
+    pub idle_timeout: Option<u32>,
+    /// Seconds of pointer inactivity before hiding over a fullscreen window.
+    /// Shortens `idle_timeout` in fullscreen; it never lengthens it.
+    pub fullscreen_idle_timeout: Option<u32>,
+    /// Hide as soon as a key is pressed.
+    pub while_typing: bool,
+    /// Hide on touch input, until the pointer next moves.
+    pub after_touch: bool,
+}
+
+impl CursorHideConfig {
+    /// The shortest timeout that applies right now, if any.
+    pub fn effective_timeout(&self, fullscreen: bool) -> Option<Duration> {
+        let secs = if fullscreen {
+            match (self.idle_timeout, self.fullscreen_idle_timeout) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (a, b) => a.or(b),
+            }
+        } else {
+            self.idle_timeout
+        }?;
+        Some(Duration::from_secs(secs as u64))
+    }
+
+    /// What to do when the idle timer fires after `elapsed` without pointer input.
+    pub fn resolve(&self, elapsed: Duration, fullscreen: bool) -> HideDecision {
+        match self.effective_timeout(fullscreen) {
+            None => HideDecision::Drop,
+            Some(timeout) if elapsed >= timeout => HideDecision::Hide,
+            Some(timeout) => HideDecision::RearmAfter(timeout - elapsed),
+        }
+    }
+
+    /// Whether any timer-driven hiding is configured at all.
+    pub fn has_idle_trigger(&self) -> bool {
+        self.idle_timeout.is_some() || self.fullscreen_idle_timeout.is_some()
+    }
+
+    /// The delay to arm the timer with, before context is known. Callers on the
+    /// input path cannot read fullscreen state without deadlocking, so they arm
+    /// pessimistically and `resolve` corrects it on fire.
+    pub fn shortest_timeout(&self) -> Option<Duration> {
+        self.effective_timeout(true)
+    }
+}
+
+impl Default for CursorHideConfig {
+    fn default() -> Self {
+        CursorHideConfig {
+            idle_timeout: None,
+            fullscreen_idle_timeout: Some(3),
+            while_typing: false,
+            after_touch: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
@@ -262,4 +336,104 @@ pub enum XwaylandDescaling {
     Disabled,
     #[default]
     Fractional,
+}
+
+#[cfg(test)]
+mod test {
+    use super::{CursorHideConfig, HideDecision};
+    use std::time::Duration;
+
+    const OFF: CursorHideConfig = CursorHideConfig {
+        idle_timeout: None,
+        fullscreen_idle_timeout: None,
+        while_typing: false,
+        after_touch: false,
+    };
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    #[test]
+    fn no_timeout_never_hides() {
+        assert_eq!(OFF.resolve(secs(600), false), HideDecision::Drop);
+        assert_eq!(OFF.resolve(secs(600), true), HideDecision::Drop);
+        assert!(!OFF.has_idle_trigger());
+    }
+
+    #[test]
+    fn global_timeout_applies_everywhere() {
+        let cfg = CursorHideConfig {
+            idle_timeout: Some(10),
+            ..OFF
+        };
+        assert_eq!(
+            cfg.resolve(secs(4), false),
+            HideDecision::RearmAfter(secs(6))
+        );
+        assert_eq!(cfg.resolve(secs(10), false), HideDecision::Hide);
+        // A fullscreen window must not suppress an enabled global timeout.
+        assert_eq!(cfg.resolve(secs(10), true), HideDecision::Hide);
+        assert!(cfg.has_idle_trigger());
+    }
+
+    #[test]
+    fn fullscreen_timeout_only_applies_in_fullscreen() {
+        let cfg = CursorHideConfig {
+            fullscreen_idle_timeout: Some(3),
+            ..OFF
+        };
+        assert_eq!(cfg.resolve(secs(3), true), HideDecision::Hide);
+        assert_eq!(cfg.resolve(secs(600), false), HideDecision::Drop);
+    }
+
+    #[test]
+    fn fullscreen_shortens_but_never_lengthens() {
+        let short_fs = CursorHideConfig {
+            idle_timeout: Some(10),
+            fullscreen_idle_timeout: Some(3),
+            ..OFF
+        };
+        assert_eq!(short_fs.resolve(secs(3), true), HideDecision::Hide);
+        assert_eq!(
+            short_fs.resolve(secs(3), false),
+            HideDecision::RearmAfter(secs(7))
+        );
+
+        let long_fs = CursorHideConfig {
+            idle_timeout: Some(3),
+            fullscreen_idle_timeout: Some(30),
+            ..OFF
+        };
+        assert_eq!(long_fs.resolve(secs(3), true), HideDecision::Hide);
+
+        // The arming delay is pessimistic: the shortest timeout that could
+        // apply in any context, because arm-time code cannot read the shell.
+        assert_eq!(short_fs.shortest_timeout(), Some(secs(3)));
+        assert_eq!(long_fs.shortest_timeout(), Some(secs(3)));
+        assert_eq!(OFF.shortest_timeout(), None);
+    }
+
+    #[test]
+    fn boundary_is_inclusive() {
+        let cfg = CursorHideConfig {
+            idle_timeout: Some(5),
+            ..OFF
+        };
+        assert_eq!(
+            cfg.resolve(Duration::from_millis(4999), false),
+            HideDecision::RearmAfter(Duration::from_millis(1))
+        );
+        assert_eq!(cfg.resolve(secs(5), false), HideDecision::Hide);
+        assert_eq!(cfg.resolve(secs(6), false), HideDecision::Hide);
+    }
+
+    #[test]
+    fn defaults_match_the_spec() {
+        let cfg = CursorHideConfig::default();
+        assert_eq!(cfg.idle_timeout, None);
+        assert_eq!(cfg.fullscreen_idle_timeout, Some(3));
+        assert!(!cfg.while_typing);
+        assert!(cfg.after_touch);
+    }
 }

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -212,7 +212,10 @@ pub enum HideDecision {
 
 /// When the cursor hides itself. Every trigger is revealed by pointer input, so
 /// these differ only in what arms the hide and after how long.
+// `default`: a trigger added later must not make every existing file fail to
+// deserialize, which `get_entry` would swallow as "reset everyone to defaults".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
 pub struct CursorHideConfig {
     /// Seconds of pointer inactivity before hiding, anywhere. `None` disables.
     pub idle_timeout: Option<u32>,
@@ -435,5 +438,28 @@ mod test {
         assert_eq!(cfg.fullscreen_idle_timeout, Some(3));
         assert!(!cfg.while_typing);
         assert!(cfg.after_touch);
+    }
+
+    #[test]
+    fn config_round_trips_and_tolerates_missing_fields() {
+        let cfg = CursorHideConfig {
+            idle_timeout: Some(7),
+            fullscreen_idle_timeout: None,
+            while_typing: true,
+            after_touch: false,
+        };
+        let encoded = ron::ser::to_string(&cfg).unwrap();
+        assert_eq!(ron::from_str::<CursorHideConfig>(&encoded).unwrap(), cfg);
+
+        // A file written before a field existed must keep the rest of the user's
+        // settings rather than resetting the whole key.
+        let partial: CursorHideConfig = ron::from_str("(idle_timeout: Some(5))").unwrap();
+        assert_eq!(
+            partial,
+            CursorHideConfig {
+                idle_timeout: Some(5),
+                ..CursorHideConfig::default()
+            }
+        );
     }
 }

--- a/cosmic-comp-config/src/lib.rs
+++ b/cosmic-comp-config/src/lib.rs
@@ -262,6 +262,17 @@ impl CursorHideConfig {
     pub fn shortest_timeout(&self) -> Option<Duration> {
         self.effective_timeout(true)
     }
+
+    /// How long to wait before the idle timer should next fire, given how long
+    /// it has been since the last pointer event. Pessimistic like
+    /// `shortest_timeout`: the caller cannot know the context, and `resolve`
+    /// corrects an early fire.
+    pub fn arm_delay(&self, since_pointer_activity: Duration) -> Option<Duration> {
+        Some(
+            self.shortest_timeout()?
+                .saturating_sub(since_pointer_activity),
+        )
+    }
 }
 
 impl Default for CursorHideConfig {
@@ -438,6 +449,29 @@ mod test {
         assert_eq!(cfg.fullscreen_idle_timeout, Some(3));
         assert!(!cfg.while_typing);
         assert!(cfg.after_touch);
+    }
+
+    #[test]
+    fn arm_delay_measures_from_the_last_pointer_event() {
+        let cfg = CursorHideConfig {
+            idle_timeout: Some(10),
+            ..OFF
+        };
+        assert_eq!(cfg.arm_delay(Duration::ZERO), Some(secs(10)));
+        assert_eq!(cfg.arm_delay(secs(4)), Some(secs(6)));
+        // Exactly due, and past due: fire immediately rather than deferring.
+        assert_eq!(cfg.arm_delay(secs(10)), Some(Duration::ZERO));
+        assert_eq!(cfg.arm_delay(secs(600)), Some(Duration::ZERO));
+
+        // Armed against the shortest timeout, as `shortest_timeout` is.
+        let fs = CursorHideConfig {
+            idle_timeout: Some(10),
+            fullscreen_idle_timeout: Some(3),
+            ..OFF
+        };
+        assert_eq!(fs.arm_delay(secs(1)), Some(secs(2)));
+
+        assert_eq!(OFF.arm_delay(Duration::ZERO), None);
     }
 
     #[test]

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -839,7 +839,7 @@ const ACTIVITY_THROTTLE: Duration = Duration::from_millis(100);
 
 /// Reveal the cursor and (re)arm the idle-hide timer; returns true if it was previously hidden
 pub fn notify_cursor_activity(state: &State, seat: &Seat<State>) -> bool {
-    let timeout = state.common.config.cosmic_conf.cursor_hide_timeout;
+    let timeout = state.common.config.cosmic_conf.cursor_hide.idle_timeout;
     let loop_handle = &state.common.event_loop_handle;
     let cursor_state = seat.user_data().get::<CursorState>().unwrap();
     let now = Instant::now();

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -891,17 +891,21 @@ pub fn notify_cursor_activity(state: &State, seat: &Seat<State>, kind: PointerEv
 
 /// (Re)arm the idle-hide timer without counting as pointer activity.
 ///
+/// The deadline is measured from the last *pointer* event, not from now, so a
+/// caller that does not stamp activity — a keystroke, a config reload — cannot
+/// postpone the hide by re-arming.
+///
 /// Takes `&State`: several callers hold a `shell` write guard, so this must not
-/// lock the shell. That is also why the timer is armed with the shortest
-/// configured timeout rather than the contextually correct one — `on_idle_timer`
-/// reads fullscreen state and corrects the delay when it fires.
+/// lock the shell. That is also why the delay is derived from the shortest
+/// configured timeout rather than the contextually correct one —
+/// `on_idle_timer` reads fullscreen state and corrects it when the timer fires.
 pub fn refresh_idle_timer(state: &State, seat: &Seat<State>) {
     let config = state.common.config.cosmic_conf.cursor_hide;
     let loop_handle = &state.common.event_loop_handle;
     let cursor_state = seat.user_data().get::<CursorState>().unwrap();
     let now = Instant::now();
 
-    let old_token = {
+    let (old_token, since_activity) = {
         let mut inner = cursor_state.lock().unwrap();
         if inner.hidden.is_some() {
             return;
@@ -914,32 +918,35 @@ pub fn refresh_idle_timer(state: &State, seat: &Seat<State>) {
         if throttled {
             return;
         }
+        let since_activity = now.duration_since(inner.last_pointer_activity);
         inner.last_armed = None;
-        inner.idle_timer.take()
+        (inner.idle_timer.take(), since_activity)
     };
 
     if let Some(token) = old_token {
         loop_handle.remove(token);
     }
 
-    let Some(delay) = config.shortest_timeout() else {
+    let Some(delay) = config.arm_delay(since_activity) else {
         return;
     };
 
     let timer = Timer::from_duration(delay);
     let timer_seat = seat.clone();
-    if let Ok(token) =
-        loop_handle.insert_source(timer, move |_, _, state| on_idle_timer(state, &timer_seat))
-    {
-        let mut inner = cursor_state.lock().unwrap();
-        inner.idle_timer = Some(token);
-        inner.last_armed = Some(now);
+    match loop_handle.insert_source(timer, move |_, _, state| on_idle_timer(state, &timer_seat)) {
+        Ok(token) => {
+            let mut inner = cursor_state.lock().unwrap();
+            inner.idle_timer = Some(token);
+            inner.last_armed = Some(now);
+        }
+        // `idle_timer` stays `None`, so the next activity is unthrottled and retries.
+        Err(err) => warn!(?err, "Failed to arm the cursor idle-hide timer"),
     }
 }
 
 /// Whether the seat's active output is showing a fullscreen surface. Only ever
 /// called from the timer callback, which holds no shell lock.
-fn fullscreen_focused(state: &State, seat: &Seat<State>) -> bool {
+fn fullscreen_on_active_output(state: &State, seat: &Seat<State>) -> bool {
     let shell = state.common.shell.read();
     shell
         .active_space(&seat.active_output())
@@ -948,7 +955,7 @@ fn fullscreen_focused(state: &State, seat: &Seat<State>) -> bool {
 
 fn on_idle_timer(state: &mut State, seat: &Seat<State>) -> TimeoutAction {
     let config = state.common.config.cosmic_conf.cursor_hide;
-    let fullscreen = fullscreen_focused(state, seat);
+    let fullscreen = fullscreen_on_active_output(state, seat);
     let cursor_state = seat.user_data().get::<CursorState>().unwrap();
 
     let elapsed = {

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -8,6 +8,7 @@ use crate::{
     utils::prelude::*,
     wayland::handlers::compositor::FRAME_TIME_FILTER,
 };
+use cosmic_comp_config::HideDecision;
 use keyframe::{ease, functions::EaseInOutCubic};
 use resvg::{tiny_skia, usvg};
 use serde::Deserialize;
@@ -451,6 +452,32 @@ pub fn draw_dnd_icon<R>(
     );
 }
 
+/// Why the cursor is currently hidden. Determines what brings it back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HideReason {
+    /// No pointer activity for the configured timeout.
+    Idle,
+    /// A key was pressed while `while_typing` is enabled.
+    Typing,
+    /// Touch input arrived while `after_touch` is enabled.
+    Touch,
+}
+
+/// Whether a pointer event carries movement. A touch-hidden cursor comes back
+/// only on real movement, so the distinction has to reach the call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointerEventKind {
+    Motion,
+    Other,
+}
+
+impl HideReason {
+    /// Whether an event of this kind should reveal the cursor.
+    fn revealed_by(self, kind: PointerEventKind) -> bool {
+        matches!(kind, PointerEventKind::Motion) || !matches!(self, HideReason::Touch)
+    }
+}
+
 pub type CursorState = Mutex<CursorStateInner>;
 pub struct CursorStateInner {
     current_cursor: Option<CursorIcon>,
@@ -462,9 +489,10 @@ pub struct CursorStateInner {
     current_image: Option<Image>,
     image_cache: Vec<CachedFrame>,
 
-    hidden: bool,
+    hidden: Option<HideReason>,
     idle_timer: Option<RegistrationToken>,
     last_armed: Option<Instant>,
+    last_pointer_activity: Instant,
 
     // shake-to-find
     shake_path: VecDeque<PathSample>,
@@ -694,7 +722,8 @@ impl Default for CursorStateInner {
             current_image: None,
             image_cache: Vec::new(),
 
-            hidden: false,
+            hidden: None,
+            last_pointer_activity: Instant::now(),
             idle_timer: None,
             last_armed: None,
 
@@ -747,7 +776,7 @@ pub fn draw_cursor<R>(
     let mut state_ref = seat_userdata.get::<CursorState>().unwrap().lock().unwrap();
     let state = &mut *state_ref;
 
-    if state.hidden {
+    if state.hidden.is_some() {
         return;
     }
 
@@ -837,54 +866,129 @@ pub fn draw_cursor<R>(
 
 const ACTIVITY_THROTTLE: Duration = Duration::from_millis(100);
 
-/// Reveal the cursor and (re)arm the idle-hide timer; returns true if it was previously hidden
-pub fn notify_cursor_activity(state: &State, seat: &Seat<State>) -> bool {
-    let timeout = state.common.config.cosmic_conf.cursor_hide.idle_timeout;
+/// Reveal the cursor if this event should, and (re)arm the idle-hide timer.
+/// Returns true if the cursor was previously hidden and is now visible.
+pub fn notify_cursor_activity(state: &State, seat: &Seat<State>, kind: PointerEventKind) -> bool {
+    let cursor_state = seat.user_data().get::<CursorState>().unwrap();
+
+    let revealed = {
+        let mut inner = cursor_state.lock().unwrap();
+        inner.last_pointer_activity = Instant::now();
+        match inner.hidden {
+            Some(reason) if reason.revealed_by(kind) => {
+                inner.hidden = None;
+                true
+            }
+            // Still hidden on purpose: leave the timer alone.
+            Some(_) => return false,
+            None => false,
+        }
+    };
+
+    refresh_idle_timer(state, seat);
+    revealed
+}
+
+/// (Re)arm the idle-hide timer without counting as pointer activity.
+///
+/// Takes `&State`: several callers hold a `shell` write guard, so this must not
+/// lock the shell. That is also why the timer is armed with the shortest
+/// configured timeout rather than the contextually correct one — `on_idle_timer`
+/// reads fullscreen state and corrects the delay when it fires.
+pub fn refresh_idle_timer(state: &State, seat: &Seat<State>) {
+    let config = state.common.config.cosmic_conf.cursor_hide;
     let loop_handle = &state.common.event_loop_handle;
     let cursor_state = seat.user_data().get::<CursorState>().unwrap();
     let now = Instant::now();
 
-    let (was_hidden, old_token) = {
+    let old_token = {
         let mut inner = cursor_state.lock().unwrap();
-        let was_hidden = inner.hidden;
-        inner.hidden = false;
-
-        let throttled = timeout.is_some()
-            && !was_hidden
-            && inner.idle_timer.is_some()
+        if inner.hidden.is_some() {
+            return;
+        }
+        // Coalesce bursts from high-frequency pointers.
+        let throttled = inner.idle_timer.is_some()
             && inner
                 .last_armed
                 .is_some_and(|t| now.duration_since(t) < ACTIVITY_THROTTLE);
         if throttled {
-            return was_hidden;
+            return;
         }
-
-        let old_token = inner.idle_timer.take();
         inner.last_armed = None;
-        (was_hidden, old_token)
+        inner.idle_timer.take()
     };
 
     if let Some(token) = old_token {
         loop_handle.remove(token);
     }
 
-    if let Some(secs) = timeout {
-        let timer = Timer::from_duration(Duration::from_secs(secs as u64));
-        let seat = seat.clone();
-        if let Ok(token) = loop_handle.insert_source(timer, move |_, _, state| {
-            hide_cursor(state, &seat);
-            TimeoutAction::Drop
-        }) {
-            let mut inner = cursor_state.lock().unwrap();
-            inner.idle_timer = Some(token);
-            inner.last_armed = Some(now);
-        }
-    }
+    let Some(delay) = config.shortest_timeout() else {
+        return;
+    };
 
-    was_hidden
+    let timer = Timer::from_duration(delay);
+    let timer_seat = seat.clone();
+    if let Ok(token) =
+        loop_handle.insert_source(timer, move |_, _, state| on_idle_timer(state, &timer_seat))
+    {
+        let mut inner = cursor_state.lock().unwrap();
+        inner.idle_timer = Some(token);
+        inner.last_armed = Some(now);
+    }
 }
 
-fn hide_cursor(state: &mut State, seat: &Seat<State>) {
+/// Whether the seat's active output is showing a fullscreen surface. Only ever
+/// called from the timer callback, which holds no shell lock.
+fn fullscreen_focused(state: &State, seat: &Seat<State>) -> bool {
+    let shell = state.common.shell.read();
+    shell
+        .active_space(&seat.active_output())
+        .is_some_and(|workspace| workspace.get_fullscreen_surfaces().next().is_some())
+}
+
+fn on_idle_timer(state: &mut State, seat: &Seat<State>) -> TimeoutAction {
+    let config = state.common.config.cosmic_conf.cursor_hide;
+    let fullscreen = fullscreen_focused(state, seat);
+    let cursor_state = seat.user_data().get::<CursorState>().unwrap();
+
+    let elapsed = {
+        let inner = cursor_state.lock().unwrap();
+        Instant::now().duration_since(inner.last_pointer_activity)
+    };
+
+    match config.resolve(elapsed, fullscreen) {
+        HideDecision::Hide => {
+            hide_cursor(state, seat, HideReason::Idle);
+            TimeoutAction::Drop
+        }
+        HideDecision::Drop => {
+            let mut inner = cursor_state.lock().unwrap();
+            inner.idle_timer = None;
+            inner.last_armed = None;
+            TimeoutAction::Drop
+        }
+        HideDecision::RearmAfter(delay) => {
+            cursor_state.lock().unwrap().last_armed = Some(Instant::now());
+            TimeoutAction::ToDuration(delay)
+        }
+    }
+}
+
+/// Hide the cursor immediately, for a trigger that does not wait on the timer.
+pub fn hide_cursor_now(state: &mut State, seat: &Seat<State>, reason: HideReason) {
+    let loop_handle = state.common.event_loop_handle.clone();
+    let token = {
+        let cursor_state = seat.user_data().get::<CursorState>().unwrap();
+        let mut inner = cursor_state.lock().unwrap();
+        inner.idle_timer.take()
+    };
+    if let Some(token) = token {
+        loop_handle.remove(token);
+    }
+    hide_cursor(state, seat, reason);
+}
+
+fn hide_cursor(state: &mut State, seat: &Seat<State>, reason: HideReason) {
     if let Some(ptr) = seat.get_pointer()
         && ptr.is_grabbed()
     {
@@ -893,12 +997,36 @@ fn hide_cursor(state: &mut State, seat: &Seat<State>) {
     let cursor_state = seat.user_data().get::<CursorState>().unwrap();
     {
         let mut inner = cursor_state.lock().unwrap();
-        inner.hidden = true;
+        if inner.hidden.is_some() {
+            return;
+        }
+        inner.hidden = Some(reason);
         inner.idle_timer = None;
         inner.last_armed = None;
     }
     let outputs: Vec<_> = state.common.shell.read().outputs().cloned().collect();
     for output in outputs {
         state.backend.schedule_render(&output);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{HideReason, PointerEventKind};
+
+    #[test]
+    fn touch_hidden_cursor_waits_for_movement() {
+        assert!(HideReason::Touch.revealed_by(PointerEventKind::Motion));
+        assert!(!HideReason::Touch.revealed_by(PointerEventKind::Other));
+    }
+
+    #[test]
+    fn idle_and_typing_hidden_cursors_are_revealed_by_any_pointer_event() {
+        for reason in [HideReason::Idle, HideReason::Typing] {
+            assert!(reason.revealed_by(PointerEventKind::Motion));
+            // A click or a scroll must rescue the cursor rather than forcing a
+            // blind click.
+            assert!(reason.revealed_by(PointerEventKind::Other));
+        }
     }
 }

--- a/src/backend/render/cursor.rs
+++ b/src/backend/render/cursor.rs
@@ -996,20 +996,20 @@ pub fn hide_cursor_now(state: &mut State, seat: &Seat<State>, reason: HideReason
 }
 
 fn hide_cursor(state: &mut State, seat: &Seat<State>, reason: HideReason) {
-    if let Some(ptr) = seat.get_pointer()
-        && ptr.is_grabbed()
-    {
-        return;
-    }
+    let grabbed = seat.get_pointer().is_some_and(|ptr| ptr.is_grabbed());
     let cursor_state = seat.user_data().get::<CursorState>().unwrap();
     {
         let mut inner = cursor_state.lock().unwrap();
-        if inner.hidden.is_some() {
+        // Every caller has already disposed of the timer source, so clear the
+        // bookkeeping before the grab check rather than only on success.
+        inner.idle_timer = None;
+        inner.last_armed = None;
+        // The reason only ever tightens: `Touch` waits for real movement, so a
+        // later trigger must not relax it back to click-or-scroll.
+        if grabbed || inner.hidden == Some(reason) || inner.hidden == Some(HideReason::Touch) {
             return;
         }
         inner.hidden = Some(reason);
-        inner.idle_timer = None;
-        inner.last_armed = None;
     }
     let outputs: Vec<_> = state.common.shell.read().outputs().cloned().collect();
     for output in outputs {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,8 +49,8 @@ mod types;
 use cosmic::config::CosmicTk;
 pub use cosmic_comp_config::EdidProduct;
 use cosmic_comp_config::{
-    ActivationPolicy, AppearanceConfig, CosmicCompConfig, DecorationPreference, KeyboardConfig,
-    TileBehavior, XkbConfig, XwaylandDescaling, XwaylandEavesdropping, ZoomConfig,
+    ActivationPolicy, AppearanceConfig, CosmicCompConfig, CursorHideConfig, DecorationPreference,
+    KeyboardConfig, TileBehavior, XkbConfig, XwaylandDescaling, XwaylandEavesdropping, ZoomConfig,
     input::{DeviceState as InputDeviceState, InputConfig, TouchpadOverride},
     output::comp::{
         OutputConfig, OutputInfo, OutputState, OutputsConfig, TransformDef, load_outputs,
@@ -983,10 +983,13 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                 let new = get_config::<bool>(&config, "cursor_shake_to_find");
                 state.common.config.cosmic_conf.cursor_shake_to_find = new;
             }
-            "cursor_hide_timeout" => {
-                let new = get_config::<Option<u32>>(&config, "cursor_hide_timeout");
-                if new != state.common.config.cosmic_conf.cursor_hide_timeout {
-                    state.common.config.cosmic_conf.cursor_hide_timeout = new;
+            "cursor_hide" => {
+                let new = get_config::<CursorHideConfig>(&config, "cursor_hide");
+                if new != state.common.config.cosmic_conf.cursor_hide {
+                    state.common.config.cosmic_conf.cursor_hide = new;
+                    // Reveal on every change: a visible cursor is the safe state,
+                    // and it avoids stranding a hidden cursor when the trigger
+                    // that hid it is switched off.
                     let seats: Vec<_> = state.common.shell.read().seats.iter().cloned().collect();
                     let mut needs_render = false;
                     for seat in seats {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -171,6 +171,20 @@ pub enum ColorFilter {
     Tritanopia = 4,
 }
 
+/// `cursor_hide_timeout` was replaced by the grouped `cursor_hide` key. Seed the
+/// new key once so configs hand-edited before the rename keep working; the old
+/// file is left in place so a downgrade still reads it.
+fn migrate_cursor_hide(config: &cosmic_config::Config, cfg: &mut CosmicCompConfig) {
+    if config.get::<CursorHideConfig>("cursor_hide").is_err()
+        && let Ok(legacy) = config.get::<Option<u32>>("cursor_hide_timeout")
+    {
+        cfg.cursor_hide.idle_timeout = legacy;
+        if let Err(err) = config.set("cursor_hide", cfg.cursor_hide) {
+            warn!(?err, "Failed to migrate cursor_hide_timeout to cursor_hide");
+        }
+    }
+}
+
 impl Config {
     pub fn load(loop_handle: &LoopHandle<'_, State>) -> Config {
         let config = cosmic_config::Config::new("com.system76.CosmicComp", 1).unwrap();
@@ -192,17 +206,7 @@ impl Config {
                 c
             });
 
-        // `cursor_hide_timeout` was replaced by the grouped `cursor_hide` key.
-        // Seed the new key once so configs hand-edited before the rename keep
-        // working; the old file is left in place so a downgrade still reads it.
-        if config.get::<CursorHideConfig>("cursor_hide").is_err()
-            && let Ok(legacy) = config.get::<Option<u32>>("cursor_hide_timeout")
-        {
-            cosmic_comp_config.cursor_hide.idle_timeout = legacy;
-            if let Err(err) = config.set("cursor_hide", cosmic_comp_config.cursor_hide) {
-                warn!(?err, "Failed to migrate cursor_hide_timeout to cursor_hide");
-            }
-        }
+        migrate_cursor_hide(&config, &mut cosmic_comp_config);
 
         // Listen for updates to the toolkit config
         if let Ok(tk_config) = cosmic_config::Config::new("com.system76.CosmicTk", 1) {
@@ -1049,5 +1053,90 @@ impl From<Output> for CompOutputInfo {
             make: physical.make,
             model: physical.model,
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::migrate_cursor_hide;
+    use cosmic_comp_config::{CosmicCompConfig, CursorHideConfig};
+    use cosmic_config::{ConfigGet, ConfigSet};
+
+    fn config(dir: &tempfile::TempDir) -> cosmic_config::Config {
+        cosmic_config::Config::with_custom_path(
+            "com.system76.CosmicComp",
+            1,
+            dir.path().to_path_buf(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn a_hand_edited_legacy_timeout_is_carried_over() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config(&dir);
+        config.set("cursor_hide_timeout", Some(5u32)).unwrap();
+
+        let mut cfg = CosmicCompConfig::default();
+        migrate_cursor_hide(&config, &mut cfg);
+
+        assert_eq!(cfg.cursor_hide.idle_timeout, Some(5));
+        // Seeded, so a second start does not migrate again.
+        assert_eq!(
+            config.get::<CursorHideConfig>("cursor_hide").unwrap(),
+            cfg.cursor_hide
+        );
+    }
+
+    #[test]
+    fn an_existing_cursor_hide_wins_over_a_stale_legacy_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config(&dir);
+        let current = CursorHideConfig {
+            idle_timeout: Some(30),
+            ..CursorHideConfig::default()
+        };
+        config.set("cursor_hide", current).unwrap();
+        config.set("cursor_hide_timeout", Some(5u32)).unwrap();
+
+        let mut cfg = CosmicCompConfig {
+            cursor_hide: current,
+            ..CosmicCompConfig::default()
+        };
+        migrate_cursor_hide(&config, &mut cfg);
+
+        assert_eq!(cfg.cursor_hide, current);
+    }
+
+    #[test]
+    fn a_partial_cursor_hide_is_not_mistaken_for_an_absent_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config(&dir);
+        // The audience for the shim hand-edits these files, so a file missing a
+        // field must still count as present rather than being overwritten.
+        std::fs::write(
+            dir.path()
+                .join("cosmic/com.system76.CosmicComp/v1/cursor_hide"),
+            "(idle_timeout: Some(30))",
+        )
+        .unwrap();
+        config.set("cursor_hide_timeout", Some(5u32)).unwrap();
+
+        let mut cfg = CosmicCompConfig::default();
+        migrate_cursor_hide(&config, &mut cfg);
+
+        assert_eq!(cfg.cursor_hide, CursorHideConfig::default());
+    }
+
+    #[test]
+    fn no_legacy_key_leaves_the_defaults_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config(&dir);
+
+        let mut cfg = CosmicCompConfig::default();
+        migrate_cursor_hide(&config, &mut cfg);
+
+        assert_eq!(cfg.cursor_hide, CursorHideConfig::default());
+        assert!(config.get::<CursorHideConfig>("cursor_hide").is_err());
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1005,8 +1005,11 @@ fn config_changed(config: cosmic_config::Config, keys: Vec<String>, state: &mut 
                     let seats: Vec<_> = state.common.shell.read().seats.iter().cloned().collect();
                     let mut needs_render = false;
                     for seat in seats {
-                        needs_render |=
-                            crate::backend::render::cursor::notify_cursor_activity(state, &seat);
+                        needs_render |= crate::backend::render::cursor::notify_cursor_activity(
+                            state,
+                            &seat,
+                            crate::backend::render::cursor::PointerEventKind::Motion,
+                        );
                     }
                     if needs_render {
                         let outputs: Vec<_> =

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use anyhow::Context;
-use cosmic_config::{ConfigGet, CosmicConfigEntry};
+use cosmic_config::{ConfigGet, ConfigSet, CosmicConfigEntry};
 use cosmic_settings_config::window_rules::ApplicationException;
 use cosmic_settings_config::{Shortcuts, shortcuts, window_rules};
 use serde::{Deserialize, Serialize};
@@ -182,7 +182,7 @@ impl Config {
             .expect("Failed to add cosmic-config to the event loop");
         let xdg = xdg::BaseDirectories::new();
 
-        let cosmic_comp_config =
+        let mut cosmic_comp_config =
             CosmicCompConfig::get_entry(&config).unwrap_or_else(|(errs, c)| {
                 if cfg!(debug_assertions) {
                     for err in errs {
@@ -191,6 +191,18 @@ impl Config {
                 }
                 c
             });
+
+        // `cursor_hide_timeout` was replaced by the grouped `cursor_hide` key.
+        // Seed the new key once so configs hand-edited before the rename keep
+        // working; the old file is left in place so a downgrade still reads it.
+        if config.get::<CursorHideConfig>("cursor_hide").is_err()
+            && let Ok(legacy) = config.get::<Option<u32>>("cursor_hide_timeout")
+        {
+            cosmic_comp_config.cursor_hide.idle_timeout = legacy;
+            if let Err(err) = config.set("cursor_hide", cosmic_comp_config.cursor_hide) {
+                warn!(?err, "Failed to migrate cursor_hide_timeout to cursor_hide");
+            }
+        }
 
         // Listen for updates to the toolkit config
         if let Ok(tk_config) = cosmic_config::Config::new("com.system76.CosmicTk", 1) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::{
-    backend::render::{ElementFilter, cursor::notify_cursor_activity},
+    backend::render::{
+        ElementFilter,
+        cursor::{PointerEventKind, notify_cursor_activity},
+    },
     config::{
         Action, Config, PrivateAction,
         key_bindings::{
@@ -340,7 +343,7 @@ impl State {
                     .cloned()
                 {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    notify_cursor_activity(self, &seat);
+                    notify_cursor_activity(self, &seat, PointerEventKind::Motion);
                     let current_output = seat.active_output();
 
                     if self.common.config.cosmic_conf.cursor_shake_to_find
@@ -714,7 +717,7 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    notify_cursor_activity(self, &seat);
+                    notify_cursor_activity(self, &seat, PointerEventKind::Motion);
                     let (output, position) = if matches!(&backend_id, InputBackendId::Ei(_)) {
                         // EI absolute coordinates are in the compositor's *global*
                         // logical space: each advertised region carries its output's
@@ -809,7 +812,7 @@ impl State {
                     return;
                 };
                 self.common.idle_notifier_state.notify_activity(&seat);
-                notify_cursor_activity(self, &seat);
+                notify_cursor_activity(self, &seat, PointerEventKind::Other);
 
                 let current_focus = seat.get_keyboard().unwrap().current_focus();
                 let shortcuts_inhibited = current_focus.as_ref().is_some_and(|f| {
@@ -1060,7 +1063,7 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    notify_cursor_activity(self, &seat);
+                    notify_cursor_activity(self, &seat, PointerEventKind::Other);
 
                     if self.source_modifiers(&backend_id, &seat).logo
                         && self
@@ -1592,7 +1595,7 @@ impl State {
                     .cloned()
                 {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    notify_cursor_activity(self, &seat);
+                    notify_cursor_activity(self, &seat, PointerEventKind::Motion);
                     let Some(output) =
                         mapped_output_for_device(&self.common.config, &shell, &event.device())
                             .cloned()
@@ -1696,7 +1699,7 @@ impl State {
                     .cloned()
                 {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    notify_cursor_activity(self, &seat);
+                    notify_cursor_activity(self, &seat, PointerEventKind::Motion);
                     let Some(output) =
                         mapped_output_for_device(&self.common.config, &shell, &event.device())
                             .cloned()
@@ -1845,7 +1848,7 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    notify_cursor_activity(self, &seat);
+                    notify_cursor_activity(self, &seat, PointerEventKind::Other);
 
                     let serial = SERIAL_COUNTER.next_serial();
                     let output = seat.active_output();
@@ -1898,7 +1901,7 @@ impl State {
                     .cloned();
                 if let Some(seat) = maybe_seat {
                     self.common.idle_notifier_state.notify_activity(&seat);
-                    notify_cursor_activity(self, &seat);
+                    notify_cursor_activity(self, &seat, PointerEventKind::Other);
                     if let Some(tool) = seat.tablet_seat().get_tool(&event.tool()) {
                         tool.button(
                             self,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -214,6 +214,16 @@ impl ModifiersShortcutQueue {
     }
 }
 
+/// Whether a key event counts as typing, for `cursor_hide.while_typing`.
+///
+/// A bare modifier press changes the modifier state; a real keystroke does not.
+/// COSMIC binds Super+drag to move windows, so hiding on Super-down would take
+/// the cursor away exactly as the user reaches for it. Super+1 still counts as
+/// typing — that is keyboard-driven intent.
+fn is_typing_keystroke(previous: ModifiersState, current: ModifiersState, state: KeyState) -> bool {
+    state == KeyState::Pressed && previous == current
+}
+
 impl State {
     #[profiling::function]
     pub fn process_input_event<B: InputBackend>(
@@ -331,14 +341,8 @@ impl State {
                         }
                     }
 
-                    // A bare modifier press changes the modifier state; a real
-                    // keystroke does not. Super+drag moves windows, so hiding on
-                    // Super-down would take the cursor away exactly as the user
-                    // reaches for it. Super+1 still counts as typing.
-                    let bare_modifier = previous_modifiers != keyboard.modifier_state();
                     if self.common.config.cosmic_conf.cursor_hide.while_typing
-                        && state == KeyState::Pressed
-                        && !bare_modifier
+                        && is_typing_keystroke(previous_modifiers, keyboard.modifier_state(), state)
                     {
                         crate::backend::render::cursor::hide_cursor_now(
                             self,
@@ -3244,5 +3248,56 @@ pub fn update_output_image_copy_cursor_position(
             session.set_cursor_hotspot(cursor_geometry.hotspot);
             session.set_cursor_pos(Some(cursor_geometry.geometry.loc));
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::is_typing_keystroke;
+    use smithay::{backend::input::KeyState, input::keyboard::ModifiersState};
+
+    fn logo() -> ModifiersState {
+        ModifiersState {
+            logo: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_plain_keystroke_is_typing() {
+        let mods = ModifiersState::default();
+        assert!(is_typing_keystroke(mods, mods, KeyState::Pressed));
+    }
+
+    #[test]
+    fn a_shortcut_with_a_real_key_is_typing() {
+        // Super is already held; Super+1 leaves the modifier state unchanged.
+        assert!(is_typing_keystroke(logo(), logo(), KeyState::Pressed));
+    }
+
+    #[test]
+    fn a_bare_modifier_is_not_typing() {
+        assert!(!is_typing_keystroke(
+            ModifiersState::default(),
+            logo(),
+            KeyState::Pressed
+        ));
+
+        let caps = ModifiersState {
+            caps_lock: true,
+            ..Default::default()
+        };
+        assert!(!is_typing_keystroke(
+            ModifiersState::default(),
+            caps,
+            KeyState::Pressed
+        ));
+    }
+
+    #[test]
+    fn a_release_is_never_typing() {
+        let mods = ModifiersState::default();
+        assert!(!is_typing_keystroke(mods, mods, KeyState::Released));
+        assert!(!is_typing_keystroke(logo(), mods, KeyState::Released));
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -330,6 +330,26 @@ impl State {
                                 keyboard.modifier_state().num_lock;
                         }
                     }
+
+                    // A bare modifier press changes the modifier state; a real
+                    // keystroke does not. Super+drag moves windows, so hiding on
+                    // Super-down would take the cursor away exactly as the user
+                    // reaches for it. Super+1 still counts as typing.
+                    let bare_modifier = previous_modifiers != keyboard.modifier_state();
+                    if self.common.config.cosmic_conf.cursor_hide.while_typing
+                        && state == KeyState::Pressed
+                        && !bare_modifier
+                    {
+                        crate::backend::render::cursor::hide_cursor_now(
+                            self,
+                            &seat,
+                            crate::backend::render::cursor::HideReason::Typing,
+                        );
+                    } else {
+                        // Still refresh: this is how entering fullscreen by
+                        // keyboard arms the fullscreen timeout.
+                        crate::backend::render::cursor::refresh_idle_timer(self, &seat);
+                    }
                 }
             }
 
@@ -1480,6 +1500,14 @@ impl State {
                             time: event.time(),
                         },
                     );
+
+                    if self.common.config.cosmic_conf.cursor_hide.after_touch {
+                        crate::backend::render::cursor::hide_cursor_now(
+                            self,
+                            &seat,
+                            crate::backend::render::cursor::HideReason::Touch,
+                        );
+                    }
                 }
             }
             InputEvent::TouchMotion { event, .. } => {


### PR DESCRIPTION
Replaces the global `cursor_hide_timeout` with contextual cursor hiding, per the UX feedback on [pop-os/cosmic-settings#2088](https://github.com/pop-os/cosmic-settings/pull/2088): each trigger has an unambiguous restore gesture, so hiding reads as intentional rather than as losing the cursor.

These are not three features. All of them share one mechanism — the cursor is hidden, pointer input reveals it — and differ only in what *arms* the hide and after how long. So the existing state machine gained more arming sources and a context-dependent delay rather than three parallel code paths.

| trigger | arms on | delay | reveals on |
| --- | --- | --- | --- |
| idle | no pointer activity | `idle_timeout` | any pointer event |
| fullscreen idle | no pointer activity, fullscreen on the seat's active output | `fullscreen_idle_timeout`, which only ever *shortens* `idle_timeout` | any pointer event |
| while typing | a real keystroke | immediate | any pointer event |
| after touch | touch down | immediate | **pointer motion only** |

**Config.** `cursor_hide_timeout: Option<u32>` becomes `cursor_hide: CursorHideConfig { idle_timeout, fullscreen_idle_timeout, while_typing, after_touch }`. Grouped rather than four flat keys because cosmic-config stores one file per top-level key, so flat keys would put four interacting settings in four unrelated-looking files.

**Migration.** The rename orphans anyone's existing `cursor_hide_timeout` file, and the recipe for setting it by hand circulated in [pop-os/cosmic-settings#603](https://github.com/pop-os/cosmic-settings/issues/603). A startup shim reads the legacy key once when the new one is absent and seeds `idle_timeout` from it; the old file is left on disk so a downgrade still finds it.

**Touch reveals only on motion.** A cursor hidden by touch waits for real pointer movement; one hidden by idle or typing is also revealed by a click or scroll, so the user is never forced to click blind. That is why `hidden` carries a reason rather than being a bool.

**Typing excludes bare modifiers.** COSMIC binds Super+drag to move windows, so hiding on Super-down would take the cursor away exactly as the user reaches for it. A bare modifier press changes the modifier state; a real keystroke does not. Super+1 still counts as typing.

**The arming rule, which is the subtle part.** `InputEvent::PointerMotion` calls into the cursor code while holding a `shell.write()` guard, so arm-time code cannot read fullscreen state without self-deadlocking. The timer is therefore armed pessimistically — the shortest timeout that could apply in any context, minus the time already elapsed since the last *pointer* event — and the context is evaluated inside the calloop callback, which holds no lock. An early fire simply re-arms for the remainder. This is also why no hook is needed in any of the six fullscreen transition sites in `shell/mod.rs`.

## Questions for reviewers

**Defaults are a UX decision, not mine.** Currently `after_touch: true` and `fullscreen_idle_timeout: Some(3)`, on the reading that @maria-komarova described touch and fullscreen as behaviours and only typing as a toggle. That turns on new behaviour for every user. `while_typing: false` and `idle_timeout: None`. Happy to ship whatever UX prefers — the implementation is identical either way.

**A known gap, stated rather than hidden.** An application that enters fullscreen with no input at all, while the pointer is already idle and `idle_timeout` is `None`, keeps its cursor until the next input of any kind. Entering fullscreen by clicking a player's button or by pressing F11 both arm correctly. The alternative was either a repeating idle wakeup or hooking six fullscreen transition sites that a seventh could silently miss. Happy to revisit if you would rather have the hooks.

**A small cost worth naming.** Under the default config on a windowed desktop, a keystroke after the pointer has been still arms a zero-delay timer that resolves to "nothing applies" on the next loop iteration. Bounded by the key-repeat rate. It is not pure waste — it is the same mechanism that makes F11-into-fullscreen hide immediately rather than a timeout late — but it is new work on the input path, so it should be a decision rather than a surprise.

## Notes

- Renaming the public `cursor_hide_timeout` field is a breaking change to `cosmic-comp-config`, which cosmic-settings consumes. Nothing in-tree references it and the settings UI PR was declined, so the blast radius is nil.
- The migration writes to the user's config during `Config::load()`, which re-enters through the `ConfigWatchSource` inserted a few lines earlier. Benign: the in-memory value is assigned before the write, so the reload's inequality check makes it a no-op.
- Two dev-dependencies are declared (`tempfile`, `ron`). Both crates were already in `Cargo.lock` — `ron` is already an optional dependency of `cosmic-comp-config` itself — so no new crates enter the dependency graph.

## Testing

19 unit tests across the two crates, covering the timeout resolution and arming arithmetic, the reveal rule, the typing predicate, config round-tripping with missing fields, and all four migration cases.

Verified on a live KMS session (a nested backend does not exercise the cursor plane):

- **Idle** hides at the configured delay and any pointer event reveals.
- **Fullscreen** hides at its own, shorter delay. Tested with the two timeouts set to different values, because with both at the same value the two triggers are indistinguishable by observation.
- **Typing** hides on a keystroke; a bare modifier press does not, so Super+drag keeps its cursor.
- **Touch** hides, and — the part that matters — a scroll afterwards does *not* reveal while pointer motion does, so the hide reason is genuinely honoured rather than the cursor being hidden generically. **Verified with a synthetic `uinput` touchscreen** (`INPUT_PROP_DIRECT`, tagged `ID_INPUT_TOUCHSCREEN` by udev), not real touch hardware, which this machine lacks. Worth a second pair of eyes from anyone with a panel.
- **The arming rule**, which the unit tests cannot pin end to end: with `idle_timeout: Some(10)` and `while_typing: false`, typing continuously hid the cursor 10 s after the last *pointer* event rather than being postponed indefinitely by the keystrokes.
- **The migration**, on a config that genuinely predated the rename: a hand-set `cursor_hide_timeout: Some(3)` was carried into `cursor_hide.idle_timeout` at login, with the legacy file left in place.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
