### PR TITLE
fix output manager done scope

### DIFF
--- a/src/wayland/protocols/output_configuration/handlers/cosmic.rs
+++ b/src/wayland/protocols/output_configuration/handlers/cosmic.rs
@@ -25,6 +25,13 @@ use cosmic_protocols::output_management::v1::server::{
 
 use crate::wayland::protocols::output_configuration::*;
 
+fn matching_manager_index<T>(
+    managers: &[T],
+    mut owns_head: impl FnMut(&T) -> bool,
+) -> Option<usize> {
+    managers.iter().position(&mut owns_head)
+}
+
 impl<D> GlobalDispatch<ZcosmicOutputManagerV1, OutputMngrGlobalData, D>
     for OutputConfigurationState<D>
 where
@@ -80,11 +87,11 @@ where
         match request {
             zcosmic_output_manager_v1::Request::GetHead { extended, head } => {
                 let inner = state.output_configuration_state();
-                if let Some(mngr) = inner
-                    .instances
-                    .iter_mut()
-                    .find(|instance| instance.heads.iter().any(|instance| instance.obj == head))
-                {
+                let serial = inner.serial_counter;
+                if let Some(index) = matching_manager_index(&inner.instances, |instance| {
+                    instance.heads.iter().any(|instance| instance.obj == head)
+                }) {
+                    let mngr = &mut inner.instances[index];
                     let head_data = mngr
                         .heads
                         .iter_mut()
@@ -95,9 +102,7 @@ where
                     let output = head_data.output.clone();
 
                     send_head_to_client::<D>(dh, mngr, &output);
-                    for manager in inner.instances.iter() {
-                        manager.obj.done(inner.serial_counter);
-                    }
+                    mngr.obj.done(serial);
                 }
             }
             zcosmic_output_manager_v1::Request::GetConfiguration { extended, config } => {


### PR DESCRIPTION
`get_head` updates one managers head data but broadcast its snapshot boundary to every bound output manager. This allowed one client (cosmic-randr for example) to make unrelated clients get ManagerDone and unnecessarily reload their display state. This is especially annoying to deal with when rearranging displays in cosmic-settings.

This pull request fixes that by sending the output manager done event only to the manager that owns the requested head. This avoids notifying unrelated output management clients when handling a COSMIC `get_head` request. 

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

